### PR TITLE
feat(cli): add version command

### DIFF
--- a/src/dev_sync/cli.py
+++ b/src/dev_sync/cli.py
@@ -885,6 +885,12 @@ def poller_status(
     raise typer.Exit(1)
 
 
+@app.command("version")
+def version() -> None:
+    """Print the package version."""
+    console.print(__version__)
+
+
 @app.command("status")
 def status(
     config_path: str = typer.Option(

--- a/tests/test_cli_version.py
+++ b/tests/test_cli_version.py
@@ -1,0 +1,22 @@
+"""Tests for the version command."""
+
+from typer.testing import CliRunner
+
+from dev_sync import __version__
+from dev_sync.cli import app
+
+runner = CliRunner()
+
+
+class TestVersionCommand:
+    def test_version_command_succeeds(self) -> None:
+        """dev-sync version should exit with code 0."""
+        result = runner.invoke(app, ["version"])
+
+        assert result.exit_code == 0
+
+    def test_version_command_prints_version(self) -> None:
+        """dev-sync version should print the package version."""
+        result = runner.invoke(app, ["version"])
+
+        assert __version__ in result.output


### PR DESCRIPTION
## Summary
- Add `dev-sync version` subcommand that prints the package version
- Add tests for the version command

Closes #3

## Test plan
- [x] `dev-sync version` exits with code 0
- [x] Output contains the version number (0.1.0)
- [x] All existing tests pass (129 tests)
- [x] Linting passes for modified files