### PR TITLE
ci: trigger build on tag push + attach artifacts to GitHub release

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,10 +3,13 @@ name: Build Python distribution
 on:
   push:
     branches: [main]
+    tags: ['v*']
   pull_request:
+  release:
+    types: [published]
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
   build:
@@ -34,3 +37,15 @@ jobs:
           name: dist
           path: dist/*
           if-no-files-found: error
+
+      - name: Attach artifacts to GitHub release
+        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${GITHUB_REF#refs/tags/}"
+          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
+            TAG="${{ github.event.release.tag_name }}"
+          fi
+          echo "Uploading dist/* to release ${TAG}"
+          gh release upload "${TAG}" dist/* --repo "${GITHUB_REPOSITORY}" --clobber


### PR DESCRIPTION
## Summary
Release v0.1.0 didn't produce any downloadable artifacts on the release page — the build workflow only listened to \`push.branches: [main]\` and \`pull_request\`, so pushing a \`v*\` tag (or creating a GH release) fired nothing.

## Changes
- \`push.tags: ['v*']\` — tag pushes now trigger the build.
- \`release.types: [published]\` — manually-created releases also run the build.
- \`permissions.contents: write\` so the workflow can upload to releases.
- New step \`Attach artifacts to GitHub release\` — uploads \`dist/*\` to the target tag/release with \`--clobber\`.

## Test plan
- [ ] After merge, create a throwaway tag on the test branch → workflow fires, builds, but won't upload (no matching release).
- [ ] Re-run manually for \`v0.1.0\` (via \`gh release create --target main --generate-notes\` or re-upload) to backfill the existing release with the built wheel/sdist.
- [ ] Next tagged release produces downloadable artifacts on the release page without manual intervention.