### PR TITLE
docs: remove docs site line from README (fixes #15)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,8 +2,6 @@
 
 Local-first automation orchestrator for GitHub repos. Wraps Claude CLI to automate security triage, issue-to-PR workflows, and multi-repo operations.
 
-📖 **Docs site:** [ainvirion.github.io/dev-sync](https://ainvirion.github.io/dev-sync/) — design specs, implementation plans, and operator guides, built from [`docs/`](docs/) with Jekyll + just-the-docs and deployed via GitHub Pages.
-
 ## Features
 
 - **Secops Pipeline** - Automated security triage across repos (Dependabot alerts, security PRs)


### PR DESCRIPTION
## Summary
- Removes the docs site reference line from README.md as requested in #15.

Closes #15

## Test plan
- [x] Verify the docs site line is removed from README.md
- [x] Verify surrounding formatting remains clean (no double blank lines)