### PR TITLE
docs: remove outdated roadmap section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,16 +394,6 @@ ruff check src/
 pytest tests/test_dev_pipeline.py -v
 ```
 
-## Roadmap
-
-- [x] Phase 1: Core infrastructure (state, config, worktrees)
-- [x] Phase 2: Claude dispatcher and checkpoint protocol
-- [x] Phase 3: Secops pipeline
-- [x] Phase 4: Dev pipeline (issue-to-PR)
-- [x] Phase 5: Telegram integration (human-in-the-loop)
-- [ ] Phase 6: Dashboard integration
-- [ ] Phase 7: Deploy-verify pipeline
-
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- Removes the outdated `## Roadmap` section from `README.md` as requested in #13.

Fixes #13

## Test plan
- [x] `git diff` shows only the roadmap section removed (10 lines, no other content touched)
- [x] No other files reference the README roadmap section