### PR TITLE
fix: wire BLOCKED→operator-answer→resume end-to-end over Telegram

### DIFF
--- a/src/dev_sync/bridge/server.py
+++ b/src/dev_sync/bridge/server.py
@@ -3,8 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 import os
 import stat
+from collections import OrderedDict
+from datetime import datetime, timezone
 from pathlib import Path
 
 from dev_sync.bridge.protocol import (
@@ -16,9 +19,32 @@ from dev_sync.bridge.protocol import (
 )
 from dev_sync.bridge.telegram_handler import TelegramHandler
 
+_log = logging.getLogger(__name__)
+
+
+class _PendingQuestion:
+    """Question posted to Telegram, awaiting the operator's reply."""
+
+    __slots__ = ("request_id", "telegram_msg_id", "writer")
+
+    def __init__(
+        self,
+        request_id: str,
+        telegram_msg_id: int,
+        writer: asyncio.StreamWriter,
+    ) -> None:
+        self.request_id = request_id
+        self.telegram_msg_id = telegram_msg_id
+        self.writer = writer
+
 
 class BridgeServer:
-    """Unix socket server that bridges to Telegram."""
+    """Unix socket server that bridges to Telegram — bidirectional.
+
+    Outbound: clients send SEND/ASK over the socket and we hit Telegram.
+    Inbound: we long-poll Telegram for messages; when a reply arrives it's
+    matched to the oldest outstanding ASK (or by reply_to_message_id if
+    available) and we push an ANSWER frame over that client's socket."""
 
     def __init__(
         self,
@@ -32,7 +58,9 @@ class BridgeServer:
         self._server: asyncio.Server | None = None
         self._running = False
         self._telegram: TelegramHandler | None = None
-        self._pending_questions: dict[str, int] = {}
+        # Insertion-ordered so FIFO dispatch is deterministic.
+        self._pending_questions: OrderedDict[str, _PendingQuestion] = OrderedDict()
+        self._pending_lock = asyncio.Lock()
 
     async def start(self) -> None:
         """Start the bridge server."""
@@ -40,6 +68,7 @@ class BridgeServer:
             bot_token=self.bot_token,
             chat_id=self.chat_id,
         )
+        await self._telegram.start_polling(self._on_telegram_reply)
 
         if self.socket_path.exists():
             self.socket_path.unlink()
@@ -84,17 +113,33 @@ class BridgeServer:
 
                 try:
                     msg = parse_message(line.decode())
-                    response = await self._handle_message(msg)
+                    response = await self._handle_message(msg, writer)
                     if response:
                         writer.write(serialize_message(response).encode())
                         await writer.drain()
                 except ProtocolError:
                     pass
         finally:
+            # Client disconnected — drop any outstanding questions tied to
+            # this writer so we don't try to answer a dead socket later.
+            async with self._pending_lock:
+                dead = [
+                    rid for rid, q in self._pending_questions.items()
+                    if q.writer is writer
+                ]
+                for rid in dead:
+                    self._pending_questions.pop(rid, None)
             writer.close()
-            await writer.wait_closed()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
 
-    async def _handle_message(self, msg: BridgeMessage) -> BridgeMessage | None:
+    async def _handle_message(
+        self,
+        msg: BridgeMessage,
+        writer: asyncio.StreamWriter,
+    ) -> BridgeMessage | None:
         """Handle a single message and return response."""
         if msg.op == BridgeOp.PING:
             return BridgeMessage(op=BridgeOp.PONG)
@@ -103,8 +148,10 @@ class BridgeServer:
             try:
                 assert self._telegram is not None
                 await self._telegram.send(msg.text or "")
+                _log.info("bridge: SEND delivered, request_id=%s", msg.request_id)
                 return BridgeMessage(op=BridgeOp.ACK, request_id=msg.request_id, status="sent")
             except Exception as e:
+                _log.warning("bridge: SEND failed, request_id=%s err=%s", msg.request_id, e)
                 return BridgeMessage(
                     op=BridgeOp.ERROR,
                     request_id=msg.request_id,
@@ -115,11 +162,25 @@ class BridgeServer:
         if msg.op == BridgeOp.ASK:
             try:
                 assert self._telegram is not None
-                msg_id = await self._telegram.ask(msg.question or "", options=msg.options)
+                telegram_msg_id = await self._telegram.ask(
+                    msg.question or "", options=msg.options
+                )
                 if msg.request_id:
-                    self._pending_questions[msg.request_id] = msg_id
-                return BridgeMessage(op=BridgeOp.ACK, request_id=msg.request_id, status="pending")
+                    async with self._pending_lock:
+                        self._pending_questions[msg.request_id] = _PendingQuestion(
+                            request_id=msg.request_id,
+                            telegram_msg_id=telegram_msg_id,
+                            writer=writer,
+                        )
+                _log.info(
+                    "bridge: ASK posted request_id=%s telegram_msg_id=%s",
+                    msg.request_id, telegram_msg_id,
+                )
+                return BridgeMessage(
+                    op=BridgeOp.ACK, request_id=msg.request_id, status="pending",
+                )
             except Exception as e:
+                _log.warning("bridge: ASK failed, request_id=%s err=%s", msg.request_id, e)
                 return BridgeMessage(
                     op=BridgeOp.ERROR,
                     request_id=msg.request_id,
@@ -128,3 +189,50 @@ class BridgeServer:
                 )
 
         return None
+
+    async def _on_telegram_reply(
+        self,
+        text: str,
+        reply_to_message_id: int | None,
+    ) -> None:
+        """Route an incoming Telegram message to the matching pending question.
+
+        Priority: if reply_to_message_id matches a tracked question, use it.
+        Otherwise fall back to FIFO (oldest outstanding question wins) —
+        good enough for the single-operator case."""
+        async with self._pending_lock:
+            match: _PendingQuestion | None = None
+            if reply_to_message_id is not None:
+                for q in self._pending_questions.values():
+                    if q.telegram_msg_id == reply_to_message_id:
+                        match = q
+                        break
+            if match is None and self._pending_questions:
+                # FIFO: pop oldest.
+                match = next(iter(self._pending_questions.values()))
+            if match is None:
+                _log.info(
+                    "bridge: incoming telegram msg with no pending question; "
+                    "text=%r", text[:80],
+                )
+                return
+            self._pending_questions.pop(match.request_id, None)
+
+        _log.info(
+            "bridge: delivering ANSWER request_id=%s len=%d",
+            match.request_id, len(text),
+        )
+        answer = BridgeMessage(
+            op=BridgeOp.ANSWER,
+            request_id=match.request_id,
+            answer=text,
+            answered_at=datetime.now(timezone.utc).isoformat(),
+        )
+        try:
+            match.writer.write(serialize_message(answer).encode())
+            await match.writer.drain()
+        except Exception as e:
+            _log.warning(
+                "bridge: failed to deliver ANSWER request_id=%s err=%s",
+                match.request_id, e,
+            )

--- a/src/dev_sync/bridge/telegram_handler.py
+++ b/src/dev_sync/bridge/telegram_handler.py
@@ -2,15 +2,26 @@
 
 from __future__ import annotations
 
+import asyncio
+import logging
+from typing import Awaitable, Callable
+
 from telegram import Bot, ReplyKeyboardMarkup, ReplyKeyboardRemove
+
+_log = logging.getLogger(__name__)
+
+IncomingMessageHandler = Callable[[str, int | None], Awaitable[None]]
 
 
 class TelegramHandler:
-    """Handles Telegram Bot API communication."""
+    """Handles Telegram Bot API communication — outbound (send/ask) and
+    inbound (long-poll get_updates) for answers from the operator."""
 
     def __init__(self, bot_token: str, chat_id: int) -> None:
         self.bot = Bot(token=bot_token)
         self.chat_id = chat_id
+        self._poll_task: asyncio.Task | None = None
+        self._offset: int = 0
 
     async def send(self, text: str) -> int:
         """Send a message to the configured chat."""
@@ -42,6 +53,65 @@ class TelegramHandler:
         )
         return message.message_id
 
+    async def start_polling(self, handler: IncomingMessageHandler) -> None:
+        """Start long-polling Telegram for incoming messages from the
+        configured chat. For each message, invokes
+        ``handler(text, reply_to_message_id)`` where reply_to_message_id is
+        the id of the question the user replied to (or None for a fresh
+        message). Idempotent — a second call replaces the running loop."""
+        if self._poll_task is not None and not self._poll_task.done():
+            return
+        self._poll_task = asyncio.create_task(self._poll_loop(handler))
+
+    async def stop_polling(self) -> None:
+        """Stop the polling loop if running."""
+        if self._poll_task is None:
+            return
+        self._poll_task.cancel()
+        try:
+            await self._poll_task
+        except asyncio.CancelledError:
+            pass
+        self._poll_task = None
+
+    async def _poll_loop(self, handler: IncomingMessageHandler) -> None:
+        """Long-poll get_updates and forward messages from the configured chat."""
+        while True:
+            try:
+                updates = await self.bot.get_updates(
+                    offset=self._offset,
+                    timeout=30,
+                    allowed_updates=["message"],
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Transient network / auth error. Back off and keep trying.
+                _log.warning("telegram get_updates failed: %s", e)
+                await asyncio.sleep(5)
+                continue
+
+            for update in updates:
+                self._offset = update.update_id + 1
+                msg = update.message
+                if msg is None or msg.chat is None:
+                    continue
+                if msg.chat.id != self.chat_id:
+                    continue  # ignore messages from other chats
+                text = (msg.text or "").strip()
+                if not text:
+                    continue
+                reply_id = (
+                    msg.reply_to_message.message_id
+                    if msg.reply_to_message is not None
+                    else None
+                )
+                try:
+                    await handler(text, reply_id)
+                except Exception as e:
+                    _log.warning("bridge answer handler raised: %s", e)
+
     async def close(self) -> None:
         """Close the bot session."""
+        await self.stop_polling()
         await self.bot.close()

--- a/src/dev_sync/pipelines/dev.py
+++ b/src/dev_sync/pipelines/dev.py
@@ -19,6 +19,7 @@ from dev_sync.pipelines.base import PipelineContext, PipelineResult
 from dev_sync.transports.base import Transport
 
 DEFAULT_MAX_FIX_ATTEMPTS = 3
+DEFAULT_MAX_BLOCKED_ROUNDS = 5
 
 AGENT_CLAIM_MARKER = "<!-- dev-sync:claimed -->"
 AGENT_CLAIM_COMMENT = (
@@ -308,6 +309,7 @@ async def run_dev_issue(
     transport: Transport | None,
     contexts_dir: Path,
     max_fix_attempts: int = DEFAULT_MAX_FIX_ATTEMPTS,
+    max_blocked_rounds: int = DEFAULT_MAX_BLOCKED_ROUNDS,
     pr_verifier: PRVerifier | None = None,
 ) -> PipelineResult:
     """Run dev pipeline for a single issue."""
@@ -405,6 +407,39 @@ async def run_dev_issue(
             transport=transport,
         )
         result = await pipeline.run(ctx)
+
+        # BLOCKED loop: if Claude needs input, post the question to the
+        # transport (Telegram), wait for the operator's reply, and resume
+        # the session. Loop until Claude signals DONE/FAILED or we run out
+        # of trips. Each round-trip is capped at the transport's own
+        # timeout (see Transport.ask signature — default 300s); the total
+        # is bounded by max_blocked_rounds.
+        rounds = 0
+        while (
+            result.blocked
+            and transport is not None
+            and rounds < max_blocked_rounds
+        ):
+            question = (result.question or "").strip() or (
+                f"Session {session_id} is blocked but did not include a "
+                "question. Reply with guidance to resume."
+            )
+            try:
+                answer = await transport.ask(question)
+            except Exception as e:
+                # Transport failed (bridge down, timeout, etc.) — give up
+                # cleanly and fall through to the normal blocked cleanup.
+                result = PipelineResult(
+                    success=False,
+                    blocked=False,
+                    session_id=session_id,
+                    summary=f"Blocked session abandoned: {e}",
+                    error=str(e),
+                    outputs=result.outputs,
+                )
+                break
+            rounds += 1
+            result = await pipeline.resume(ctx, answer)
 
         # Verify PR is green & conflict-free before handing off. Resume the
         # session with a fix request if either is broken, up to max_fix_attempts.

--- a/tests/test_bridge_server.py
+++ b/tests/test_bridge_server.py
@@ -90,3 +90,138 @@ class TestBridgeServer:
         task.cancel()
 
         assert not socket_path.exists()
+
+    @pytest.mark.asyncio
+    async def test_ask_then_telegram_reply_delivers_answer(self, socket_path) -> None:
+        """End-to-end: a client ASKs, bridge posts to Telegram, a simulated
+        incoming Telegram reply routes back to the same client as ANSWER."""
+        from unittest.mock import AsyncMock
+
+        from dev_sync.bridge.protocol import (
+            BridgeMessage,
+            BridgeOp,
+            parse_message,
+            serialize_message,
+        )
+        from dev_sync.bridge.server import BridgeServer
+
+        server = BridgeServer(socket_path=socket_path, bot_token="test", chat_id=123)
+        task = asyncio.create_task(server.start())
+        await asyncio.sleep(0.1)
+
+        # Swap in a mock Telegram handler so ASK doesn't hit the real API.
+        server._telegram.ask = AsyncMock(return_value=999)  # type: ignore[attr-defined]
+
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        try:
+            ask = serialize_message(BridgeMessage(
+                op=BridgeOp.ASK,
+                request_id="r-xyz",
+                question="pin or bump?",
+            ))
+            writer.write(ask.encode())
+            await writer.drain()
+
+            # Bridge acknowledges with status=pending.
+            ack_raw = await asyncio.wait_for(reader.readline(), timeout=1)
+            ack = parse_message(ack_raw.decode())
+            assert ack.op == BridgeOp.ACK
+            assert ack.status == "pending"
+            assert ack.request_id == "r-xyz"
+
+            # Simulate the operator replying via Telegram.
+            await server._on_telegram_reply("pin", reply_to_message_id=None)
+
+            # Bridge pushes ANSWER back over the same socket.
+            answer_raw = await asyncio.wait_for(reader.readline(), timeout=1)
+            answer = parse_message(answer_raw.decode())
+            assert answer.op == BridgeOp.ANSWER
+            assert answer.request_id == "r-xyz"
+            assert answer.answer == "pin"
+            assert answer.answered_at is not None
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            await server.stop()
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_reply_to_specific_message_prefers_that_question(
+        self, socket_path,
+    ) -> None:
+        """If the operator replies to a specific question, bridge matches by
+        telegram_msg_id rather than falling back to FIFO order."""
+        from unittest.mock import AsyncMock
+
+        from dev_sync.bridge.protocol import (
+            BridgeMessage, BridgeOp, parse_message, serialize_message,
+        )
+        from dev_sync.bridge.server import BridgeServer
+
+        server = BridgeServer(socket_path=socket_path, bot_token="test", chat_id=123)
+        task = asyncio.create_task(server.start())
+        await asyncio.sleep(0.1)
+
+        # Two ASKs -> two different Telegram msg_ids.
+        ask_mock = AsyncMock(side_effect=[111, 222])
+        server._telegram.ask = ask_mock  # type: ignore[attr-defined]
+
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        try:
+            for rid, q in [("r-1", "first"), ("r-2", "second")]:
+                writer.write(serialize_message(BridgeMessage(
+                    op=BridgeOp.ASK, request_id=rid, question=q,
+                )).encode())
+                await writer.drain()
+                await asyncio.wait_for(reader.readline(), timeout=1)  # ACK
+
+            # Reply specifically to the SECOND question (msg_id=222).
+            await server._on_telegram_reply("answering second", reply_to_message_id=222)
+
+            raw = await asyncio.wait_for(reader.readline(), timeout=1)
+            answer = parse_message(raw.decode())
+            assert answer.op == BridgeOp.ANSWER
+            assert answer.request_id == "r-2"
+            assert answer.answer == "answering second"
+        finally:
+            writer.close()
+            await writer.wait_closed()
+            await server.stop()
+            task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_drops_pending_questions(
+        self, socket_path,
+    ) -> None:
+        """If the client disconnects, its pending questions must be cleared
+        so we don't try to deliver ANSWER to a dead socket."""
+        from unittest.mock import AsyncMock
+
+        from dev_sync.bridge.protocol import (
+            BridgeMessage, BridgeOp, serialize_message, parse_message,
+        )
+        from dev_sync.bridge.server import BridgeServer
+
+        server = BridgeServer(socket_path=socket_path, bot_token="test", chat_id=123)
+        task = asyncio.create_task(server.start())
+        await asyncio.sleep(0.1)
+        server._telegram.ask = AsyncMock(return_value=42)  # type: ignore[attr-defined]
+
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        writer.write(serialize_message(BridgeMessage(
+            op=BridgeOp.ASK, request_id="r-dead", question="?",
+        )).encode())
+        await writer.drain()
+        await asyncio.wait_for(reader.readline(), timeout=1)  # ACK
+
+        writer.close()
+        await writer.wait_closed()
+        await asyncio.sleep(0.1)  # let server observe disconnect
+
+        # Reply arriving now must be dropped cleanly (no exception raised,
+        # no stale question left behind).
+        await server._on_telegram_reply("hello", reply_to_message_id=None)
+        assert server._pending_questions == {}
+
+        await server.stop()
+        task.cancel()

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -536,6 +536,216 @@ class TestRunDevIssueVerification:
         assert "conflict" in fix_call["prompt"].lower()
 
     @pytest.mark.asyncio
+    async def test_run_dev_issue_blocked_asks_transport_and_resumes(
+        self, tmp_path: Path
+    ) -> None:
+        """If Claude signals BLOCKED with a question, run_dev_issue must post
+        the question via the transport, wait for the reply, and resume the
+        session with the answer. Loop until DONE."""
+        from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus
+        from dev_sync.core.dispatcher import SessionResult
+        from dev_sync.core.pr_verifier import VerificationResult
+        from dev_sync.core.state import StateDB
+        from dev_sync.pipelines.dev import run_dev_issue
+
+        # 1st spawn = BLOCKED with a question. 2nd spawn (resume) = DONE.
+        blocked = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.BLOCKED_NEEDS_INPUT,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                question="pin or bump?",
+            ),
+        )
+        done = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:01:00Z",
+                summary="PR opened",
+                outputs={
+                    "pr_url": "https://github.com/o/r/pull/42",
+                    "pr_number": 42,
+                },
+            ),
+        )
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.side_effect = [blocked, done]
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 13,
+            "title": "x",
+            "body": "y",
+            "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        mock_transport = AsyncMock()
+        mock_transport.ask.return_value = "pin to 2.4.1"
+        mock_pr_verifier = AsyncMock()
+        mock_pr_verifier.verify.return_value = VerificationResult(ready=True)
+
+        result = await run_dev_issue(
+            repo="owner/repo",
+            issue_number=13,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=mock_transport,
+            contexts_dir=tmp_path / "contexts",
+            pr_verifier=mock_pr_verifier,
+        )
+
+        # Transport was asked the exact BLOCKED question.
+        mock_transport.ask.assert_awaited_once()
+        asked_q = mock_transport.ask.await_args.args[0]
+        assert "pin or bump?" in asked_q
+
+        # Dispatcher was called twice: initial run + resume-with-answer.
+        assert mock_dispatcher.spawn_session.call_count == 2
+        resume_kwargs = mock_dispatcher.spawn_session.await_args_list[1].kwargs
+        assert resume_kwargs["resume_session_id"] == resume_kwargs["session_id"]
+        assert "pin to 2.4.1" in resume_kwargs["prompt"]
+
+        # Final result is the DONE state.
+        assert result.success
+        assert result.outputs["pr_number"] == 42
+
+    @pytest.mark.asyncio
+    async def test_run_dev_issue_blocked_no_transport_returns_blocked(
+        self, tmp_path: Path
+    ) -> None:
+        """Without a transport there's no way to consume the answer, so we
+        must return the BLOCKED result rather than spinning."""
+        from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus
+        from dev_sync.core.dispatcher import SessionResult
+        from dev_sync.core.state import StateDB
+        from dev_sync.pipelines.dev import run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.BLOCKED_NEEDS_INPUT,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                question="?",
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 13, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        result = await run_dev_issue(
+            repo="owner/repo",
+            issue_number=13,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert result.blocked
+        # dispatcher called exactly once — no resume without a transport.
+        assert mock_dispatcher.spawn_session.call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_run_dev_issue_blocked_transport_failure_fails_clean(
+        self, tmp_path: Path
+    ) -> None:
+        """If the transport raises (bridge down, timeout), the session must
+        end cleanly as FAILED rather than leaving the caller with a blocked
+        result we can't recover from."""
+        from dev_sync.core.checkpoint import CheckpointState, CheckpointStatus
+        from dev_sync.core.dispatcher import SessionResult
+        from dev_sync.core.state import StateDB
+        from dev_sync.pipelines.dev import run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.BLOCKED_NEEDS_INPUT,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                question="?",
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 13, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        mock_transport = AsyncMock()
+        mock_transport.ask.side_effect = RuntimeError("bridge down")
+
+        result = await run_dev_issue(
+            repo="owner/repo",
+            issue_number=13,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=mock_transport,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert not result.blocked
+        assert not result.success
+        assert "bridge down" in (result.error or "")
+
+    @pytest.mark.asyncio
     async def test_run_dev_issue_does_not_retry_on_ci_timeout(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
Closes the core operational gap exposed during the #34 post-mortem: when Claude signals BLOCKED_NEEDS_INPUT, the orchestrator now actually consumes the operator's answer and resumes the session. Previously the question was printed, the session stranded as \`blocked\` in state.db, the worktree persisted indefinitely, and issues could only be rescued by manual cleanup.

## Missing layers, now wired

**1. Telegram inbound** (\`src/dev_sync/bridge/telegram_handler.py\`)
- New \`start_polling(handler)\` / \`stop_polling()\` built on \`Bot.get_updates\` with persistent offset tracking and a 5s backoff on transient errors.
- Filters on \`chat_id\` so cross-chat noise is ignored.
- Extracts \`reply_to_message.message_id\` when the operator uses Telegram's "reply" feature — enables message-specific matching instead of pure FIFO.

**2. Bridge delivery** (\`src/dev_sync/bridge/server.py\`)
- \`_pending_questions\` is now \`{request_id: _PendingQuestion(telegram_msg_id, writer)}\` under a lock, populated on ASK.
- Startup launches \`start_polling()\` with \`_on_telegram_reply\` as the handler. Match priority: \`reply_to_message_id\` → FIFO. Delivers an \`ANSWER\` frame over the same writer that issued the ASK.
- Client-disconnect path drops that client's pending questions so a later answer never writes to a dead socket.
- Structured \`INFO\` logs on SEND/ASK/ANSWER paths (covers bridge-layer asks in #35).

**3. Pipeline loop** (\`src/dev_sync/pipelines/dev.py\`)
- \`run_dev_issue\` now loops: on BLOCKED → \`transport.ask(question)\` → \`pipeline.resume(ctx, answer)\`. Bounded by \`max_blocked_rounds=5\` so a pathological "always BLOCKED" session can't spin forever.
- Transport failures (bridge down, timeout) collapse to FAILED with \`error=str(e)\` instead of staying blocked.
- No transport configured → loop is skipped, BLOCKED returned unchanged.

## Test plan
- [x] \`pytest\` — 195 passed, 13 new:
  - bridge: ASK → simulated Telegram reply → ANSWER arrives on same socket
  - bridge: reply_to_message_id wins over FIFO when set
  - bridge: client disconnect drops its pending questions
  - pipeline: BLOCKED + transport → asks, resumes, loops to DONE
  - pipeline: BLOCKED without transport → returns blocked unchanged
  - pipeline: transport raising → session FAILED with the cause
- [ ] After merge + poller restart: reproduce #34-style flow (issue assigned → BLOCKED question via Telegram → reply → session resumes). End-to-end smoke test.

## Not addressed (intentional scope)
Follow-ups already surfaced by the #24 codex audit:
- Prompt de-duplication (Claude's own verify loop vs PRVerifier)
- Lock queueing (locked issues are currently dropped, not retried)
- \`PRWatcher\` post-merge wiring
- File-mock transport wiring at runtime