### PR TITLE
feat(dev-pipeline): post claim comment on issue when work begins

### DIFF
--- a/src/dev_sync/core/github.py
+++ b/src/dev_sync/core/github.py
@@ -172,6 +172,20 @@ class GitHubCLI:
         )
         return json.loads(output)
 
+    async def comment_on_issue(
+        self,
+        repo: str,
+        issue_number: int,
+        body: str,
+    ) -> None:
+        """Post a comment on an issue."""
+        await self._run_gh(
+            "issue", "comment",
+            str(issue_number),
+            "--repo", repo,
+            "--body", body,
+        )
+
     async def close_issue(
         self,
         repo: str,
@@ -180,12 +194,7 @@ class GitHubCLI:
     ) -> None:
         """Close an issue with an optional comment."""
         if comment is not None:
-            await self._run_gh(
-                "issue", "comment",
-                str(issue_number),
-                "--repo", repo,
-                "--body", comment,
-            )
+            await self.comment_on_issue(repo, issue_number, comment)
         await self._run_gh(
             "issue", "close",
             str(issue_number),

--- a/src/dev_sync/pipelines/dev.py
+++ b/src/dev_sync/pipelines/dev.py
@@ -17,6 +17,12 @@ from dev_sync.dashboard.client import DashboardClient, EventPayload
 from dev_sync.pipelines.base import PipelineContext, PipelineResult
 from dev_sync.transports.base import Transport
 
+AGENT_CLAIM_MARKER = "<!-- dev-sync:claimed -->"
+AGENT_CLAIM_COMMENT = (
+    "🤖 Agent is working on this issue. A PR will be opened for review.\n\n"
+    f"{AGENT_CLAIM_MARKER}"
+)
+
 
 @dataclass
 class DevPipeline:
@@ -155,6 +161,21 @@ async def run_dev_issue(
     try:
         # Get issue details
         issue = await github.get_issue(repo, issue_number)
+
+        # Post claim comment so collaborators can see the agent picked it up.
+        # Skip if a previous attempt already left the marker — keeps it idempotent
+        # across retries / resumed sessions.
+        existing_comments = issue.get("comments") or []
+        already_claimed = any(
+            AGENT_CLAIM_MARKER in (c.get("body") or "")
+            for c in existing_comments
+        )
+        if not already_claimed:
+            await github.comment_on_issue(
+                repo=repo,
+                issue_number=issue_number,
+                body=AGENT_CLAIM_COMMENT,
+            )
 
         # Create worktree with new branch
         await worktree.ensure_bare_repo(repo)

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -132,6 +132,132 @@ class TestDevPipeline:
         mock_worktree.create_worktree_with_new_branch.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_run_dev_issue_posts_claim_comment(self, tmp_path: Path) -> None:
+        """Should post a claim comment on the issue when work begins."""
+        from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus
+        from dev_sync.core.dispatcher import SessionResult
+        from dev_sync.core.state import StateDB
+        from dev_sync.pipelines.dev import AGENT_CLAIM_MARKER, run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42 opened",
+                outputs={"pr_url": "https://github.com/o/r/pull/42", "pr_number": 42},
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 123,
+            "title": "Fix bug",
+            "body": "Bug description",
+            "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        await run_dev_issue(
+            repo="owner/repo",
+            issue_number=123,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        mock_github.comment_on_issue.assert_called_once()
+        call_args = mock_github.comment_on_issue.call_args
+        assert call_args.kwargs.get("repo") == "owner/repo" or call_args.args[0] == "owner/repo"
+        assert (
+            call_args.kwargs.get("issue_number") == 123
+            or 123 in call_args.args
+        )
+        body = call_args.kwargs.get("body") or call_args.args[-1]
+        assert AGENT_CLAIM_MARKER in body
+        assert "working on" in body.lower() or "checking" in body.lower()
+
+    @pytest.mark.asyncio
+    async def test_run_dev_issue_skips_claim_comment_if_already_posted(
+        self, tmp_path: Path
+    ) -> None:
+        """Should not post a duplicate claim comment if marker is already present."""
+        from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus
+        from dev_sync.core.dispatcher import SessionResult
+        from dev_sync.core.state import StateDB
+        from dev_sync.pipelines.dev import AGENT_CLAIM_MARKER, run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42 opened",
+                outputs={"pr_url": "https://github.com/o/r/pull/42", "pr_number": 42},
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 123,
+            "title": "Fix bug",
+            "body": "Bug description",
+            "comments": [
+                {
+                    "body": (
+                        f"Agent is already on it\n\n{AGENT_CLAIM_MARKER}"
+                    ),
+                    "author": {"login": "alice"},
+                }
+            ],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        await run_dev_issue(
+            repo="owner/repo",
+            issue_number=123,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        mock_github.comment_on_issue.assert_not_called()
+
+    @pytest.mark.asyncio
     async def test_run_returns_blocked_when_needs_input(self, tmp_path: Path) -> None:
         """Should return blocked result when Claude needs input."""
         from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -174,6 +174,24 @@ class TestGitHubCLI:
             assert "55" in args
 
     @pytest.mark.asyncio
+    async def test_comment_on_issue(self) -> None:
+        """Should post a comment on an issue."""
+        from dev_sync.core.github import GitHubCLI
+
+        with patch("dev_sync.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = ""
+            gh = GitHubCLI()
+            await gh.comment_on_issue("owner/repo", 7, "hello there")
+
+            mock_run.assert_called_once()
+            args = mock_run.call_args[0]
+            assert "issue" in args
+            assert "comment" in args
+            assert "7" in args
+            assert "--body" in args
+            assert "hello there" in args
+
+    @pytest.mark.asyncio
     async def test_close_issue_without_comment(self) -> None:
         """Should close an issue without adding a comment."""
         from dev_sync.core.github import GitHubCLI


### PR DESCRIPTION
## Summary
- Adds `GitHubCLI.comment_on_issue()` for posting a comment on a GitHub issue.
- `run_dev_issue()` now leaves a visible "🤖 Agent is working on this issue" comment as soon as it claims the issue (after the lock is acquired, before spawning Claude).
- Idempotent via a hidden `<!-- dev-sync:claimed -->` marker — re-runs / resumes won't duplicate the comment.

Closes #9

## Acceptance criteria
- [x] Poller posts a comment on the issue as soon as it claims it
- [x] Comment content is clear (`🤖 Agent is working on this issue. A PR will be opened for review.`)
- [x] Comment is only posted once per claim (no duplicates on retries)

## Test plan
- [x] `pytest tests/test_github.py tests/test_dev_pipeline.py tests/test_poller.py` — passes (23/23)
- [x] Full suite: `pytest` — passes (130/130)
- [x] New tests: `test_comment_on_issue`, `test_run_dev_issue_posts_claim_comment`, `test_run_dev_issue_skips_claim_comment_if_already_posted`