### PR TITLE
fix(bridge): swallow ConnectionResetError when client disconnects mid-response

### DIFF
--- a/src/ctrlrelay/bridge/server.py
+++ b/src/ctrlrelay/bridge/server.py
@@ -115,12 +115,30 @@ class BridgeServer:
 
                 try:
                     msg = parse_message(line.decode())
-                    response = await self._handle_message(msg, writer)
-                    if response:
-                        writer.write(serialize_message(response).encode())
-                        await writer.drain()
                 except ProtocolError:
-                    pass
+                    continue
+
+                response = await self._handle_message(msg, writer)
+                if response is None:
+                    continue
+
+                # Response write races client disconnect: the transport
+                # (SocketTransport) finishes a send/ask round-trip and closes
+                # the socket while we're still flushing the ACK. Swallow the
+                # expected disconnect errors instead of propagating a
+                # traceback into bridge.error.log.
+                if writer.is_closing():
+                    break
+                try:
+                    writer.write(serialize_message(response).encode())
+                    await writer.drain()
+                except (ConnectionResetError, BrokenPipeError, OSError) as e:
+                    _log.debug(
+                        "bridge: client disconnected mid-response "
+                        "(op=%s request_id=%s err=%s)",
+                        msg.op, msg.request_id, e,
+                    )
+                    break
         finally:
             # Client disconnected — drop any outstanding questions tied to
             # this writer so we don't try to answer a dead socket later.

--- a/tests/test_bridge_server.py
+++ b/tests/test_bridge_server.py
@@ -225,3 +225,59 @@ class TestBridgeServer:
 
         await server.stop()
         task.cancel()
+
+    @pytest.mark.asyncio
+    async def test_client_disconnect_during_response_write_is_silent(
+        self, socket_path, caplog,
+    ) -> None:
+        """Race: the client closes the socket right after sending a request
+        but before the bridge finishes flushing the ACK. The bridge used to
+        propagate ConnectionResetError from writer.drain() as an unhandled
+        exception into bridge.error.log. After the fix it must be swallowed
+        quietly (DEBUG-level at most)."""
+        import logging
+        from unittest.mock import AsyncMock
+
+        from ctrlrelay.bridge.protocol import (
+            BridgeMessage, BridgeOp, serialize_message,
+        )
+        from ctrlrelay.bridge.server import BridgeServer
+
+        server = BridgeServer(socket_path=socket_path, bot_token="test", chat_id=123)
+        task = asyncio.create_task(server.start())
+        await asyncio.sleep(0.1)
+
+        # Make the telegram call slow enough that we can close the client
+        # before the bridge finishes the response write.
+        async def slow_ask(*args, **kwargs):
+            await asyncio.sleep(0.1)
+            return 42
+        server._telegram.ask = AsyncMock(side_effect=slow_ask)  # type: ignore[attr-defined]
+
+        reader, writer = await asyncio.open_unix_connection(str(socket_path))
+        writer.write(serialize_message(BridgeMessage(
+            op=BridgeOp.ASK, request_id="r-race", question="?",
+        )).encode())
+        await writer.drain()
+
+        # Close immediately — race the bridge's write-back path.
+        writer.close()
+        try:
+            await writer.wait_closed()
+        except Exception:
+            pass
+
+        # Give the server a moment to try to flush the response and observe
+        # the disconnect, THEN shutdown.
+        with caplog.at_level(logging.ERROR, logger="asyncio"), \
+             caplog.at_level(logging.ERROR, logger="ctrlrelay.bridge.server"):
+            await asyncio.sleep(0.3)
+            await server.stop()
+            task.cancel()
+
+        # Must not have logged an unhandled ERROR-level traceback.
+        errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+        assert not errors, (
+            f"bridge logged ERROR records during client-disconnect race: "
+            f"{[r.getMessage() for r in errors]}"
+        )


### PR DESCRIPTION
## Summary
The bridge server used to propagate a \`ConnectionResetError\` traceback into \`bridge.error.log\` on a common race: the client (\`SocketTransport\`) completes a \`SEND\`/\`ASK\` round-trip and closes the socket while the bridge is still flushing the ACK frame. \`writer.drain()\` then raises \"Connection lost\" and surfaces as an unhandled exception in \`client_connected_cb\`.

Observed on ctrlrelay main after the rebrand + bidirectional bridge landed — every successful dev run was emitting a noisy traceback even though the message had already been delivered and the run otherwise completed cleanly (e.g. #43 → #44).

## Fix
In \`_handle_client\` (src/ctrlrelay/bridge/server.py):
- Restructure the response-write path so protocol-parse failures, missing responses, and write races are all handled as flow control, not except-wrapped side effects.
- Check \`writer.is_closing()\` before attempting to write the response.
- Wrap \`writer.write + drain\` in try/except for \`ConnectionResetError\`/\`BrokenPipeError\`/\`OSError\` and exit the per-client loop cleanly on disconnect. Log at DEBUG with op + request_id so the event is traceable but doesn't pollute the error log.

## Test
- \`test_client_disconnect_during_response_write_is_silent\`: injects a slow \`ASK\` response so the client closes the socket while the bridge is still flushing the ACK, then asserts no \`ERROR\`-level records were logged during the race.
- Full suite: 213 passed (1 pre-existing unrelated test deselected — unchanged from prior commits).

## Blast radius
Behavior preserved for happy paths (response delivered, reader/writer closed normally). Only the error-logging behavior changes for the specific disconnect-during-write race.