### PR TITLE
Release 0.1.0: changelog and version wiring (#31)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2026-04-18
+
+First tagged release of the `dev-sync` orchestrator. Bundles the multi-device
+sync toolkit with the Phase 0–4 implementation of the local-first Claude Code
+orchestrator (config, checkpoints, Telegram bridge, secops pipeline, and dev
+pipeline).
+
+### Added
+
+#### Orchestrator package (`dev_sync`)
+
+- **Phase 0 — package skeleton**: `pyproject.toml` with metadata and entry
+  point, Typer-based CLI (`dev-sync`), Pydantic config models with validation,
+  SQLite-backed state with per-repo locks, and `config validate` / `status`
+  commands.
+- **Phase 1 — checkpoints & skill audit**: checkpoint Pydantic models,
+  `done` / `blocked` / `failed` helpers, `read_checkpoint` for the
+  orchestrator, skill discovery from `SKILL.md`, audit checks with markdown
+  report formatting, and `skills audit` / `skills list` CLI commands.
+- **Phase 2 — Telegram bridge**: bridge protocol message types, transport
+  protocol abstraction with `SocketTransport` and `FileMockTransport`
+  implementations, bridge server with socket handling, Telegram handler,
+  `bridge start/stop/status/test` CLI commands, and a daemon entry point.
+- **Phase 3 — secops pipeline**: GitHub CLI wrapper, git worktree manager,
+  Claude subprocess dispatcher, dashboard client with offline event queue,
+  pipeline base protocol, `secops` pipeline implementation, and the
+  `run secops` CLI command.
+- **Phase 4 — dev pipeline**: GitHub issue and PR helpers, assigned-issue
+  poller with persistent seen-state, worktree+branch creation and push,
+  PR merge watcher, `dev` pipeline orchestration with post-merge handler,
+  and `dev` / `poll` CLI commands.
+
+#### Multi-device sync toolkit
+
+- `./sync` CLI for cloning, pulling, and inspecting repos listed in
+  `repos.manifest`, with filter and dry-run modes.
+- Claude Code config sync (`export` / `import`) for settings, keybindings,
+  agents, hooks, and skills, plus `team-export` / `team-import` for
+  shareable team config (with home-path sanitization).
+- Codex CLI sync (`codex-export` / `codex-import` / `codex-install`) and
+  `codex-reviewer` MCP server for Claude ↔ Codex code review.
+- First-time device bootstrap (`./sync setup`) and manifest rescanning
+  (`./sync manifest`), including support for nested repo folders.
+- Bundled Claude skills under `claude-config/skills/` (VID, gh-issue,
+  gh-dashboard, gh-secops, gh-prdone, code-interest-sniff-test,
+  codex-review-loop) and lab skills (ainvirion-design-conventions,
+  ainvirion-morphs, minions, vid-spec).
+
+### Documentation
+
+- `docs/dev-sync-orchestrator-spec.md` — orchestrator design spec.
+- `docs/superpowers/specs/2026-04-17-dev-sync-orchestrator-design.md` and
+  per-phase implementation plans (Phase 0 through Phase 4).
+- `docs/Claude_Code_Project_Guide.md` — project development guide.
+
+[Unreleased]: https://github.com/AInvirion/dev-sync/compare/v0.1.0...HEAD
+[0.1.0]: https://github.com/AInvirion/dev-sync/releases/tag/v0.1.0

--- a/src/dev_sync/dashboard/client.py
+++ b/src/dev_sync/dashboard/client.py
@@ -11,13 +11,15 @@ from typing import Any
 import httpx
 from pydantic import BaseModel
 
+from dev_sync import __version__
+
 
 class HeartbeatPayload(BaseModel):
     """Payload for heartbeat endpoint."""
 
     node_id: str
     timestamp: str = ""
-    version: str = "0.1.0"
+    version: str = __version__
     uptime_seconds: int = 0
     platform: str = ""
     active_sessions: list[dict[str, Any]] = []


### PR DESCRIPTION
## Summary

Prepares the 0.1.0 release per #31:

- Adds `CHANGELOG.md` (Keep-a-Changelog format) covering Phase 0–4 of the orchestrator and the multi-device sync toolkit.
- Wires `HeartbeatPayload.version` to `dev_sync.__version__` so the dashboard heartbeat reports the package version automatically on future bumps.
- Version in `pyproject.toml` and `src/dev_sync/__init__.py` is already `0.1.0` — no bump needed for this first tagged release.

## Release tag and GitHub release

The issue also asks for a `v0.1.0` tag and a GitHub release. Per the orchestrator workflow ("Do NOT merge the PR — wait for human review"), I'm leaving the tag/release creation as a manual post-merge step. Once this PR merges to `main`, the human reviewer can run:

```bash
git checkout main && git pull
git tag -a v0.1.0 -m "Release 0.1.0"
git push origin v0.1.0
gh release create v0.1.0 --title "v0.1.0" --notes-from-tag
```

The CHANGELOG already contains the release notes the GitHub release should use.

## Test plan

- [x] `pytest -q` — 127 passed
- [x] `ruff check src/dev_sync/dashboard/client.py` — clean (pre-existing lint errors in `tests/` are unchanged by this PR)
- [ ] Reviewer to verify CHANGELOG completeness against `git log`

Closes #31