### PR TITLE
fix(poller): skip transient per-repo failures, survive iteration errors (#46)

### DIFF
--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -153,20 +153,51 @@ class IssuePoller:
                 )
             except asyncio.CancelledError:
                 raise
-            except _TRANSIENT_POLL_ERRORS as e:
-                self._record_repo_failure(repo, e, phase="poll")
+            except Exception as e:
+                # Transient-ish (TimeoutError/GitHubError/OSError) goes through
+                # the failure counter so persistent misconfig escalates; any
+                # other unexpected exception is logged as a skip too so the
+                # surrounding repos still get processed AND new_issues from
+                # prior repos reaches the caller. Without this catch, a later
+                # repo exploding would leave earlier repos' seen_issues
+                # mutated but their new_issues list unreturned.
+                if isinstance(e, _TRANSIENT_POLL_ERRORS):
+                    self._record_repo_failure(repo, e, phase="poll")
+                else:
+                    log_event(
+                        _logger,
+                        "poll.repo.unexpected_error",
+                        repo=repo,
+                        reason=type(e).__name__,
+                        error=str(e)[:200],
+                        phase="poll",
+                    )
                 continue
 
             # Successful lookup — clear any accumulated failure count.
             self._clear_repo_failure(repo)
 
-            seen_for_repo = self.seen_issues.setdefault(repo, set())
-
-            for issue in issues:
-                number: int = issue["number"]
-                if number not in seen_for_repo:
-                    new_issues.append({"repo": repo, "issue": issue})
-                    seen_for_repo.add(number)
+            try:
+                seen_for_repo = self.seen_issues.setdefault(repo, set())
+                for issue in issues:
+                    number: int = issue["number"]
+                    if number not in seen_for_repo:
+                        new_issues.append({"repo": repo, "issue": issue})
+                        seen_for_repo.add(number)
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Malformed issue payload (missing 'number', wrong type) etc.
+                # Contain the damage to this repo so other repos' results and
+                # any already-accumulated new_issues still reach the caller.
+                log_event(
+                    _logger,
+                    "poll.repo.processing_failed",
+                    repo=repo,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
+                continue
 
         # Never propagate a save_state disk failure out of poll() — the
         # caller has work to do with new_issues. Log and move on.

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -9,7 +9,15 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
-from ctrlrelay.core.github import GitHubCLI
+from ctrlrelay.core.github import GitHubCLI, GitHubError
+from ctrlrelay.core.obs import get_logger, log_event
+
+_logger = get_logger("core.poller")
+
+# Exceptions that are transient and should skip the current repo/iteration
+# rather than tear the whole poll loop down. asyncio.CancelledError is
+# deliberately excluded so a shutdown signal still propagates.
+_TRANSIENT_POLL_ERRORS = (TimeoutError, GitHubError, OSError)
 
 
 @dataclass
@@ -65,15 +73,33 @@ class IssuePoller:
 
         Returns:
             A list of ``{"repo": str, "issue": dict}`` entries for issues that
-            have not been seen before.  Updates ``seen_issues`` and persists
+            have not been seen before. Updates ``seen_issues`` and persists
             state to disk.
+
+        Per-repo resilience: a transient failure on one repo (network timeout,
+        ``gh`` exit, OS error) is logged and skipped so the other repos still
+        get polled. Only ``asyncio.CancelledError`` escapes, which allows a
+        clean shutdown signal to propagate.
         """
         new_issues: list[dict[str, Any]] = []
 
         for repo in self.repos:
-            issues = await self.github.list_assigned_issues(
-                repo, assignee=self.username
-            )
+            try:
+                issues = await self.github.list_assigned_issues(
+                    repo, assignee=self.username
+                )
+            except asyncio.CancelledError:
+                raise
+            except _TRANSIENT_POLL_ERRORS as e:
+                log_event(
+                    _logger,
+                    "poll.repo.skipped",
+                    repo=repo,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
+                continue
+
             seen_for_repo = self.seen_issues.setdefault(repo, set())
 
             for issue in issues:
@@ -99,11 +125,29 @@ class IssuePoller:
 
         Call this on first startup to avoid treating existing assignments
         as new. Only issues assigned AFTER this seed will trigger handlers.
+
+        Failure mode: if a per-repo lookup fails transiently, the seed skips
+        that repo and logs ``poll.repo.skipped``. The consequence is that on
+        next poll, any currently-assigned issues on the skipped repo will be
+        treated as new and picked up — that's safer than crashing first-run.
         """
         for repo in self.repos:
-            issues = await self.github.list_assigned_issues(
-                repo, assignee=self.username
-            )
+            try:
+                issues = await self.github.list_assigned_issues(
+                    repo, assignee=self.username
+                )
+            except asyncio.CancelledError:
+                raise
+            except _TRANSIENT_POLL_ERRORS as e:
+                log_event(
+                    _logger,
+                    "poll.repo.skipped",
+                    repo=repo,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                    phase="seed",
+                )
+                continue
             seen_for_repo = self.seen_issues.setdefault(repo, set())
             for issue in issues:
                 seen_for_repo.add(issue["number"])
@@ -123,13 +167,28 @@ async def run_poll_loop(
         handler: Async function to call for each new issue (repo, issue)
         interval: Seconds between polls
         max_iterations: Max iterations (None = infinite)
+
+    Iteration resilience: any non-cancellation exception from the poll or a
+    handler call is logged as ``poll.iteration.failed`` and the loop sleeps
+    and continues. This keeps a single bad cycle (slow network, one flaky
+    handler) from crashing the daemon and forcing a launchd restart.
     """
     iterations = 0
     while max_iterations is None or iterations < max_iterations:
-        new_issues = await poller.poll()
-
-        for item in new_issues:
-            await handler(item["repo"], item["issue"])
+        try:
+            new_issues = await poller.poll()
+            for item in new_issues:
+                await handler(item["repo"], item["issue"])
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            log_event(
+                _logger,
+                "poll.iteration.failed",
+                iteration=iterations,
+                reason=type(e).__name__,
+                error=str(e)[:200],
+            )
 
         iterations += 1
         if max_iterations is None or iterations < max_iterations:

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -17,7 +17,18 @@ _logger = get_logger("core.poller")
 # Exceptions that are transient and should skip the current repo/iteration
 # rather than tear the whole poll loop down. asyncio.CancelledError is
 # deliberately excluded so a shutdown signal still propagates.
+#
+# GitHubError is included because we can't distinguish transient (rate
+# limit, 5xx, network) from permanent (bad repo name, expired auth, 404)
+# without fragile error-message parsing — classifying both as skip avoids
+# crashes. A persistent-failure counter (see below) makes permanent
+# misconfiguration visible even though it's technically skipped here.
 _TRANSIENT_POLL_ERRORS = (TimeoutError, GitHubError, OSError)
+
+# After this many consecutive per-repo failures, escalate log level to
+# WARNING so a persistent misconfiguration (expired auth, renamed repo,
+# revoked access) stops hiding behind routine "transient" skip logs.
+_REPO_FAILURE_WARN_THRESHOLD = 3
 
 
 @dataclass
@@ -33,6 +44,10 @@ class IssuePoller:
     repos: list[str]
     state_file: Path
     seen_issues: dict[str, set[int]] = field(default_factory=dict)
+    # Per-repo consecutive-skip counter; populated at runtime by poll() /
+    # seed_current(). Not persisted — intentionally resets on daemon
+    # restart so an operator fix is exercised before we re-escalate.
+    _repo_failure_counts: dict[str, int] = field(default_factory=dict, repr=False)
 
     def __post_init__(self) -> None:
         self._load_state()
@@ -64,6 +79,54 @@ class IssuePoller:
         self.state_file.parent.mkdir(parents=True, exist_ok=True)
         self.state_file.write_text(json.dumps(data, indent=2))
 
+    def _save_state_best_effort(self) -> None:
+        """Try to persist state; log and continue on disk errors.
+
+        Callers MUST NOT let a _save_state failure propagate out of poll() —
+        doing so would drop the new-issues list on the floor while the
+        in-memory seen_issues set has already been mutated, silently
+        abandoning the work until the daemon restarts.
+        """
+        try:
+            self._save_state()
+        except OSError as e:
+            log_event(
+                _logger,
+                "poll.save_state.failed",
+                reason=type(e).__name__,
+                error=str(e)[:200],
+                state_file=str(self.state_file),
+            )
+
+    def _record_repo_failure(
+        self,
+        repo: str,
+        exc: Exception,
+        *,
+        phase: str = "poll",
+    ) -> None:
+        """Bump the consecutive-failure counter and log with an escalated
+        level once the threshold is reached. ``phase`` distinguishes
+        poll-time vs seed-time skips in the event payload."""
+        count = self._repo_failure_counts.get(repo, 0) + 1
+        self._repo_failure_counts[repo] = count
+        fields = {
+            "repo": repo,
+            "reason": type(exc).__name__,
+            "error": str(exc)[:200],
+            "consecutive_failures": count,
+            "phase": phase,
+        }
+        if count >= _REPO_FAILURE_WARN_THRESHOLD:
+            fields["persistent"] = True
+            _logger.warning("poll.repo.skipped", extra=fields)
+        else:
+            log_event(_logger, "poll.repo.skipped", **fields)
+
+    def _clear_repo_failure(self, repo: str) -> None:
+        """Reset the failure counter after a successful repo lookup."""
+        self._repo_failure_counts.pop(repo, None)
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -91,14 +154,11 @@ class IssuePoller:
             except asyncio.CancelledError:
                 raise
             except _TRANSIENT_POLL_ERRORS as e:
-                log_event(
-                    _logger,
-                    "poll.repo.skipped",
-                    repo=repo,
-                    reason=type(e).__name__,
-                    error=str(e)[:200],
-                )
+                self._record_repo_failure(repo, e, phase="poll")
                 continue
+
+            # Successful lookup — clear any accumulated failure count.
+            self._clear_repo_failure(repo)
 
             seen_for_repo = self.seen_issues.setdefault(repo, set())
 
@@ -108,7 +168,9 @@ class IssuePoller:
                     new_issues.append({"repo": repo, "issue": issue})
                     seen_for_repo.add(number)
 
-        self._save_state()
+        # Never propagate a save_state disk failure out of poll() — the
+        # caller has work to do with new_issues. Log and move on.
+        self._save_state_best_effort()
         return new_issues
 
     def mark_seen(self, repo: str, issue_number: int) -> None:
@@ -139,19 +201,13 @@ class IssuePoller:
             except asyncio.CancelledError:
                 raise
             except _TRANSIENT_POLL_ERRORS as e:
-                log_event(
-                    _logger,
-                    "poll.repo.skipped",
-                    repo=repo,
-                    reason=type(e).__name__,
-                    error=str(e)[:200],
-                    phase="seed",
-                )
+                self._record_repo_failure(repo, e, phase="seed")
                 continue
+            self._clear_repo_failure(repo)
             seen_for_repo = self.seen_issues.setdefault(repo, set())
             for issue in issues:
                 seen_for_repo.add(issue["number"])
-        self._save_state()
+        self._save_state_best_effort()
 
 
 async def run_poll_loop(

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -177,27 +177,27 @@ class IssuePoller:
             # Successful lookup — clear any accumulated failure count.
             self._clear_repo_failure(repo)
 
-            try:
-                seen_for_repo = self.seen_issues.setdefault(repo, set())
-                for issue in issues:
-                    number: int = issue["number"]
-                    if number not in seen_for_repo:
-                        new_issues.append({"repo": repo, "issue": issue})
-                        seen_for_repo.add(number)
-            except asyncio.CancelledError:
-                raise
-            except Exception as e:
-                # Malformed issue payload (missing 'number', wrong type) etc.
-                # Contain the damage to this repo so other repos' results and
-                # any already-accumulated new_issues still reach the caller.
-                log_event(
-                    _logger,
-                    "poll.repo.processing_failed",
-                    repo=repo,
-                    reason=type(e).__name__,
-                    error=str(e)[:200],
-                )
-                continue
+            seen_for_repo = self.seen_issues.setdefault(repo, set())
+            for issue in issues:
+                # Per-issue guard so ONE malformed payload (missing 'number',
+                # wrong type, non-dict entry) doesn't poison the remaining
+                # good issues in the same repo's batch.
+                try:
+                    number = int(issue["number"])
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    log_event(
+                        _logger,
+                        "poll.issue.malformed",
+                        repo=repo,
+                        reason=type(e).__name__,
+                        error=str(e)[:200],
+                    )
+                    continue
+                if number not in seen_for_repo:
+                    new_issues.append({"repo": repo, "issue": issue})
+                    seen_for_repo.add(number)
 
         # Never propagate a save_state disk failure out of poll() — the
         # caller has work to do with new_issues. Log and move on.
@@ -262,10 +262,11 @@ async def run_poll_loop(
     """
     iterations = 0
     while max_iterations is None or iterations < max_iterations:
+        # Guard poll() separately from the handler dispatch: a malformed
+        # poll result shouldn't lose queued work, and a handler failure
+        # shouldn't skip the rest of the batch.
         try:
             new_issues = await poller.poll()
-            for item in new_issues:
-                await handler(item["repo"], item["issue"])
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -273,9 +274,30 @@ async def run_poll_loop(
                 _logger,
                 "poll.iteration.failed",
                 iteration=iterations,
+                phase="poll",
                 reason=type(e).__name__,
                 error=str(e)[:200],
             )
+            new_issues = []
+
+        # Each handler invocation is isolated. A failure on one issue must
+        # not cancel the remaining already-seen-and-persisted issues — those
+        # would otherwise be silently dropped until daemon restart.
+        for item in new_issues:
+            try:
+                await handler(item["repo"], item["issue"])
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                issue = item.get("issue") or {}
+                log_event(
+                    _logger,
+                    "poll.handler.failed",
+                    repo=item.get("repo"),
+                    issue_number=issue.get("number"),
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
 
         iterations += 1
         if max_iterations is None or iterations < max_iterations:

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -314,6 +314,134 @@ class TestIssuePoller:
         assert any("poll.repo.skipped" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
+    async def test_poll_returns_new_issues_even_if_save_state_fails(
+        self, tmp_path: Path, monkeypatch, caplog
+    ) -> None:
+        """Codex P2: if _save_state raises (disk full, permissions), poll()
+        must still return the new-issues list so the handler runs — otherwise
+        seen_issues was mutated in-memory and the work is silently lost until
+        the daemon restarts."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[{"number": 42, "title": "work to do"}]
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        def boom(*a, **kw):
+            raise OSError("disk full")
+        monkeypatch.setattr(poller, "_save_state", boom)
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            new = await poller.poll()
+
+        # New issue MUST flow to the caller even though save_state failed.
+        assert [(x["repo"], x["issue"]["number"]) for x in new] == [
+            ("owner/repo", 42)
+        ]
+        # And the failure is recorded for operator visibility.
+        assert any(
+            "poll.save_state.failed" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_persistent_repo_failure_escalates_to_warning(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Codex P2: after _REPO_FAILURE_WARN_THRESHOLD consecutive failures
+        on the same repo, the log level escalates to WARNING so a permanent
+        misconfig (expired auth, renamed repo) stops hiding as routine
+        transient skips."""
+        import logging
+
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            side_effect=GitHubError("gh failed: HTTP 401 Bad credentials")
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/expired-auth"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        # 1st and 2nd cycles: INFO-level skip.
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            await poller.poll()
+            await poller.poll()
+
+        info_skips = [
+            r for r in caplog.records
+            if r.levelno == logging.INFO and "poll.repo.skipped" in r.getMessage()
+        ]
+        assert len(info_skips) == 2
+
+        # 3rd cycle: hits threshold, escalates to WARNING.
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            await poller.poll()
+
+        warn_skips = [
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "poll.repo.skipped" in r.getMessage()
+        ]
+        assert warn_skips, "expected a WARNING-level skip at the threshold"
+        # 4th cycle: still WARNING (persistent).
+        await poller.poll()
+        assert len([
+            r for r in caplog.records
+            if r.levelno == logging.WARNING and "poll.repo.skipped" in r.getMessage()
+        ]) >= 2
+
+    @pytest.mark.asyncio
+    async def test_repo_failure_counter_resets_on_success(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """A successful lookup must reset the per-repo failure counter so a
+        previously flaky repo doesn't stay escalated forever after it recovers."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        calls = 0
+
+        async def flaky_then_fine(repo: str, *, assignee: str):  # noqa: ARG001
+            nonlocal calls
+            calls += 1
+            if calls <= 2:
+                raise TimeoutError("first two fail")
+            return [{"number": 5, "title": "ok"}]
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=flaky_then_fine)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+        # Two failures accumulate, then success — counter should reset.
+        await poller.poll()
+        await poller.poll()
+        assert poller._repo_failure_counts.get("owner/repo") == 2
+
+        await poller.poll()
+        assert "owner/repo" not in poller._repo_failure_counts
+
+    @pytest.mark.asyncio
     async def test_run_poll_loop_survives_handler_exception(
         self, tmp_path: Path, caplog
     ) -> None:

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -385,10 +385,46 @@ class TestIssuePoller:
         assert [(x["repo"], x["issue"]["number"]) for x in new] == [
             ("owner/ok", 10)
         ]
-        # Bad repo's processing failure is logged.
+        # The malformed item is logged.
         assert any(
-            "poll.repo.processing_failed" in r.getMessage()
-            for r in caplog.records
+            "poll.issue.malformed" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_poll_malformed_issue_does_not_block_later_issues_in_same_repo(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Codex P2: a malformed issue MUST NOT prevent later good issues in
+        the same repo's batch from being discovered. Otherwise the valid
+        issues after the bad one are never processed until someone fixes the
+        data upstream."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[
+                {"number": 1, "title": "first good"},
+                {"title": "no number — malformed"},
+                {"number": 2, "title": "second good AFTER the bad one"},
+            ]
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            new = await poller.poll()
+
+        numbers = sorted(x["issue"]["number"] for x in new)
+        assert numbers == [1, 2], (
+            "expected both good issues to be discovered even though there "
+            f"was a malformed item between them, got {numbers}"
         )
 
     @pytest.mark.asyncio
@@ -524,7 +560,7 @@ class TestIssuePoller:
         self, tmp_path: Path, caplog
     ) -> None:
         """An exception from the handler (e.g. run_dev_issue crash) must be
-        caught by the outer safety net so the next poll cycle still runs."""
+        logged and the loop must continue to the next iteration."""
         import logging
 
         from ctrlrelay.core.poller import IssuePoller, run_poll_loop
@@ -552,7 +588,57 @@ class TestIssuePoller:
                 max_iterations=1,
             )
 
-        # The handler failure should have been logged as iteration.failed,
-        # not propagated up as an unhandled exception.
         msgs = [r.getMessage() for r in caplog.records]
-        assert any("poll.iteration.failed" in m for m in msgs), msgs
+        # The per-handler guard emits poll.handler.failed with the offending
+        # repo+issue — distinct from the outer poll.iteration.failed which
+        # is only for poll() itself crashing.
+        assert any("poll.handler.failed" in m for m in msgs), msgs
+
+    @pytest.mark.asyncio
+    async def test_run_poll_loop_handler_failure_does_not_skip_rest_of_batch(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Codex P1: if handler fails on the first issue, the rest of the
+        batch from the same poll cycle MUST still run. Otherwise those
+        issues are marked seen (by poll()) but never handled — silently
+        dropped until daemon restart."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller, run_poll_loop
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[
+                {"number": 1, "title": "will blow up handler"},
+                {"number": 2, "title": "second"},
+                {"number": 3, "title": "third"},
+            ]
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        processed: list[int] = []
+
+        async def handler(repo: str, issue: dict) -> None:
+            if issue["number"] == 1:
+                raise RuntimeError("handler blew up on first")
+            processed.append(issue["number"])
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            await run_poll_loop(
+                poller=poller,
+                handler=handler,
+                interval=0,
+                max_iterations=1,
+            )
+
+        # Issues 2 and 3 MUST still have run — per-handler isolation.
+        assert processed == [2, 3], processed
+        assert any(
+            "poll.handler.failed" in r.getMessage() for r in caplog.records
+        )

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -314,6 +314,84 @@ class TestIssuePoller:
         assert any("poll.repo.skipped" in r.getMessage() for r in caplog.records)
 
     @pytest.mark.asyncio
+    async def test_poll_unexpected_exception_on_one_repo_does_not_lose_prior_repos(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Codex P2: if an unexpected (non-transient) exception escapes the
+        lookup for a later repo, poll() must still return the issues it
+        already collected from earlier repos. Otherwise earlier repos'
+        seen_issues is mutated in-memory and the handler never runs — silent
+        drop until daemon restart."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        async def per_repo(repo: str, *, assignee: str):  # noqa: ARG001
+            if repo == "owner/first":
+                return [{"number": 1, "title": "fine"}]
+            # RuntimeError is NOT in _TRANSIENT_POLL_ERRORS.
+            raise RuntimeError("unexpected upstream glitch")
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/first", "owner/second"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            new = await poller.poll()
+
+        assert [(x["repo"], x["issue"]["number"]) for x in new] == [
+            ("owner/first", 1)
+        ]
+        # The unexpected error is logged distinctly so operators can spot it.
+        assert any(
+            "poll.repo.unexpected_error" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_poll_malformed_issue_payload_contained_to_that_repo(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Malformed issue data from one repo (missing 'number') must not
+        poison other repos' results."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        async def per_repo(repo: str, *, assignee: str):  # noqa: ARG001
+            if repo == "owner/bad":
+                return [{"title": "no number field!"}]  # missing 'number'
+            return [{"number": 10, "title": "fine"}]
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/bad", "owner/ok"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            new = await poller.poll()
+
+        # Healthy repo still produces its issue.
+        assert [(x["repo"], x["issue"]["number"]) for x in new] == [
+            ("owner/ok", 10)
+        ]
+        # Bad repo's processing failure is logged.
+        assert any(
+            "poll.repo.processing_failed" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
     async def test_poll_returns_new_issues_even_if_save_state_fails(
         self, tmp_path: Path, monkeypatch, caplog
     ) -> None:

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -180,3 +180,173 @@ class TestIssuePoller:
 
         assert len(handled_issues) == 1
         assert handled_issues[0] == ("owner/repo", 123)
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_repo_on_timeout_and_continues(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """A transient TimeoutError on one repo must skip that repo for the
+        round and return issues from the other repos — not crash the loop."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        async def per_repo(repo: str, *, assignee: str):  # noqa: ARG001
+            if repo == "owner/flaky":
+                raise TimeoutError("gh took too long")
+            return [{"number": 42, "title": "fine"}]
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/flaky", "owner/ok"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            new = await poller.poll()
+
+        # Healthy repo still produced its issue.
+        assert [(x["repo"], x["issue"]["number"]) for x in new] == [
+            ("owner/ok", 42)
+        ]
+        # Flaky repo logged a skip event with the transient reason.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("poll.repo.skipped" in m for m in msgs), msgs
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_repo_on_gh_error(self, tmp_path: Path) -> None:
+        """GitHubError on one repo (non-zero gh exit) is also skipped."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.poller import IssuePoller
+
+        async def per_repo(repo: str, *, assignee: str):  # noqa: ARG001
+            if repo == "owner/broken":
+                raise GitHubError("gh failed: HTTP 503")
+            return [{"number": 1, "title": "ok"}]
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/broken", "owner/ok"],
+            state_file=tmp_path / "poller_state.json",
+        )
+        new = await poller.poll()
+        assert [(x["repo"], x["issue"]["number"]) for x in new] == [
+            ("owner/ok", 1)
+        ]
+
+    @pytest.mark.asyncio
+    async def test_poll_propagates_cancellation(self, tmp_path: Path) -> None:
+        """CancelledError MUST propagate so shutdown signals aren't swallowed."""
+        import asyncio as _asyncio
+
+        from ctrlrelay.core.poller import IssuePoller
+
+        async def always_cancel(repo: str, *, assignee: str):  # noqa: ARG001
+            raise _asyncio.CancelledError()
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=always_cancel)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+        with pytest.raises(_asyncio.CancelledError):
+            await poller.poll()
+
+    @pytest.mark.asyncio
+    async def test_run_poll_loop_survives_iteration_failure(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """A failing iteration must be logged + retried next cycle rather
+        than crashing the whole daemon."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller, run_poll_loop
+
+        call_count = 0
+
+        async def flaky_then_fine(repo: str, *, assignee: str):  # noqa: ARG001
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                raise TimeoutError("first call times out")
+            return [{"number": 77, "title": "second cycle"}]
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(side_effect=flaky_then_fine)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        handled: list[int] = []
+
+        async def handler(repo: str, issue: dict) -> None:
+            handled.append(issue["number"])
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            # 2 iterations: cycle 1 is caught by the per-repo skip handler
+            # (not the outer safety net), cycle 2 succeeds.
+            await run_poll_loop(
+                poller=poller,
+                handler=handler,
+                interval=0,
+                max_iterations=2,
+            )
+
+        # Cycle 2 delivered issue 77.
+        assert handled == [77]
+        # poll.repo.skipped fired on cycle 1.
+        assert any("poll.repo.skipped" in r.getMessage() for r in caplog.records)
+
+    @pytest.mark.asyncio
+    async def test_run_poll_loop_survives_handler_exception(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """An exception from the handler (e.g. run_dev_issue crash) must be
+        caught by the outer safety net so the next poll cycle still runs."""
+        import logging
+
+        from ctrlrelay.core.poller import IssuePoller, run_poll_loop
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[{"number": 1, "title": "x"}]
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="testuser",
+            repos=["owner/repo"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        async def handler(repo: str, issue: dict) -> None:
+            raise RuntimeError("handler blew up")
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.poller"):
+            await run_poll_loop(
+                poller=poller,
+                handler=handler,
+                interval=0,
+                max_iterations=1,
+            )
+
+        # The handler failure should have been logged as iteration.failed,
+        # not propagated up as an unhandled exception.
+        msgs = [r.getMessage() for r in caplog.records]
+        assert any("poll.iteration.failed" in m for m in msgs), msgs


### PR DESCRIPTION
Closes #46.

## Problem
A single flaky \`gh\` call (timeout, non-zero exit, OS-level network error) propagated all the way out of \`run_poll_loop\` → \`asyncio.run\` and crashed the poller process. launchd auto-restart masked it, but every hiccup produced a full traceback in \`poller.error.log\` and tore down any in-flight bridge connection state. Reproduced live during this session — a \`TimeoutError\` from \`asyncio.wait_for(proc.communicate(), timeout=60)\` inside \`_run_gh\` took the whole poll loop down.

## Fix — two layers
**Per-repo skip** in \`IssuePoller.poll()\` / \`seed_current()\`:
Wrap each \`list_assigned_issues\` call in \`try/except (TimeoutError, GitHubError, OSError)\`. Log a structured \`poll.repo.skipped\` event with \`repo\`, \`reason\`, \`error\`, and continue with the next repo.

**Outer safety net** in \`run_poll_loop()\`:
Wrap the poll + handler-dispatch body in a broad \`try/except Exception\` that logs \`poll.iteration.failed\`. Catches whatever slips past the per-repo handler (including handler-side crashes like a transient exception inside \`run_dev_issue\`).

Both layers explicitly re-raise \`asyncio.CancelledError\` — shutdown signals must not be swallowed.

Uses the structured-logging helper from #40. Events are one-line JSON with \`event\`, \`repo\`, \`reason\`, \`error\` fields — same pattern as the bridge events.

## Tests
5 new, 11 total in \`test_poller.py\` (218 in the full suite, was 213):
- \`test_poll_skips_repo_on_timeout_and_continues\` — healthy repo still returns issues
- \`test_poll_skips_repo_on_gh_error\` — same for GitHubError
- \`test_poll_propagates_cancellation\` — CancelledError is NOT swallowed
- \`test_run_poll_loop_survives_iteration_failure\` — cycle 1 fails, cycle 2 delivers
- \`test_run_poll_loop_survives_handler_exception\` — handler crash is caught at the outer net

## Blast radius
Happy-path behavior unchanged. Only the failure path differs: instead of escaping as an unhandled traceback, a transient error is logged as a structured skip and the next repo/iteration proceeds.