### PR TITLE
ci: add workflow to build Python sdist and wheel (closes #25)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,36 @@
+name: Build Python distribution
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: uv build
+
+      - name: List built artifacts
+        run: ls -la dist/
+
+      - name: Upload distribution artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/build.yml` that builds the Python `sdist` + `wheel` on every push to `main` and every pull request.
- Uses `uv build` on Python 3.12 (matches `pyproject.toml`'s `requires-python = ">=3.12"`).
- Uploads `dist/*` as a workflow artifact via `actions/upload-artifact@v4`.
- Does **not** publish to PyPI / TestPyPI and does not require any publish secrets (permissions are `contents: read`).

Closes #25.

## Test plan
- [x] Verified `python -m build` produces both `dev_sync-0.1.0.tar.gz` and `dev_sync-0.1.0-py3-none-any.whl` locally against this branch.
- [ ] CI: the new `Build Python distribution` workflow runs green on this PR.
- [ ] Artifact `dist` is attached to the workflow run and downloadable.