### PR TITLE
docs: remove broken docs link from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,6 @@ across your GitHub repos. Watches for assigned issues, runs the dev pipeline
 in an isolated git worktree, opens a PR, and asks you on Telegram when it
 gets stuck.
 
-📖 **Docs:** <https://ainvirion.github.io/ctrlrelay/>
-
 ## Install
 
 Requires Python 3.12+, the `claude` CLI, the `gh` CLI, and `git` 2.20+.


### PR DESCRIPTION
## Summary
- Removes the `📖 **Docs:** <https://ainvirion.github.io/ctrlrelay/>` line from the top of the README as requested in #43.

Closes #43.

## Test plan
- [x] Verify diff only removes the single link + surrounding blank line
- [x] README still renders correctly