### PR TITLE
fix(docs): wrap plan code blocks in {% raw %} to fix Pages build

### DIFF
--- a/docs/superpowers/plans/2026-04-17-dev-sync-phase0-package-skeleton.md
+++ b/docs/superpowers/plans/2026-04-17-dev-sync-phase0-package-skeleton.md
@@ -353,6 +353,7 @@ def sample_config_file(sample_config_dict: dict, tmp_path: Path) -> Path:
 ```
 
 Create `tests/test_config.py`:
+{% raw %}
 ```python
 """Tests for configuration loading and validation."""
 
@@ -398,6 +399,7 @@ class TestConfigPaths:
         assert "~" not in str(config.paths.state_db)
         assert str(config.paths.state_db).startswith("/")
 ```
+{% endraw %}
 
 - [ ] **Step 2: Run tests to verify they fail**
 

--- a/docs/superpowers/plans/2026-04-17-dev-sync-phase4-dev-pipeline.md
+++ b/docs/superpowers/plans/2026-04-17-dev-sync-phase4-dev-pipeline.md
@@ -745,6 +745,7 @@ Expected: FAIL with "No module named 'dev_sync.pipelines.dev'"
 
 - [ ] **Step 3: Create dev pipeline skeleton**
 
+{% raw %}
 ```python
 # src/dev_sync/pipelines/dev.py
 """Dev pipeline for issue-to-PR workflow."""
@@ -876,6 +877,7 @@ Use checkpoint.failed() if something goes wrong."""
             error=result.state.error,
         )
 ```
+{% endraw %}
 
 - [ ] **Step 4: Run test to verify it passes**
 


### PR DESCRIPTION
## Summary
- GitHub Pages runs Jekyll 3.10 (pinned by the `github-pages` gem), which does not support the `render_with_liquid: false` frontmatter flag added in #7 — so that fix was a silent no-op and the Pages build kept failing.
- Two Python code blocks in the Phase 0 and Phase 4 plans contain literal `{{` characters (test fixtures / f-string-like content) that Liquid tries to parse as variables.
- Wrap the offending fenced blocks in `{% raw %}...{% endraw %}` so Liquid leaves them alone. Left `render_with_liquid: false` in frontmatter so the fix remains correct if/when the site moves to Jekyll 4.

Fixes the build failure seen on run 24598691801 ("Deploy docs to GitHub Pages" on main).

## Test plan
- [ ] Pages build job (`Deploy docs to GitHub Pages`) completes successfully on this PR
- [ ] Resulting site renders the Phase 0 and Phase 4 plan pages with the Python code blocks intact (no `{% raw %}` tags visible in the rendered output)