### PR TITLE
docs: remove Requirements section from README (fixes #14)

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,12 +25,6 @@ uv pip install -e .
 pip install -e .
 ```
 
-### Requirements
-
-- Python 3.11+
-- [Claude CLI](https://docs.anthropic.com/en/docs/claude-code) (`claude` command)
-- [GitHub CLI](https://cli.github.com/) (`gh` command, authenticated)
-
 ## Quick Start
 
 ### 1. Configure


### PR DESCRIPTION
## Summary
- Removes the `### Requirements` subsection from README.md under Installation.

Closes #14.

## Test plan
- [x] `git diff` shows only the Requirements heading + 3 bullet points removed.
- [x] No other docs reference the removed section.