### PR TITLE
fix(pipeline): clean up worktree + branch on failed dispatcher runs (#17)

### DIFF
--- a/src/dev_sync/core/worktree.py
+++ b/src/dev_sync/core/worktree.py
@@ -152,7 +152,8 @@ class WorktreeManager:
             pass
 
     async def branch_exists_on_remote(self, repo: str, branch: str) -> bool:
-        """Return True if `branch` exists on origin. Fail-closed: on error,
+        """Return True if `branch` exists on origin. Fail-closed: on any error
+        (WorktreeError, asyncio.TimeoutError from _run_git's wait_for, etc.)
         returns True so callers err on the side of NOT deleting."""
         bare_path = self._get_bare_repo_path(repo)
         if not bare_path.exists():
@@ -162,7 +163,7 @@ class WorktreeManager:
                 "ls-remote", "--heads", "origin", branch, cwd=bare_path
             )
             return bool(output.strip())
-        except WorktreeError:
+        except Exception:
             return True
 
     def _get_gitdir(self, worktree_path: Path) -> Path:

--- a/src/dev_sync/core/worktree.py
+++ b/src/dev_sync/core/worktree.py
@@ -151,6 +151,20 @@ class WorktreeManager:
         except WorktreeError:
             pass
 
+    async def branch_exists_on_remote(self, repo: str, branch: str) -> bool:
+        """Return True if `branch` exists on origin. Fail-closed: on error,
+        returns True so callers err on the side of NOT deleting."""
+        bare_path = self._get_bare_repo_path(repo)
+        if not bare_path.exists():
+            return True
+        try:
+            output = await self._run_git(
+                "ls-remote", "--heads", "origin", branch, cwd=bare_path
+            )
+            return bool(output.strip())
+        except WorktreeError:
+            return True
+
     def _get_gitdir(self, worktree_path: Path) -> Path:
         """Get the real gitdir for a worktree.
 

--- a/src/dev_sync/core/worktree.py
+++ b/src/dev_sync/core/worktree.py
@@ -141,6 +141,16 @@ class WorktreeManager:
         if bare_path.exists():
             await self._run_git("worktree", "prune", cwd=bare_path)
 
+    async def delete_branch(self, repo: str, branch: str) -> None:
+        """Delete a local branch in the bare repo. Best-effort; no-op if absent."""
+        bare_path = self._get_bare_repo_path(repo)
+        if not bare_path.exists():
+            return
+        try:
+            await self._run_git("branch", "-D", branch, cwd=bare_path)
+        except WorktreeError:
+            pass
+
     def _get_gitdir(self, worktree_path: Path) -> Path:
         """Get the real gitdir for a worktree.
 

--- a/src/dev_sync/core/worktree.py
+++ b/src/dev_sync/core/worktree.py
@@ -151,6 +151,20 @@ class WorktreeManager:
         except WorktreeError:
             pass
 
+    async def branch_exists_locally(self, repo: str, branch: str) -> bool:
+        """Check if `branch` exists as a local ref in the bare repo."""
+        bare_path = self._get_bare_repo_path(repo)
+        if not bare_path.exists():
+            return False
+        try:
+            await self._run_git(
+                "show-ref", "--verify", "--quiet", f"refs/heads/{branch}",
+                cwd=bare_path,
+            )
+            return True
+        except Exception:
+            return False
+
     async def branch_exists_on_remote(self, repo: str, branch: str) -> bool:
         """Return True if `branch` exists on origin. Fail-closed: on any error
         (WorktreeError, asyncio.TimeoutError from _run_git's wait_for, etc.)

--- a/src/dev_sync/pipelines/dev.py
+++ b/src/dev_sync/pipelines/dev.py
@@ -186,6 +186,8 @@ async def run_dev_issue(
             error="Repository locked by another session",
         )
 
+    worktree_path: Path | None = None
+
     try:
         # Get issue details
         issue = await github.get_issue(repo, issue_number)
@@ -266,10 +268,18 @@ async def run_dev_issue(
                 },
             ))
 
-        # Cleanup only if not blocked (blocked sessions need worktree for resume)
-        if not result.blocked:
+        # Cleanup rules:
+        #   DONE    -> remove worktree, keep branch (the open PR references it)
+        #   BLOCKED -> keep both (user may resume the session)
+        #   FAILED  -> remove worktree AND delete branch so the next retry can
+        #              re-create `fix/issue-<n>` cleanly
+        if result.success:
             worktree.remove_context_symlink(worktree_path)
             await worktree.remove_worktree(repo, session_id)
+        elif not result.blocked:
+            worktree.remove_context_symlink(worktree_path)
+            await worktree.remove_worktree(repo, session_id)
+            await worktree.delete_branch(repo, branch_name)
 
         return result
 
@@ -279,6 +289,22 @@ async def run_dev_issue(
             ("failed", f"Error: {e}", int(time.time()), session_id),
         )
         state_db.commit()
+
+        # Best-effort cleanup so a retry isn't blocked by leftover branch/worktree.
+        if worktree_path is not None:
+            try:
+                worktree.remove_context_symlink(worktree_path)
+            except Exception:
+                pass
+            try:
+                await worktree.remove_worktree(repo, session_id)
+            except Exception:
+                pass
+        try:
+            await worktree.delete_branch(repo, branch_name)
+        except Exception:
+            pass
+
         return PipelineResult(
             success=False,
             session_id=session_id,

--- a/src/dev_sync/pipelines/dev.py
+++ b/src/dev_sync/pipelines/dev.py
@@ -187,20 +187,27 @@ async def run_dev_issue(
         )
 
     worktree_path: Path | None = None
-    branch_created = False
+    # Pessimistic default: if we never got far enough to check, assume the
+    # branch was pre-existing so cleanup never clobbers unrelated state.
+    branch_preexisted = True
 
     try:
         # Get issue details
         issue = await github.get_issue(repo, issue_number)
 
-        # Create worktree with new branch
+        # Snapshot branch ownership BEFORE we try to create it. If the ref
+        # already exists in the bare repo, it came from another run (possibly
+        # a prior DONE session whose PR is still open) and we must not touch
+        # it. If it does not exist here, any ref we see later belongs to us —
+        # even if `git worktree add -b` fails partway through and leaves the
+        # ref behind without a usable worktree.
         await worktree.ensure_bare_repo(repo)
+        branch_preexisted = await worktree.branch_exists_locally(repo, branch_name)
         worktree_path = await worktree.create_worktree_with_new_branch(
             repo=repo,
             session_id=session_id,
             new_branch=branch_name,
         )
-        branch_created = True
 
         # Symlink context
         context_path = contexts_dir / repo.replace("/", "-") / "CLAUDE.md"
@@ -274,16 +281,16 @@ async def run_dev_issue(
         #   DONE    -> remove worktree, keep branch (the open PR references it)
         #   BLOCKED -> keep both (user may resume the session)
         #   FAILED  -> remove worktree AND delete branch so the next retry can
-        #              re-create `fix/issue-<n>` cleanly — BUT only if we
-        #              created the branch in this run and it was never pushed;
-        #              if it's on origin, the user has recoverable work there.
+        #              re-create `fix/issue-<n>` cleanly — BUT only if the
+        #              branch did not pre-exist (we own it) and it was never
+        #              pushed (no recoverable work on origin).
         if result.success:
             worktree.remove_context_symlink(worktree_path)
             await worktree.remove_worktree(repo, session_id)
         elif not result.blocked:
             worktree.remove_context_symlink(worktree_path)
             await worktree.remove_worktree(repo, session_id)
-            if branch_created and not await worktree.branch_exists_on_remote(
+            if not branch_preexisted and not await worktree.branch_exists_on_remote(
                 repo, branch_name
             ):
                 await worktree.delete_branch(repo, branch_name)
@@ -298,8 +305,10 @@ async def run_dev_issue(
         state_db.commit()
 
         # Best-effort cleanup so a retry isn't blocked by leftover state. Only
-        # touch the branch if this run created it AND it has no remote copy
-        # (preserves pushed work and never clobbers pre-existing branches).
+        # touch the branch if it didn't pre-exist (we own it) AND origin has
+        # no copy (no recoverable work to orphan). Covers partial failures of
+        # `git worktree add -b` that create the ref before the directory setup
+        # crashes.
         if worktree_path is not None:
             try:
                 worktree.remove_context_symlink(worktree_path)
@@ -309,7 +318,7 @@ async def run_dev_issue(
                 await worktree.remove_worktree(repo, session_id)
             except Exception:
                 pass
-        if branch_created:
+        if not branch_preexisted:
             try:
                 has_remote = await worktree.branch_exists_on_remote(repo, branch_name)
             except Exception:

--- a/src/dev_sync/pipelines/dev.py
+++ b/src/dev_sync/pipelines/dev.py
@@ -187,6 +187,7 @@ async def run_dev_issue(
         )
 
     worktree_path: Path | None = None
+    branch_created = False
 
     try:
         # Get issue details
@@ -199,6 +200,7 @@ async def run_dev_issue(
             session_id=session_id,
             new_branch=branch_name,
         )
+        branch_created = True
 
         # Symlink context
         context_path = contexts_dir / repo.replace("/", "-") / "CLAUDE.md"
@@ -272,14 +274,19 @@ async def run_dev_issue(
         #   DONE    -> remove worktree, keep branch (the open PR references it)
         #   BLOCKED -> keep both (user may resume the session)
         #   FAILED  -> remove worktree AND delete branch so the next retry can
-        #              re-create `fix/issue-<n>` cleanly
+        #              re-create `fix/issue-<n>` cleanly — BUT only if we
+        #              created the branch in this run and it was never pushed;
+        #              if it's on origin, the user has recoverable work there.
         if result.success:
             worktree.remove_context_symlink(worktree_path)
             await worktree.remove_worktree(repo, session_id)
         elif not result.blocked:
             worktree.remove_context_symlink(worktree_path)
             await worktree.remove_worktree(repo, session_id)
-            await worktree.delete_branch(repo, branch_name)
+            if branch_created and not await worktree.branch_exists_on_remote(
+                repo, branch_name
+            ):
+                await worktree.delete_branch(repo, branch_name)
 
         return result
 
@@ -290,7 +297,9 @@ async def run_dev_issue(
         )
         state_db.commit()
 
-        # Best-effort cleanup so a retry isn't blocked by leftover branch/worktree.
+        # Best-effort cleanup so a retry isn't blocked by leftover state. Only
+        # touch the branch if this run created it AND it has no remote copy
+        # (preserves pushed work and never clobbers pre-existing branches).
         if worktree_path is not None:
             try:
                 worktree.remove_context_symlink(worktree_path)
@@ -300,10 +309,16 @@ async def run_dev_issue(
                 await worktree.remove_worktree(repo, session_id)
             except Exception:
                 pass
-        try:
-            await worktree.delete_branch(repo, branch_name)
-        except Exception:
-            pass
+        if branch_created:
+            try:
+                has_remote = await worktree.branch_exists_on_remote(repo, branch_name)
+            except Exception:
+                has_remote = True
+            if not has_remote:
+                try:
+                    await worktree.delete_branch(repo, branch_name)
+                except Exception:
+                    pass
 
         return PipelineResult(
             success=False,

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -119,6 +119,7 @@ class TestDevPipelineCleanup:
         *,
         branch_on_remote: bool = False,
         create_side_effect=None,
+        branch_preexists_locally: bool = False,
     ):
         """Run the dev pipeline with a stub dispatcher behavior, returning
         (result, mocks) so tests can assert on cleanup calls.
@@ -157,10 +158,12 @@ class TestDevPipelineCleanup:
              patch.object(worktree, "remove_worktree", new_callable=AsyncMock) as mock_remove_wt, \
              patch.object(worktree, "delete_branch", new_callable=AsyncMock) as mock_delete_branch, \
              patch.object(worktree, "branch_exists_on_remote", new_callable=AsyncMock) as mock_remote, \
+             patch.object(worktree, "branch_exists_locally", new_callable=AsyncMock) as mock_local, \
              patch.object(worktree, "symlink_context"), \
              patch.object(worktree, "remove_context_symlink"):
 
             mock_remote.return_value = branch_on_remote
+            mock_local.return_value = branch_preexists_locally
 
             if create_side_effect is not None:
                 mock_create.side_effect = create_side_effect
@@ -296,9 +299,9 @@ class TestDevPipelineCleanup:
     async def test_setup_failure_does_not_delete_preexisting_branch(
         self, tmp_path: Path
     ) -> None:
-        """Codex P2: if worktree creation fails (e.g. branch from a prior DONE
-        session with an open PR), cleanup must NOT call delete_branch — this
-        session never created or owned that branch."""
+        """Codex P2: if the branch already existed before this run (from a
+        prior DONE session with an open PR) and worktree creation fails,
+        cleanup must NOT call delete_branch — this session never owned it."""
 
         async def create_boom(**kwargs):
             raise RuntimeError("branch already exists (from a prior DONE run)")
@@ -307,7 +310,10 @@ class TestDevPipelineCleanup:
             raise AssertionError("spawn should not be reached")
 
         result, mock_remove_wt, mock_delete_branch = await self._run(
-            tmp_path, spawn, create_side_effect=create_boom
+            tmp_path,
+            spawn,
+            create_side_effect=create_boom,
+            branch_preexists_locally=True,
         )
 
         assert not result.success
@@ -315,6 +321,39 @@ class TestDevPipelineCleanup:
         mock_remove_wt.assert_not_awaited()
         # and never touch the pre-existing branch
         mock_delete_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_partial_worktree_create_still_cleans_up_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex follow-up P2: `git worktree add -b` can create the branch
+        ref before the worktree directory setup fails. In that case we
+        *did* introduce the branch even though create_worktree_with_new_branch
+        raised — cleanup must delete it so the next retry isn't blocked."""
+
+        async def create_partial_fail(**kwargs):
+            # Simulate: ref got created, but the worktree dir step crashed.
+            raise RuntimeError(
+                "worktree add failed after branch ref was created "
+                "(disk full / permission denied on dir)"
+            )
+
+        async def spawn(**kwargs):
+            raise AssertionError("spawn should not be reached")
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(
+            tmp_path,
+            spawn,
+            create_side_effect=create_partial_fail,
+            branch_preexists_locally=False,  # this run introduced the ref
+        )
+
+        assert not result.success
+        # worktree_path never got assigned, so remove_worktree isn't called
+        mock_remove_wt.assert_not_awaited()
+        # but we owned the branch, so it must be deleted
+        mock_delete_branch.assert_awaited_once()
+        assert mock_delete_branch.await_args.args[1] == "fix/issue-13"
 
     @pytest.mark.asyncio
     async def test_success_preserves_branch(self, tmp_path: Path) -> None:

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -107,3 +107,182 @@ class TestDevIntegration:
         assert rows[0]["issue_number"] == 123
 
         state_db.close()
+
+
+class TestDevPipelineCleanup:
+    """Regression tests for #17: worktree + branch cleanup on failure paths."""
+
+    async def _run(
+        self,
+        tmp_path: Path,
+        spawn_side_effect,
+    ):
+        """Run the dev pipeline with a stub dispatcher behavior, returning
+        (result, worktree_manager_mocks) so tests can assert on cleanup calls."""
+        from dev_sync.core.dispatcher import ClaudeDispatcher
+        from dev_sync.core.github import GitHubCLI
+        from dev_sync.core.state import StateDB
+        from dev_sync.core.worktree import WorktreeManager
+        from dev_sync.pipelines.dev import run_dev_issue
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        worktree = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+
+        mock_github = AsyncMock(spec=GitHubCLI)
+        mock_github.get_issue.return_value = {
+            "number": 13,
+            "title": "Remove roadmap section from README",
+            "body": "Outdated.",
+        }
+
+        mock_dispatcher = AsyncMock(spec=ClaudeDispatcher)
+        mock_dispatcher.spawn_session.side_effect = spawn_side_effect
+
+        with patch.object(worktree, "ensure_bare_repo", new_callable=AsyncMock), \
+             patch.object(worktree, "create_worktree_with_new_branch", new_callable=AsyncMock) as mock_create, \
+             patch.object(worktree, "remove_worktree", new_callable=AsyncMock) as mock_remove_wt, \
+             patch.object(worktree, "delete_branch", new_callable=AsyncMock) as mock_delete_branch, \
+             patch.object(worktree, "symlink_context"), \
+             patch.object(worktree, "remove_context_symlink"):
+
+            worktree_path = tmp_path / "worktrees" / "wt-13"
+            worktree_path.mkdir(parents=True)
+            mock_create.return_value = worktree_path
+
+            result = await run_dev_issue(
+                repo="owner/repo",
+                issue_number=13,
+                branch_template="fix/issue-{n}",
+                dispatcher=mock_dispatcher,
+                github=mock_github,
+                worktree=worktree,
+                dashboard=None,
+                state_db=state_db,
+                transport=None,
+                contexts_dir=tmp_path / "contexts",
+            )
+
+        state_db.close()
+        return result, mock_remove_wt, mock_delete_branch
+
+    @pytest.mark.asyncio
+    async def test_dispatcher_exception_cleans_up_worktree_and_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #17: if dispatcher raises (e.g. claude binary missing),
+        the leftover worktree and fix/issue-<n> branch must be cleaned up so the
+        next retry can re-create them."""
+
+        async def spawn(**kwargs):
+            raise FileNotFoundError(2, "No such file or directory", "claude")
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(tmp_path, spawn)
+
+        assert not result.success
+        assert not result.blocked
+        mock_remove_wt.assert_awaited_once()
+        mock_delete_branch.assert_awaited_once()
+        assert mock_delete_branch.await_args.args[1] == "fix/issue-13"
+
+    @pytest.mark.asyncio
+    async def test_failed_checkpoint_cleans_up_worktree_and_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """A FAILED checkpoint (claude exited cleanly but flagged failure) must
+        trigger the same cleanup as an exception — retry must not be blocked by
+        a leftover branch."""
+        from dev_sync.core.checkpoint import read_checkpoint
+        from dev_sync.core.dispatcher import SessionResult
+
+        async def spawn(**kwargs):
+            state_file = kwargs["state_file"]
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({
+                "version": "1",
+                "status": "FAILED",
+                "session_id": kwargs["session_id"],
+                "timestamp": "2026-04-17T12:00:00Z",
+                "error": "something broke",
+            }))
+            return SessionResult(
+                session_id=kwargs["session_id"],
+                exit_code=1,
+                stdout="",
+                stderr="",
+                state=read_checkpoint(state_file),
+            )
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(tmp_path, spawn)
+
+        assert not result.success
+        assert not result.blocked
+        mock_remove_wt.assert_awaited_once()
+        mock_delete_branch.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_blocked_preserves_worktree_and_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """BLOCKED must NOT clean up — the user may resume the session."""
+        from dev_sync.core.checkpoint import read_checkpoint
+        from dev_sync.core.dispatcher import SessionResult
+
+        async def spawn(**kwargs):
+            state_file = kwargs["state_file"]
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({
+                "version": "1",
+                "status": "BLOCKED_NEEDS_INPUT",
+                "session_id": kwargs["session_id"],
+                "timestamp": "2026-04-17T12:00:00Z",
+                "question": "pin or bump?",
+            }))
+            return SessionResult(
+                session_id=kwargs["session_id"],
+                exit_code=0,
+                stdout="",
+                stderr="",
+                state=read_checkpoint(state_file),
+            )
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(tmp_path, spawn)
+
+        assert result.blocked
+        mock_remove_wt.assert_not_awaited()
+        mock_delete_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_success_preserves_branch(self, tmp_path: Path) -> None:
+        """DONE removes the worktree but keeps the branch — the open PR
+        references it, so deleting would break the PR."""
+        from dev_sync.core.checkpoint import read_checkpoint
+        from dev_sync.core.dispatcher import SessionResult
+
+        async def spawn(**kwargs):
+            state_file = kwargs["state_file"]
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({
+                "version": "1",
+                "status": "DONE",
+                "session_id": kwargs["session_id"],
+                "timestamp": "2026-04-17T12:00:00Z",
+                "summary": "PR opened",
+                "outputs": {"pr_url": "https://x/pr/1", "pr_number": 1},
+            }))
+            return SessionResult(
+                session_id=kwargs["session_id"],
+                exit_code=0,
+                stdout="",
+                stderr="",
+                state=read_checkpoint(state_file),
+            )
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(tmp_path, spawn)
+
+        assert result.success
+        mock_remove_wt.assert_awaited_once()
+        mock_delete_branch.assert_not_awaited()

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -116,9 +116,19 @@ class TestDevPipelineCleanup:
         self,
         tmp_path: Path,
         spawn_side_effect,
+        *,
+        branch_on_remote: bool = False,
+        create_side_effect=None,
     ):
         """Run the dev pipeline with a stub dispatcher behavior, returning
-        (result, worktree_manager_mocks) so tests can assert on cleanup calls."""
+        (result, mocks) so tests can assert on cleanup calls.
+
+        - `branch_on_remote`: what branch_exists_on_remote() returns. False
+          means the branch is local-only (safe to delete). True means origin
+          has it (must preserve).
+        - `create_side_effect`: if set, overrides create_worktree_with_new_branch
+          to simulate setup failure before the branch is created.
+        """
         from dev_sync.core.dispatcher import ClaudeDispatcher
         from dev_sync.core.github import GitHubCLI
         from dev_sync.core.state import StateDB
@@ -146,12 +156,18 @@ class TestDevPipelineCleanup:
              patch.object(worktree, "create_worktree_with_new_branch", new_callable=AsyncMock) as mock_create, \
              patch.object(worktree, "remove_worktree", new_callable=AsyncMock) as mock_remove_wt, \
              patch.object(worktree, "delete_branch", new_callable=AsyncMock) as mock_delete_branch, \
+             patch.object(worktree, "branch_exists_on_remote", new_callable=AsyncMock) as mock_remote, \
              patch.object(worktree, "symlink_context"), \
              patch.object(worktree, "remove_context_symlink"):
 
-            worktree_path = tmp_path / "worktrees" / "wt-13"
-            worktree_path.mkdir(parents=True)
-            mock_create.return_value = worktree_path
+            mock_remote.return_value = branch_on_remote
+
+            if create_side_effect is not None:
+                mock_create.side_effect = create_side_effect
+            else:
+                worktree_path = tmp_path / "worktrees" / "wt-13"
+                worktree_path.mkdir(parents=True)
+                mock_create.return_value = worktree_path
 
             result = await run_dev_issue(
                 repo="owner/repo",
@@ -253,6 +269,51 @@ class TestDevPipelineCleanup:
 
         assert result.blocked
         mock_remove_wt.assert_not_awaited()
+        mock_delete_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_pushed_branch_is_preserved_on_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1: if Claude pushed the branch to origin before failing,
+        cleanup must NOT delete the local branch — the user's commits are on
+        origin and deleting local state would orphan them from their clone."""
+
+        async def spawn(**kwargs):
+            raise RuntimeError("claude died after pushing")
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(
+            tmp_path, spawn, branch_on_remote=True
+        )
+
+        assert not result.success
+        # worktree can still be removed (branch ref persists locally anyway)
+        mock_remove_wt.assert_awaited_once()
+        # but the branch must be preserved
+        mock_delete_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_setup_failure_does_not_delete_preexisting_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2: if worktree creation fails (e.g. branch from a prior DONE
+        session with an open PR), cleanup must NOT call delete_branch — this
+        session never created or owned that branch."""
+
+        async def create_boom(**kwargs):
+            raise RuntimeError("branch already exists (from a prior DONE run)")
+
+        async def spawn(**kwargs):
+            raise AssertionError("spawn should not be reached")
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(
+            tmp_path, spawn, create_side_effect=create_boom
+        )
+
+        assert not result.success
+        # no worktree to remove either
+        mock_remove_wt.assert_not_awaited()
+        # and never touch the pre-existing branch
         mock_delete_branch.assert_not_awaited()
 
     @pytest.mark.asyncio

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -186,3 +186,77 @@ class TestWorktreeManager:
         link = worktree_path / "CLAUDE.md"
         assert link.is_symlink()
         assert link.resolve() == context_file.resolve()
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_on_remote_true(self, tmp_path: Path) -> None:
+        """ls-remote returning a ref line means the branch is on origin."""
+        from dev_sync.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = (
+                "abc123\trefs/heads/fix/issue-13\n"
+            )
+            assert await manager.branch_exists_on_remote("owner/repo", "fix/issue-13") is True
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_on_remote_false(self, tmp_path: Path) -> None:
+        """Empty ls-remote output means the branch is not on origin."""
+        from dev_sync.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = ""
+            assert await manager.branch_exists_on_remote("owner/repo", "fix/issue-13") is False
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_on_remote_fails_closed_on_timeout(
+        self, tmp_path: Path
+    ) -> None:
+        """If ls-remote hangs / times out (credential prompt, flaky network),
+        the probe must return True so callers preserve the branch instead of
+        mistakenly treating it as local-only."""
+        import asyncio as _asyncio
+
+        from dev_sync.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = _asyncio.TimeoutError()
+            assert await manager.branch_exists_on_remote("owner/repo", "fix/issue-13") is True
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_on_remote_fails_closed_on_worktree_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Generic git failures (auth, network refused) also fail closed."""
+        from dev_sync.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = WorktreeError("fatal: could not read Username")
+            assert await manager.branch_exists_on_remote("owner/repo", "fix/issue-13") is True

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -188,6 +188,49 @@ class TestWorktreeManager:
         assert link.resolve() == context_file.resolve()
 
     @pytest.mark.asyncio
+    async def test_branch_exists_locally_true(self, tmp_path: Path) -> None:
+        """show-ref returning 0 means the branch is a local ref."""
+        from dev_sync.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = ""
+            assert await manager.branch_exists_locally("owner/repo", "fix/issue-13") is True
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_locally_false(self, tmp_path: Path) -> None:
+        """show-ref raising means the branch does not exist locally."""
+        from dev_sync.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare_path = tmp_path / "repos" / "owner-repo.git"
+        bare_path.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = WorktreeError("bad ref")
+            assert await manager.branch_exists_locally("owner/repo", "fix/issue-13") is False
+
+    @pytest.mark.asyncio
+    async def test_branch_exists_locally_no_bare_repo(self, tmp_path: Path) -> None:
+        """With no bare repo yet, the branch cannot exist locally."""
+        from dev_sync.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        assert await manager.branch_exists_locally("owner/repo", "fix/issue-13") is False
+
+    @pytest.mark.asyncio
     async def test_branch_exists_on_remote_true(self, tmp_path: Path) -> None:
         """ls-remote returning a ref line means the branch is on origin."""
         from dev_sync.core.worktree import WorktreeManager


### PR DESCRIPTION
Closes #17.

## Summary
If the dev pipeline failed before or during `dispatcher.spawn_session` (uncaught exception), or if Claude itself signaled FAILED, the freshly-created worktree and `fix/issue-<n>` branch were left behind. The next retry hit:

\`\`\`
git failed: Preparing worktree (new branch 'fix/issue-13')
fatal: a branch named 'fix/issue-13' already exists
\`\`\`

...so the issue could never be retried without manual cleanup of both the worktree and the local branch in the bare repo. We saw this today in `AInvirion/dev-sync` for issues #13, #14, #15 after the launchd PATH fix in #16 landed.

## Changes
- `core/worktree.py`: new `delete_branch(repo, branch)` — best-effort `git branch -D` in the bare repo. Silently absorbs `WorktreeError` so cleanup paths don't mask the original failure.
- `pipelines/dev.py` (`run_dev_issue`):
  - Track `worktree_path` in outer scope so the `except` handler can clean up.
  - On **FAILED** checkpoint: remove worktree **and** delete branch (previously only the worktree was removed).
  - On **exception** before/during `pipeline.run`: best-effort cleanup of context symlink, worktree, and branch so the next retry succeeds. Each cleanup step is independently try/excepted so one failure doesn't block the rest.
  - On **DONE**: unchanged — remove worktree but keep the branch (the open PR still references it).
  - On **BLOCKED**: unchanged — keep both (user may resume).

## Test plan
- [x] `pytest tests/test_dev_integration.py -v` — 5 passed, covering:
  - dispatcher exception → worktree + branch removed
  - FAILED checkpoint → worktree + branch removed
  - BLOCKED → nothing removed
  - DONE → worktree removed, branch kept
- [x] Full suite `pytest -q` — 150 passed
- [ ] After merge + poller restart: intentionally break the dispatcher, trigger an issue, confirm that after the failure the worktree under `~/.dev-sync/worktrees/` and the `fix/issue-<n>` branch in the bare repo are both absent; retry succeeds.