### PR TITLE
fix(dispatcher): resolve bare claude binary name at construction time

### DIFF
--- a/src/dev_sync/core/dispatcher.py
+++ b/src/dev_sync/core/dispatcher.py
@@ -61,8 +61,11 @@ class ClaudeDispatcher:
     extra_env: dict[str, str] = field(default_factory=dict)
 
     def __post_init__(self) -> None:
-        if not os.path.isabs(self.claude_binary):
-            resolved = shutil.which(self.claude_binary)
+        # Only auto-resolve the bare default. Absolute paths, relative paths
+        # (resolved vs. working_dir by the child), and custom bare names pass
+        # through so explicit config is never silently overridden.
+        if self.claude_binary == "claude":
+            resolved = shutil.which("claude")
             self.claude_binary = resolved or _find_claude()
 
     async def spawn_session(

--- a/src/dev_sync/core/dispatcher.py
+++ b/src/dev_sync/core/dispatcher.py
@@ -60,6 +60,11 @@ class ClaudeDispatcher:
     default_timeout: int = 1800
     extra_env: dict[str, str] = field(default_factory=dict)
 
+    def __post_init__(self) -> None:
+        if not os.path.isabs(self.claude_binary):
+            resolved = shutil.which(self.claude_binary)
+            self.claude_binary = resolved or _find_claude()
+
     async def spawn_session(
         self,
         session_id: str,


### PR DESCRIPTION
## Summary
Under the launchd-managed poller, PATH does not include `~/.local/bin`, so spawning claude fails with:

```
❌ Failed on #15: [Errno 2] No such file or directory: 'claude'
```

The previous launchd fix (0c7c4e5) added `_find_claude()` as the dataclass field's `default_factory`, but the CLI always passes `claude_binary=config.claude.binary` explicitly (see `cli.py:478`, `cli.py:593`, `cli.py:787`). The config default is the bare name `"claude"`, so the factory is bypassed and the bare name is handed straight to `asyncio.create_subprocess_exec`, which cannot resolve it under launchd's minimal PATH.

## Fix
In `ClaudeDispatcher.__post_init__`, if the provided binary is not an absolute path, resolve it via `shutil.which` first and fall back to the common-locations search (`_find_claude`) if PATH lookup fails. Works whether the caller supplies a bare name, an absolute path, or nothing.

## Test plan
- [x] `pytest tests/test_dispatcher.py -q` — 4 passed
- [x] Full suite: `pytest -q` — 146 passed
- [ ] After merge, reload the poller plist and retrigger a new issue — expect the agent to pick it up without the `No such file or directory` error