### PR TITLE
fix(docs): set baseurl in _config.yml so Pages assets and nav links resolve

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -44,8 +44,7 @@ jobs:
         run: |
           bundle exec jekyll build \
             --source . \
-            --destination ./_site \
-            --baseurl "${{ steps.pages.outputs.base_path }}"
+            --destination ./_site
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/docs/_config.yml
+++ b/docs/_config.yml
@@ -2,8 +2,8 @@ title: dev-sync
 description: >-
   Local-first orchestrator for Claude Code across multiple GitHub repos —
   design specs, implementation plans, and operator guides.
-url: ""
-baseurl: ""
+url: "https://ainvirion.github.io"
+baseurl: "/dev-sync"
 
 remote_theme: just-the-docs/just-the-docs
 


### PR DESCRIPTION
## Summary
The published site at https://ainvirion.github.io/dev-sync/ renders with root-relative asset and nav URLs instead of paths prefixed with \`/dev-sync/\`, so the theme CSS/JS 404s and every internal link breaks. Example broken paths in the current HTML:

\`\`\`
href="/assets/css/just-the-docs-default.css"     # should be /dev-sync/assets/...
href="/Claude_Code_Project_Guide.html"           # should be /dev-sync/Claude_Code_Project_Guide.html
\`\`\`

**Root cause:** \`docs/_config.yml\` had \`url: ""\` and \`baseurl: ""\`. The workflow tried to compensate with \`--baseurl "\${{ steps.pages.outputs.base_path }}"\` on the CLI, but that override was not applied to theme-generated links from \`just-the-docs\` in this build.

**Fix:**
- Set canonical values in \`docs/_config.yml\`:
  - \`url: "https://ainvirion.github.io"\`
  - \`baseurl: "/dev-sync"\`
- Drop the redundant \`--baseurl\` CLI flag from the Pages workflow so \`_config.yml\` is the single source of truth.

## Test plan
- [ ] Pages build job succeeds on merge
- [ ] \`curl -s https://ainvirion.github.io/dev-sync/ | grep -E 'href=\"/assets'\` shows paths under \`/dev-sync/assets/\`
- [ ] Visiting the site in a browser shows the themed layout (sidebar, typography) with CSS loaded
- [ ] Clicking a nav link (Phase 0, Orchestrator Spec, etc.) successfully loads the page