### PR TITLE
fix(worktree): reuse existing branch on retry (#28)

### DIFF
--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -129,79 +129,46 @@ class WorktreeManager:
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
         if await self.branch_exists_locally(repo, new_branch):
-            # Sync the reused branch to the remote head BEFORE checkout so
-            # a retry after an out-of-band push (reviewer commit on the
-            # PR, another machine) starts from the fresh upstream state.
-            # Two constraints drive the shape of this:
-            #
-            #   1. ensure_bare_repo uses plain `git clone --bare`, whose
-            #      default fetch refspec is `+refs/heads/*:refs/heads/*`
-            #      — there are NO `refs/remotes/origin/*` tracking refs,
-            #      and an unscoped `git fetch origin <branch>` would
-            #      OVERWRITE refs/heads/<branch> directly, destroying any
-            #      unpushed local commits. So we fetch into a dedicated
-            #      scratch ref `refs/ctrlrelay/sync/<branch>` that never
-            #      touches the live branch.
-            #   2. If the local branch is AHEAD of origin (prior session
-            #      committed locally but died before push), only
-            #      fast-forward is safe. `merge-base --is-ancestor`
-            #      exit 0 means local is behind/equal — ok to update.
-            #      Non-zero means ahead or diverged — preserve local.
-            #
-            # Everything in this block is best-effort: if any step fails
-            # (network timeout, permissions, invalid ref) we fall back to
-            # reusing the local ref as-is rather than aborting the retry.
-            if await self.branch_exists_on_remote(repo, new_branch):
-                scratch_ref = f"refs/ctrlrelay/sync/{new_branch}"
-                fetched = False
+            on_remote = await self.branch_exists_on_remote(repo, new_branch)
+            if on_remote:
+                # Remote exists → sync local to remote head (preserving
+                # unpushed ahead-of-origin commits) and reuse.
+                await self._sync_reused_branch_to_origin(bare_path, new_branch)
+                await self._run_git(
+                    "worktree", "add",
+                    str(worktree_path),
+                    new_branch,
+                    cwd=bare_path,
+                )
+                return worktree_path
+
+            # Local-only. Distinguish between:
+            #   (a) stale-merged: the prior PR was merged (any strategy) and
+            #       the remote branch auto-deleted. The local ref's commits
+            #       are all patch-equivalent to commits in the default
+            #       branch. Reusing it would resurrect already-merged
+            #       changes into the next PR — delete + create fresh.
+            #   (b) recoverable unpushed work: the prior session made
+            #       commits locally and died before push. Local has
+            #       content not represented in the default branch — reuse
+            #       so the operator's work isn't silently dropped.
+            if await self._branch_is_fully_merged(repo, new_branch):
                 try:
                     await self._run_git(
-                        "fetch", "origin",
-                        f"+refs/heads/{new_branch}:{scratch_ref}",
-                        cwd=bare_path,
-                        timeout=30,
+                        "update-ref", "-d", f"refs/heads/{new_branch}",
+                        cwd=bare_path, timeout=10,
                     )
-                    fetched = True
                 except Exception:
                     pass
-                if fetched:
-                    try:
-                        await self._run_git(
-                            "merge-base", "--is-ancestor",
-                            new_branch, scratch_ref,
-                            cwd=bare_path,
-                            timeout=10,
-                        )
-                    except Exception:
-                        # Ahead / diverged / error — preserve local.
-                        pass
-                    else:
-                        try:
-                            await self._run_git(
-                                "update-ref", f"refs/heads/{new_branch}",
-                                scratch_ref,
-                                cwd=bare_path,
-                                timeout=10,
-                            )
-                        except Exception:
-                            pass
-                    # Clean up the scratch ref regardless of outcome.
-                    try:
-                        await self._run_git(
-                            "update-ref", "-d", scratch_ref,
-                            cwd=bare_path,
-                            timeout=10,
-                        )
-                    except Exception:
-                        pass
-            # Reuse: check out the (possibly-updated) ref into the new worktree.
-            await self._run_git(
-                "worktree", "add",
-                str(worktree_path),
-                new_branch,
-                cwd=bare_path,
-            )
-            return worktree_path
+                # Fall through to the fresh-branch creation below.
+            else:
+                await self._run_git(
+                    "worktree", "add",
+                    str(worktree_path),
+                    new_branch,
+                    cwd=bare_path,
+                )
+                return worktree_path
 
         if base_branch is None:
             base_branch = await self.get_default_branch(repo)
@@ -214,6 +181,98 @@ class WorktreeManager:
             cwd=bare_path,
         )
         return worktree_path
+
+    async def _sync_reused_branch_to_origin(
+        self, bare_path: Path, branch: str,
+    ) -> None:
+        """Fast-forward the local ``branch`` to origin's head using a
+        scratch ref so it never touches ``refs/heads/<branch>`` except
+        via a safe `update-ref` that's gated by a merge-base ancestor
+        check.
+
+        Bare clones from `git clone --bare` have fetch refspec
+        `+refs/heads/*:refs/heads/*`, so there are NO
+        `refs/remotes/origin/*` tracking refs AND an unscoped
+        `git fetch origin <branch>` would overwrite the live local ref
+        directly — destroying any unpushed local commits before we get
+        to compare. Routing through a scratch ref in
+        `refs/ctrlrelay/sync/*` avoids both problems.
+
+        Rules:
+          - If local is ancestor of the fetched remote tip → fast-forward.
+          - If local is ahead or diverged → leave local alone (ahead
+            contains unpushed work; forcing would destroy it).
+
+        All steps are best-effort: any failure (timeout, network,
+        permissions, bad ref) falls back to reusing the local ref
+        unchanged, so a flaky origin never aborts the retry.
+        """
+        scratch_ref = f"refs/ctrlrelay/sync/{branch}"
+        fetched = False
+        try:
+            await self._run_git(
+                "fetch", "origin",
+                f"+refs/heads/{branch}:{scratch_ref}",
+                cwd=bare_path, timeout=30,
+            )
+            fetched = True
+        except Exception:
+            return
+        try:
+            try:
+                await self._run_git(
+                    "merge-base", "--is-ancestor", branch, scratch_ref,
+                    cwd=bare_path, timeout=10,
+                )
+            except Exception:
+                # Local ahead / diverged / error — preserve local.
+                return
+            try:
+                await self._run_git(
+                    "update-ref", f"refs/heads/{branch}", scratch_ref,
+                    cwd=bare_path, timeout=10,
+                )
+            except Exception:
+                pass
+        finally:
+            if fetched:
+                try:
+                    await self._run_git(
+                        "update-ref", "-d", scratch_ref,
+                        cwd=bare_path, timeout=10,
+                    )
+                except Exception:
+                    pass
+
+    async def _branch_is_fully_merged(self, repo: str, branch: str) -> bool:
+        """Return True if every commit reachable from ``branch`` is
+        patch-equivalent to something already in the default branch.
+
+        Uses ``git cherry <default> <branch>`` which compares commits
+        by patch-id (content), not by SHA — so this catches squash and
+        rebase merges too, not just regular merge commits.
+
+        Conservative: on any error (unknown default branch, cherry
+        failure) returns False so we preserve the local ref.
+        """
+        bare_path = self._get_bare_repo_path(repo)
+        try:
+            default = await self.get_default_branch(repo)
+        except Exception:
+            return False
+        try:
+            out = await self._run_git(
+                "cherry", default, branch,
+                cwd=bare_path, timeout=15,
+            )
+        except Exception:
+            return False
+        lines = [line for line in out.splitlines() if line.strip()]
+        if not lines:
+            # No commits in branch not in default — fully merged / stale.
+            return True
+        # Each line starts with "+" (unique) or "-" (patch-equivalent in upstream).
+        return all(line.startswith("-") for line in lines)
 
     async def push_branch(self, worktree_path: Path, branch: str) -> None:
         """Push a branch to origin."""

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -130,20 +130,48 @@ class WorktreeManager:
 
         if await self.branch_exists_locally(repo, new_branch):
             # Sync the local ref to origin/<branch> before checkout so a
-            # retry after an out-of-band push (human commit on the PR,
-            # another machine) doesn't reuse stale local state and then
-            # fail on a non-fast-forward push. Best-effort: if the sync
-            # can't run (no remote branch, network error), fall back to
-            # whatever the local ref points at.
+            # retry after an out-of-band push (reviewer commit on the PR,
+            # another machine) starts from the fresh upstream state. Two
+            # safeties matter here:
+            #   1. ensure_bare_repo's earlier `fetch --all` may have run
+            #      seconds or minutes ago; between then and now someone
+            #      could have pushed. Re-fetch this specific branch so
+            #      origin/<branch> really does reflect the remote head.
+            #   2. The local branch may be AHEAD of origin — e.g. the
+            #      prior session committed locally and died before
+            #      `git push`. A blind `branch -f` would rewind those
+            #      commits and destroy the only copy. Only fast-forward
+            #      when the local tip is an ancestor of origin/<branch>;
+            #      if local is ahead or diverged, leave it alone.
             if await self.branch_exists_on_remote(repo, new_branch):
                 try:
                     await self._run_git(
-                        "branch", "-f", new_branch, f"origin/{new_branch}",
-                        cwd=bare_path,
+                        "fetch", "origin", new_branch, cwd=bare_path,
                     )
                 except WorktreeError:
                     pass
-            # Reuse: check out the existing ref into the new worktree.
+                try:
+                    # merge-base --is-ancestor exits 0 if local is ancestor
+                    # of origin/<branch> (i.e. behind or equal). Non-zero =
+                    # local is ahead or diverged.
+                    await self._run_git(
+                        "merge-base", "--is-ancestor",
+                        new_branch, f"origin/{new_branch}",
+                        cwd=bare_path,
+                    )
+                except WorktreeError:
+                    # Local is ahead or diverged — preserve recoverable
+                    # commits; skip the force-update.
+                    pass
+                else:
+                    try:
+                        await self._run_git(
+                            "branch", "-f", new_branch, f"origin/{new_branch}",
+                            cwd=bare_path,
+                        )
+                    except WorktreeError:
+                        pass
+            # Reuse: check out the (possibly-updated) ref into the new worktree.
             await self._run_git(
                 "worktree", "add",
                 str(worktree_path),

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -129,47 +129,70 @@ class WorktreeManager:
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
         if await self.branch_exists_locally(repo, new_branch):
-            # Sync the local ref to origin/<branch> before checkout so a
-            # retry after an out-of-band push (reviewer commit on the PR,
-            # another machine) starts from the fresh upstream state. Two
-            # safeties matter here:
-            #   1. ensure_bare_repo's earlier `fetch --all` may have run
-            #      seconds or minutes ago; between then and now someone
-            #      could have pushed. Re-fetch this specific branch so
-            #      origin/<branch> really does reflect the remote head.
-            #   2. The local branch may be AHEAD of origin — e.g. the
-            #      prior session committed locally and died before
-            #      `git push`. A blind `branch -f` would rewind those
-            #      commits and destroy the only copy. Only fast-forward
-            #      when the local tip is an ancestor of origin/<branch>;
-            #      if local is ahead or diverged, leave it alone.
+            # Sync the reused branch to the remote head BEFORE checkout so
+            # a retry after an out-of-band push (reviewer commit on the
+            # PR, another machine) starts from the fresh upstream state.
+            # Two constraints drive the shape of this:
+            #
+            #   1. ensure_bare_repo uses plain `git clone --bare`, whose
+            #      default fetch refspec is `+refs/heads/*:refs/heads/*`
+            #      — there are NO `refs/remotes/origin/*` tracking refs,
+            #      and an unscoped `git fetch origin <branch>` would
+            #      OVERWRITE refs/heads/<branch> directly, destroying any
+            #      unpushed local commits. So we fetch into a dedicated
+            #      scratch ref `refs/ctrlrelay/sync/<branch>` that never
+            #      touches the live branch.
+            #   2. If the local branch is AHEAD of origin (prior session
+            #      committed locally but died before push), only
+            #      fast-forward is safe. `merge-base --is-ancestor`
+            #      exit 0 means local is behind/equal — ok to update.
+            #      Non-zero means ahead or diverged — preserve local.
+            #
+            # Everything in this block is best-effort: if any step fails
+            # (network timeout, permissions, invalid ref) we fall back to
+            # reusing the local ref as-is rather than aborting the retry.
             if await self.branch_exists_on_remote(repo, new_branch):
+                scratch_ref = f"refs/ctrlrelay/sync/{new_branch}"
+                fetched = False
                 try:
                     await self._run_git(
-                        "fetch", "origin", new_branch, cwd=bare_path,
-                    )
-                except WorktreeError:
-                    pass
-                try:
-                    # merge-base --is-ancestor exits 0 if local is ancestor
-                    # of origin/<branch> (i.e. behind or equal). Non-zero =
-                    # local is ahead or diverged.
-                    await self._run_git(
-                        "merge-base", "--is-ancestor",
-                        new_branch, f"origin/{new_branch}",
+                        "fetch", "origin",
+                        f"+refs/heads/{new_branch}:{scratch_ref}",
                         cwd=bare_path,
+                        timeout=30,
                     )
-                except WorktreeError:
-                    # Local is ahead or diverged — preserve recoverable
-                    # commits; skip the force-update.
+                    fetched = True
+                except Exception:
                     pass
-                else:
+                if fetched:
                     try:
                         await self._run_git(
-                            "branch", "-f", new_branch, f"origin/{new_branch}",
+                            "merge-base", "--is-ancestor",
+                            new_branch, scratch_ref,
                             cwd=bare_path,
+                            timeout=10,
                         )
-                    except WorktreeError:
+                    except Exception:
+                        # Ahead / diverged / error — preserve local.
+                        pass
+                    else:
+                        try:
+                            await self._run_git(
+                                "update-ref", f"refs/heads/{new_branch}",
+                                scratch_ref,
+                                cwd=bare_path,
+                                timeout=10,
+                            )
+                        except Exception:
+                            pass
+                    # Clean up the scratch ref regardless of outcome.
+                    try:
+                        await self._run_git(
+                            "update-ref", "-d", scratch_ref,
+                            cwd=bare_path,
+                            timeout=10,
+                        )
+                    except Exception:
                         pass
             # Reuse: check out the (possibly-updated) ref into the new worktree.
             await self._run_git(

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -143,7 +143,27 @@ class WorktreeManager:
                     "`git worktree remove` in the bare repo before retrying."
                 )
 
-            on_remote = await self.branch_exists_on_remote(repo, new_branch)
+            # Remote presence has to be KNOWN to take either sync-to-origin
+            # or stale-merged branches. branch_exists_on_remote is
+            # fail-closed (returns True on timeout/auth error) which is
+            # good for "should I delete this branch" decisions but wrong
+            # here — a transient probe failure would skip the stale-merged
+            # recreate path and resurrect already-merged commits. Use the
+            # strict variant that raises on probe failure; on error we
+            # reuse the local ref unchanged, without mutations.
+            try:
+                on_remote = await self._branch_exists_on_remote_strict(
+                    bare_path, new_branch,
+                )
+            except Exception:
+                await self._run_git(
+                    "worktree", "add",
+                    str(worktree_path),
+                    new_branch,
+                    cwd=bare_path,
+                )
+                return worktree_path
+
             if on_remote:
                 # Remote exists → sync local to remote head (preserving
                 # unpushed ahead-of-origin commits) and reuse.
@@ -156,7 +176,7 @@ class WorktreeManager:
                 )
                 return worktree_path
 
-            # Local-only. Distinguish between:
+            # Local-only (confirmed). Distinguish between:
             #   (a) stale-merged: the prior PR was merged (any strategy) and
             #       the remote branch auto-deleted. The local ref's commits
             #       are all patch-equivalent to commits in the default
@@ -293,6 +313,25 @@ class WorktreeManager:
                     )
                 except Exception:
                     pass
+
+    async def _branch_exists_on_remote_strict(
+        self, bare_path: Path, branch: str,
+    ) -> bool:
+        """Strict variant of branch_exists_on_remote: True if origin
+        has the branch, False if it does not, RAISES on probe failure.
+
+        The public branch_exists_on_remote is fail-closed (returns True
+        on error) so callers making "safe to delete" decisions err
+        on preservation. That semantic is wrong for the reuse path,
+        where a transient error must NOT be interpreted as "remote
+        exists" — that would skip the stale-merged recreate branch and
+        resurrect already-merged commits into a new PR.
+        """
+        output = await self._run_git(
+            "ls-remote", "--heads", "origin", branch,
+            cwd=bare_path, timeout=10,
+        )
+        return bool(output.strip())
 
     async def _branch_is_checked_out_elsewhere(
         self, bare_path: Path, branch: str,

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -129,6 +129,20 @@ class WorktreeManager:
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
         if await self.branch_exists_locally(repo, new_branch):
+            # Sync the local ref to origin/<branch> before checkout so a
+            # retry after an out-of-band push (human commit on the PR,
+            # another machine) doesn't reuse stale local state and then
+            # fail on a non-fast-forward push. Best-effort: if the sync
+            # can't run (no remote branch, network error), fall back to
+            # whatever the local ref points at.
+            if await self.branch_exists_on_remote(repo, new_branch):
+                try:
+                    await self._run_git(
+                        "branch", "-f", new_branch, f"origin/{new_branch}",
+                        cwd=bare_path,
+                    )
+                except WorktreeError:
+                    pass
             # Reuse: check out the existing ref into the new worktree.
             await self._run_git(
                 "worktree", "add",

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -108,12 +108,35 @@ class WorktreeManager:
         new_branch: str,
         base_branch: str | None = None,
     ) -> Path:
-        """Create a worktree with a new branch."""
+        """Create a worktree for ``new_branch``.
+
+        If ``new_branch`` already exists in the bare repo — e.g. because a
+        previous session for the same issue ran out of fix attempts and left
+        its PR branch pushed to origin — reuse that branch so the retry can
+        iterate on the prior commits instead of hitting
+        ``fatal: a branch named 'fix/issue-N' already exists`` from
+        ``git worktree add -b``. Without this, any issue that exhausts the
+        verify-fix loop once gets permanently wedged until someone manually
+        deletes the branch.
+
+        When we have to fall back to a brand-new branch, it's cut from
+        ``base_branch`` (default: the repo's default branch).
+        """
         bare_path = self._get_bare_repo_path(repo)
         worktree_path = self._get_worktree_path(repo, session_id)
 
         if worktree_path.exists():
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
+
+        if await self.branch_exists_locally(repo, new_branch):
+            # Reuse: check out the existing ref into the new worktree.
+            await self._run_git(
+                "worktree", "add",
+                str(worktree_path),
+                new_branch,
+                cwd=bare_path,
+            )
+            return worktree_path
 
         if base_branch is None:
             base_branch = await self.get_default_branch(repo)

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -233,21 +233,57 @@ class WorktreeManager:
         except Exception:
             return
         try:
+            # Distinguish three cases cleanly:
+            #   a) local is ancestor of remote → local behind → fast-forward
+            #   b) remote is ancestor of local → local ahead (unpushed work) → preserve
+            #   c) neither → diverged → raise; caller surfaces as session failure
+            #      so we don't silently reuse a branch that will fail on push.
+            local_behind = False
+            local_ahead = False
             try:
                 await self._run_git(
                     "merge-base", "--is-ancestor", branch, scratch_ref,
                     cwd=bare_path, timeout=10,
                 )
-            except Exception:
-                # Local ahead / diverged / error — preserve local.
-                return
-            try:
-                await self._run_git(
-                    "update-ref", f"refs/heads/{branch}", scratch_ref,
-                    cwd=bare_path, timeout=10,
-                )
-            except Exception:
+                local_behind = True
+            except WorktreeError:
                 pass
+            except Exception:
+                # Timeout or other — play safe and preserve local.
+                return
+            if not local_behind:
+                try:
+                    await self._run_git(
+                        "merge-base", "--is-ancestor", scratch_ref, branch,
+                        cwd=bare_path, timeout=10,
+                    )
+                    local_ahead = True
+                except WorktreeError:
+                    pass
+                except Exception:
+                    return
+
+            if local_behind:
+                try:
+                    await self._run_git(
+                        "update-ref", f"refs/heads/{branch}", scratch_ref,
+                        cwd=bare_path, timeout=10,
+                    )
+                except Exception:
+                    pass
+            elif local_ahead:
+                # Preserve local — ahead means unpushed operator work.
+                pass
+            else:
+                # Diverged: local has commits origin doesn't, and origin has
+                # commits local doesn't. Reusing either side silently loses
+                # work or produces non-ff pushes. Surface the conflict so
+                # the session fails cleanly.
+                raise WorktreeError(
+                    f"Local branch {branch!r} has diverged from "
+                    f"origin/{branch}. Rebase or reset manually in the bare "
+                    "repo before retrying."
+                )
         finally:
             if fetched:
                 try:

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -129,6 +129,20 @@ class WorktreeManager:
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
         if await self.branch_exists_locally(repo, new_branch):
+            # CRITICAL safety: never mutate or delete a branch that's still
+            # checked out by another linked worktree (e.g. a BLOCKED session
+            # that kept its worktree alive on purpose so it can be resumed
+            # when the operator replies). `git update-ref` / `update-ref -d`
+            # don't refuse in that case; they'd leave the live worktree's
+            # HEAD pointing at a stale or missing ref, corrupting the
+            # resumable state. Surface a clean error instead.
+            if await self._branch_is_checked_out_elsewhere(bare_path, new_branch):
+                raise WorktreeError(
+                    f"Branch {new_branch!r} is already checked out in another "
+                    f"worktree of {repo!r}. Resolve with `git worktree list` + "
+                    "`git worktree remove` in the bare repo before retrying."
+                )
+
             on_remote = await self.branch_exists_on_remote(repo, new_branch)
             if on_remote:
                 # Remote exists → sync local to remote head (preserving
@@ -243,6 +257,30 @@ class WorktreeManager:
                     )
                 except Exception:
                     pass
+
+    async def _branch_is_checked_out_elsewhere(
+        self, bare_path: Path, branch: str,
+    ) -> bool:
+        """Return True if ``refs/heads/<branch>`` is currently checked out
+        by any linked worktree of this bare repo.
+
+        Conservative (fails closed): if ``git worktree list --porcelain``
+        itself errors, returns True — better to refuse mutation than to
+        risk corrupting a live worktree.
+        """
+        try:
+            output = await self._run_git(
+                "worktree", "list", "--porcelain",
+                cwd=bare_path, timeout=10,
+            )
+        except Exception:
+            return True
+        target = f"refs/heads/{branch}"
+        for line in output.splitlines():
+            line = line.strip()
+            if line.startswith("branch ") and line[7:].strip() == target:
+                return True
+        return False
 
     async def _branch_is_fully_merged(self, repo: str, branch: str) -> bool:
         """Return True if every commit reachable from ``branch`` is

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -337,11 +337,19 @@ class WorktreeManager:
         self, bare_path: Path, branch: str,
     ) -> bool:
         """Return True if ``refs/heads/<branch>`` is currently checked out
-        by any linked worktree of this bare repo.
+        by any LIVE linked worktree of this bare repo.
 
-        Conservative (fails closed): if ``git worktree list --porcelain``
-        itself errors, returns True — better to refuse mutation than to
-        risk corrupting a live worktree.
+        `git worktree list --porcelain` emits a blank-line-separated
+        stanza per worktree. A stanza with a ``prunable <reason>`` line
+        is a stale metadata entry — the worktree directory is gone, we
+        just haven't run ``git worktree prune`` yet. Such stanzas don't
+        represent a real checkout and MUST be ignored here, otherwise a
+        crash between ``shutil.rmtree()`` and ``worktree prune`` wedges
+        the branch for all future retries.
+
+        Conservative (fails closed): if the probe itself errors, returns
+        True — better to refuse mutation than to risk corrupting a live
+        worktree.
         """
         try:
             output = await self._run_git(
@@ -350,11 +358,26 @@ class WorktreeManager:
             )
         except Exception:
             return True
+
         target = f"refs/heads/{branch}"
-        for line in output.splitlines():
-            line = line.strip()
-            if line.startswith("branch ") and line[7:].strip() == target:
-                return True
+        current_branch: str | None = None
+        current_prunable = False
+        for raw in output.splitlines() + [""]:  # trailing "" to flush last stanza
+            line = raw.strip()
+            if not line:
+                # End of stanza — check if this one matches and is live.
+                if (
+                    current_branch == target
+                    and not current_prunable
+                ):
+                    return True
+                current_branch = None
+                current_prunable = False
+                continue
+            if line.startswith("branch "):
+                current_branch = line[7:].strip()
+            elif line.startswith("prunable"):
+                current_prunable = True
         return False
 
     async def _branch_is_fully_merged(self, repo: str, branch: str) -> bool:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -212,13 +212,14 @@ class TestWorktreeManager:
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Ancestor check FAILS — local ahead/diverged.
+            # Ancestor check FAILS — local ahead/diverged. Cleanup of the
+            # scratch ref still runs via the helper's finally block.
             mock_git.side_effect = [
                 "",                                  # show-ref
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
                 "",                                  # fetch into scratch
                 WorktreeError("not an ancestor"),    # merge-base --is-ancestor
-                "",                                  # update-ref -d scratch (cleanup)
+                "",                                  # update-ref -d scratch (finally)
                 "",                                  # worktree add (reuse as-is)
             ]
 
@@ -258,6 +259,8 @@ class TestWorktreeManager:
         import asyncio as _asyncio
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Fetch raises TimeoutError; helper returns early (no cleanup —
+            # scratch ref was never created).
             mock_git.side_effect = [
                 "",                                  # show-ref
                 "abc\trefs/heads/fix/issue-42\n",    # ls-remote
@@ -280,12 +283,12 @@ class TestWorktreeManager:
         assert len(worktree_add_calls) == 1
 
     @pytest.mark.asyncio
-    async def test_reuse_when_branch_not_on_remote_skips_sync(
+    async def test_local_only_with_unique_commits_is_reused(
         self, tmp_path: Path
     ) -> None:
-        """If the local branch exists but origin has no copy (e.g. a prior
-        session never got as far as pushing), don't attempt the branch -f
-        sync — just reuse the local ref."""
+        """Local-only branch with unique unpushed commits (prior session
+        died before push) must be REUSED, not recreated — otherwise the
+        operator's work is silently dropped."""
         from ctrlrelay.core.worktree import WorktreeManager
 
         manager = WorktreeManager(
@@ -297,24 +300,128 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",   # show-ref --verify ok (local branch exists)
-                "",   # ls-remote --heads origin (empty → not on remote)
-                "",   # worktree add (reuse)
+                "",                                      # show-ref (exists)
+                "",                                      # ls-remote (empty, not on remote)
+                "refs/heads/main\n",                     # get_default_branch → symbolic-ref HEAD
+                "+ abc123 unpushed\n+ def456 more\n",    # cherry default branch — all unique
+                "",                                      # worktree add (reuse)
             ]
-
             wt = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
-                session_id="retry-2",
+                session_id="retry-keep",
                 new_branch="fix/issue-9",
             )
 
-        assert "retry-2" in str(wt)
-        # No branch -f should have been called when origin had nothing.
-        branch_f_calls = [
+        assert "retry-keep" in str(wt)
+        # No delete + no fresh-branch creation.
+        delete_calls = [
             c for c in mock_git.call_args_list
-            if "branch" in c[0] and "-f" in c[0]
+            if "update-ref" in c[0] and "-d" in c[0]
         ]
-        assert branch_f_calls == []
+        assert delete_calls == []
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add_calls) == 1
+        # Reuse path: no -b.
+        assert "-b" not in worktree_add_calls[0][0]
+
+    @pytest.mark.asyncio
+    async def test_local_only_fully_merged_is_deleted_and_recreated(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2: local-only branch whose commits are all already in the
+        default branch (prior PR was merged — any strategy — and the
+        remote was auto-deleted) must NOT be reused. Delete + recreate
+        fresh from default so the next PR doesn't resurrect already-merged
+        changes."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref (local exists)
+                "",                                      # ls-remote (empty)
+                "refs/heads/main\n",                     # get_default_branch (1st)
+                "- abc already merged\n- def ditto\n",   # cherry: all "-" (patch-equivalent)
+                "",                                      # update-ref -d refs/heads/<branch>
+                "refs/heads/main\n",                     # get_default_branch (2nd, for fresh path)
+                "",                                      # worktree add -b
+            ]
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="rerun-merged",
+                new_branch="fix/issue-7",
+            )
+
+        assert "rerun-merged" in str(wt)
+        # update-ref -d refs/heads/<branch> was called.
+        delete_calls = [
+            c for c in mock_git.call_args_list
+            if "update-ref" in c[0] and "-d" in c[0]
+            and "refs/heads/fix/issue-7" in c[0]
+        ]
+        assert len(delete_calls) == 1
+        # Fresh worktree add with -b.
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add_calls) == 1
+        args = worktree_add_calls[0][0]
+        assert "-b" in args
+        assert "fix/issue-7" in args
+
+    @pytest.mark.asyncio
+    async def test_local_only_empty_cherry_is_treated_as_merged(
+        self, tmp_path: Path
+    ) -> None:
+        """If `git cherry <default> <branch>` returns empty output, the
+        branch has no commits that aren't in default (branch tip == or
+        ancestor of default). Treat as fully merged → delete + recreate."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                      # show-ref
+                "",                      # ls-remote
+                "refs/heads/main\n",     # get_default_branch
+                "",                      # cherry: empty
+                "",                      # update-ref -d
+                "refs/heads/main\n",     # get_default_branch (fresh path)
+                "",                      # worktree add -b
+            ]
+            await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="s",
+                new_branch="fix/issue-x",
+            )
+
+        # Path took the stale-merged branch (delete + recreate).
+        delete_calls = [
+            c for c in mock_git.call_args_list
+            if "update-ref" in c[0] and "-d" in c[0]
+        ]
+        assert len(delete_calls) == 1
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert "-b" in worktree_add_calls[0][0]
 
     @pytest.mark.asyncio
     async def test_create_worktree_with_new_branch_uses_default_branch(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -213,14 +213,16 @@ class TestWorktreeManager:
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Ancestor check FAILS — local ahead/diverged. Cleanup of the
-            # scratch ref still runs via the helper's finally block.
+            # First merge-base check (local→remote) fails: local NOT ancestor.
+            # Second check (remote→local) SUCCEEDS: remote is ancestor of
+            # local, meaning local is strictly ahead. Preserve local.
             mock_git.side_effect = [
                 "",                                  # show-ref
-                "",                                  # worktree list --porcelain (no other checkouts)
+                "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
                 "",                                  # fetch into scratch
-                WorktreeError("not an ancestor"),    # merge-base --is-ancestor
+                WorktreeError("not an ancestor"),    # merge-base local→scratch
+                "",                                  # merge-base scratch→local (ok → ahead)
                 "",                                  # update-ref -d scratch (finally)
                 "",                                  # worktree add (reuse as-is)
             ]
@@ -243,6 +245,46 @@ class TestWorktreeManager:
             "reuse must not update refs/heads/<branch> when local is ahead "
             "(would destroy unpushed commits)"
         )
+
+    @pytest.mark.asyncio
+    async def test_reuse_raises_on_diverged_branches(self, tmp_path: Path) -> None:
+        """Codex P2: if local has commits origin doesn't, AND origin has
+        commits local doesn't (true divergence), silently reusing either
+        side would lose commits or produce a non-fast-forward push. Surface
+        the conflict as a WorktreeError so the session fails cleanly."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Both ancestor checks fail → diverged.
+            mock_git.side_effect = [
+                "",                                  # show-ref
+                "",                                  # worktree list --porcelain
+                "abc\trefs/heads/fix/issue-3\n",     # ls-remote
+                "",                                  # fetch scratch
+                WorktreeError("not an ancestor"),    # merge-base local→scratch
+                WorktreeError("not an ancestor"),    # merge-base scratch→local
+                "",                                  # update-ref -d scratch (finally)
+            ]
+            with pytest.raises(WorktreeError, match="diverged"):
+                await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-diverged",
+                    new_branch="fix/issue-3",
+                )
+
+        # Worktree add must NOT have been attempted.
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert worktree_add_calls == []
 
     @pytest.mark.asyncio
     async def test_reuse_survives_fetch_timeout(self, tmp_path: Path) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -129,12 +129,17 @@ class TestWorktreeManager:
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # show-ref (exists), ls-remote (branch on origin), branch -f, worktree add
+            # Reuse path happy-case: local behind origin, fast-forward to origin.
+            #  show-ref (exists) → ls-remote (on origin) → fetch origin <branch>
+            #    → merge-base --is-ancestor (exit 0, local behind)
+            #    → branch -f <branch> origin/<branch> → worktree add
             mock_git.side_effect = [
-                "",                                  # show-ref --verify ok
-                "abc123\trefs/heads/fix/issue-5\n",  # ls-remote --heads origin fix/...
-                "",                                  # branch -f fix/issue-5 origin/...
-                "",                                  # worktree add (reuse)
+                "",                                  # show-ref --verify
+                "abc123\trefs/heads/fix/issue-5\n",  # ls-remote --heads origin
+                "",                                  # fetch origin fix/issue-5
+                "",                                  # merge-base --is-ancestor (ok)
+                "",                                  # branch -f
+                "",                                  # worktree add
             ]
 
             wt = await manager.create_worktree_with_new_branch(
@@ -144,7 +149,21 @@ class TestWorktreeManager:
             )
 
         assert "retry-1" in str(wt)
-        # A branch -f call must have happened, targeting origin/<branch>.
+        # Fetched the specific branch to refresh the tracking ref.
+        fetch_calls = [
+            c for c in mock_git.call_args_list
+            if "fetch" in c[0] and "origin" in c[0]
+        ]
+        assert any("fix/issue-5" in c[0] for c in fetch_calls), (
+            f"expected `git fetch origin fix/issue-5`; got {fetch_calls}"
+        )
+        # Ancestor-check ran before any force-update.
+        ancestor_calls = [
+            c for c in mock_git.call_args_list
+            if "merge-base" in c[0] and "--is-ancestor" in c[0]
+        ]
+        assert len(ancestor_calls) == 1
+        # branch -f happened (fast-forward was safe).
         branch_f_calls = [
             c for c in mock_git.call_args_list
             if "branch" in c[0] and "-f" in c[0]
@@ -153,18 +172,59 @@ class TestWorktreeManager:
         bf_args = branch_f_calls[0][0]
         assert "fix/issue-5" in bf_args
         assert "origin/fix/issue-5" in bf_args
-
+        # worktree add without -b.
         worktree_add_calls = [
             c for c in mock_git.call_args_list
             if "worktree" in c[0] and "add" in c[0]
         ]
         assert len(worktree_add_calls) == 1
         args = worktree_add_calls[0][0]
-        # Reuse path MUST NOT pass -b.
-        assert "-b" not in args, (
-            f"reuse path must not use -b; git call args: {args}"
-        )
+        assert "-b" not in args
         assert "fix/issue-5" in args
+
+    @pytest.mark.asyncio
+    async def test_reuse_preserves_local_commits_when_ahead_of_origin(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1: if the prior attempt made commits locally but died
+        before pushing, the local branch is AHEAD of origin. The sync MUST
+        NOT `branch -f` over those commits — that's the only copy of the
+        operator's recoverable work."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Ancestor check FAILS (non-zero → local is ahead or diverged).
+            mock_git.side_effect = [
+                "",                                  # show-ref
+                "abc\trefs/heads/fix/issue-9\n",     # ls-remote
+                "",                                  # fetch origin
+                WorktreeError("not an ancestor"),    # merge-base --is-ancestor
+                "",                                  # worktree add (reuse as-is)
+            ]
+
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-ahead",
+                new_branch="fix/issue-9",
+            )
+
+        assert "retry-ahead" in str(wt)
+        # CRITICAL: no branch -f should have been attempted.
+        branch_f_calls = [
+            c for c in mock_git.call_args_list
+            if "branch" in c[0] and "-f" in c[0]
+        ]
+        assert branch_f_calls == [], (
+            "reuse must not force-update when local is ahead of origin "
+            "(would destroy unpushed commits)"
+        )
 
     @pytest.mark.asyncio
     async def test_reuse_when_branch_not_on_remote_skips_sync(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -423,6 +423,57 @@ class TestWorktreeManager:
         )
 
     @pytest.mark.asyncio
+    async def test_prunable_worktree_stanza_does_not_block_reuse(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2: if `git worktree list` still reports a stale stanza
+        for a worktree that's been rm -rf'd but not yet pruned, the
+        branch-checked-out probe must IGNORE it (the `prunable` marker
+        means the checkout is gone). Otherwise a crash between worktree
+        dir removal and `git worktree prune` wedges the branch for all
+        future retries."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        stale_porcelain = (
+            "worktree /Users/x/.ctrlrelay/worktrees/owner-repo-crashed-sess\n"
+            "HEAD abc123\n"
+            "branch refs/heads/fix/issue-88\n"
+            "prunable gitdir file points to non-existent location\n"
+            "\n"
+        )
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref (local exists)
+                stale_porcelain,                         # worktree list: prunable stanza
+                "",                                      # ls-remote (no remote)
+                "refs/heads/main\n",                     # get_default_branch
+                "+ abc unique\n",                        # cherry: unique → reuse
+                "",                                      # worktree add (reuse)
+            ]
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-after-crash",
+                new_branch="fix/issue-88",
+            )
+
+        assert "retry-after-crash" in str(wt)
+        # Reuse must have happened — no `already checked out` error raised.
+        worktree_add = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add) == 1
+        assert "-b" not in worktree_add[0][0]
+
+    @pytest.mark.asyncio
     async def test_local_only_with_unique_commits_is_reused(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -137,6 +137,7 @@ class TestWorktreeManager:
             #  update-ref -d refs/ctrlrelay/sync/<b> → worktree add
             mock_git.side_effect = [
                 "",                                  # show-ref --verify
+                "",                                  # worktree list --porcelain (no other checkouts)
                 "abc\trefs/heads/fix/issue-5\n",     # ls-remote --heads origin
                 "",                                  # fetch into scratch
                 "",                                  # merge-base --is-ancestor (ok)
@@ -216,6 +217,7 @@ class TestWorktreeManager:
             # scratch ref still runs via the helper's finally block.
             mock_git.side_effect = [
                 "",                                  # show-ref
+                "",                                  # worktree list --porcelain (no other checkouts)
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
                 "",                                  # fetch into scratch
                 WorktreeError("not an ancestor"),    # merge-base --is-ancestor
@@ -263,6 +265,7 @@ class TestWorktreeManager:
             # scratch ref was never created).
             mock_git.side_effect = [
                 "",                                  # show-ref
+                "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-42\n",    # ls-remote
                 _asyncio.TimeoutError(),             # fetch scratch — hangs
                 "",                                  # worktree add (proceed)
@@ -283,6 +286,52 @@ class TestWorktreeManager:
         assert len(worktree_add_calls) == 1
 
     @pytest.mark.asyncio
+    async def test_reuse_refuses_when_branch_checked_out_elsewhere(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1: if the branch is checked out by another worktree
+        (e.g. a BLOCKED session that kept its worktree alive for resume),
+        mutating or deleting refs/heads/<branch> would corrupt that live
+        worktree. Raise WorktreeError before touching anything."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        porcelain = (
+            "worktree /Users/x/.ctrlrelay/worktrees/owner-repo-blocked-sess\n"
+            "HEAD abc123def456\n"
+            "branch refs/heads/fix/issue-7\n"
+        )
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                  # show-ref (local exists)
+                porcelain,           # worktree list: another worktree has the branch
+            ]
+            with pytest.raises(WorktreeError, match="already checked out"):
+                await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-colliding",
+                    new_branch="fix/issue-7",
+                )
+
+        # No ref mutation should have happened.
+        mutating_calls = [
+            c for c in mock_git.call_args_list
+            if "update-ref" in c[0] or ("branch" in c[0] and "-f" in c[0])
+            or ("worktree" in c[0] and "add" in c[0])
+        ]
+        assert mutating_calls == [], (
+            f"no mutating git ops allowed when branch is checked out "
+            f"elsewhere; got {mutating_calls}"
+        )
+
+    @pytest.mark.asyncio
     async def test_local_only_with_unique_commits_is_reused(
         self, tmp_path: Path
     ) -> None:
@@ -301,6 +350,7 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
                 "",                                      # show-ref (exists)
+                "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty, not on remote)
                 "refs/heads/main\n",                     # get_default_branch → symbolic-ref HEAD
                 "+ abc123 unpushed\n+ def456 more\n",    # cherry default branch — all unique
@@ -348,6 +398,7 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
                 "",                                      # show-ref (local exists)
+                "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty)
                 "refs/heads/main\n",                     # get_default_branch (1st)
                 "- abc already merged\n- def ditto\n",   # cherry: all "-" (patch-equivalent)
@@ -398,6 +449,7 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
                 "",                      # show-ref
+                "",                      # worktree list --porcelain
                 "",                      # ls-remote
                 "refs/heads/main\n",     # get_default_branch
                 "",                      # cherry: empty

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -129,16 +129,19 @@ class TestWorktreeManager:
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Reuse path happy-case: local behind origin, fast-forward to origin.
-            #  show-ref (exists) → ls-remote (on origin) → fetch origin <branch>
-            #    → merge-base --is-ancestor (exit 0, local behind)
-            #    → branch -f <branch> origin/<branch> → worktree add
+            # Reuse happy-case: local behind origin, fast-forward via scratch ref.
+            #  show-ref → ls-remote (on origin) →
+            #  fetch +refs/heads/<b>:refs/ctrlrelay/sync/<b> →
+            #  merge-base --is-ancestor <b> refs/ctrlrelay/sync/<b> (0) →
+            #  update-ref refs/heads/<b> refs/ctrlrelay/sync/<b> →
+            #  update-ref -d refs/ctrlrelay/sync/<b> → worktree add
             mock_git.side_effect = [
                 "",                                  # show-ref --verify
-                "abc123\trefs/heads/fix/issue-5\n",  # ls-remote --heads origin
-                "",                                  # fetch origin fix/issue-5
+                "abc\trefs/heads/fix/issue-5\n",     # ls-remote --heads origin
+                "",                                  # fetch into scratch
                 "",                                  # merge-base --is-ancestor (ok)
-                "",                                  # branch -f
+                "",                                  # update-ref refs/heads/...
+                "",                                  # update-ref -d scratch
                 "",                                  # worktree add
             ]
 
@@ -149,29 +152,38 @@ class TestWorktreeManager:
             )
 
         assert "retry-1" in str(wt)
-        # Fetched the specific branch to refresh the tracking ref.
-        fetch_calls = [
-            c for c in mock_git.call_args_list
-            if "fetch" in c[0] and "origin" in c[0]
-        ]
-        assert any("fix/issue-5" in c[0] for c in fetch_calls), (
-            f"expected `git fetch origin fix/issue-5`; got {fetch_calls}"
-        )
-        # Ancestor-check ran before any force-update.
+
+        # Fetch goes into the dedicated scratch ref, NOT overwriting refs/heads.
+        fetch_calls = [c for c in mock_git.call_args_list if "fetch" in c[0]]
+        assert len(fetch_calls) == 1
+        fargs = fetch_calls[0][0]
+        assert "origin" in fargs
+        refspec = [a for a in fargs if ":" in a and "refs/" in a]
+        assert refspec, f"expected a refs/... refspec in fetch; got {fargs}"
+        assert "refs/ctrlrelay/sync/fix/issue-5" in refspec[0]
+
+        # Ancestor check compares local branch against scratch ref.
         ancestor_calls = [
             c for c in mock_git.call_args_list
             if "merge-base" in c[0] and "--is-ancestor" in c[0]
         ]
         assert len(ancestor_calls) == 1
-        # branch -f happened (fast-forward was safe).
-        branch_f_calls = [
-            c for c in mock_git.call_args_list
-            if "branch" in c[0] and "-f" in c[0]
-        ]
-        assert len(branch_f_calls) == 1
-        bf_args = branch_f_calls[0][0]
-        assert "fix/issue-5" in bf_args
-        assert "origin/fix/issue-5" in bf_args
+        assert "refs/ctrlrelay/sync/fix/issue-5" in ancestor_calls[0][0]
+
+        # Fast-forward via update-ref (NOT branch -f origin/...).
+        update_calls = [c for c in mock_git.call_args_list if "update-ref" in c[0]]
+        assert any(
+            "refs/heads/fix/issue-5" in c[0] and "refs/ctrlrelay/sync/fix/issue-5" in c[0]
+            and "-d" not in c[0]
+            for c in update_calls
+        ), f"expected the live-branch update-ref; got {update_calls}"
+
+        # Scratch ref gets cleaned up.
+        assert any(
+            "-d" in c[0] and "refs/ctrlrelay/sync/fix/issue-5" in c[0]
+            for c in update_calls
+        ), f"expected cleanup of scratch ref; got {update_calls}"
+
         # worktree add without -b.
         worktree_add_calls = [
             c for c in mock_git.call_args_list
@@ -188,8 +200,8 @@ class TestWorktreeManager:
     ) -> None:
         """Codex P1: if the prior attempt made commits locally but died
         before pushing, the local branch is AHEAD of origin. The sync MUST
-        NOT `branch -f` over those commits — that's the only copy of the
-        operator's recoverable work."""
+        NOT update refs/heads/<branch> to the remote tip — those commits
+        are the only recoverable copy."""
         from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
 
         manager = WorktreeManager(
@@ -200,12 +212,13 @@ class TestWorktreeManager:
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Ancestor check FAILS (non-zero → local is ahead or diverged).
+            # Ancestor check FAILS — local ahead/diverged.
             mock_git.side_effect = [
                 "",                                  # show-ref
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
-                "",                                  # fetch origin
+                "",                                  # fetch into scratch
                 WorktreeError("not an ancestor"),    # merge-base --is-ancestor
+                "",                                  # update-ref -d scratch (cleanup)
                 "",                                  # worktree add (reuse as-is)
             ]
 
@@ -216,15 +229,55 @@ class TestWorktreeManager:
             )
 
         assert "retry-ahead" in str(wt)
-        # CRITICAL: no branch -f should have been attempted.
-        branch_f_calls = [
+        # CRITICAL: no update-ref that touches refs/heads/fix/issue-9 ran.
+        refs_heads_updates = [
             c for c in mock_git.call_args_list
-            if "branch" in c[0] and "-f" in c[0]
+            if "update-ref" in c[0]
+            and "refs/heads/fix/issue-9" in c[0]
+            and "-d" not in c[0]
         ]
-        assert branch_f_calls == [], (
-            "reuse must not force-update when local is ahead of origin "
+        assert refs_heads_updates == [], (
+            "reuse must not update refs/heads/<branch> when local is ahead "
             "(would destroy unpushed commits)"
         )
+
+    @pytest.mark.asyncio
+    async def test_reuse_survives_fetch_timeout(self, tmp_path: Path) -> None:
+        """Codex P2: if the sync fetch times out (asyncio.TimeoutError), the
+        retry must still proceed with the local branch as-is rather than
+        failing the whole worktree creation."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        import asyncio as _asyncio
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                  # show-ref
+                "abc\trefs/heads/fix/issue-42\n",    # ls-remote
+                _asyncio.TimeoutError(),             # fetch scratch — hangs
+                "",                                  # worktree add (proceed)
+            ]
+
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-timeout",
+                new_branch="fix/issue-42",
+            )
+
+        assert "retry-timeout" in str(wt)
+        # Worktree add must still have been called.
+        worktree_add_calls = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add_calls) == 1
 
     @pytest.mark.asyncio
     async def test_reuse_when_branch_not_on_remote_skips_sync(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -116,22 +116,26 @@ class TestWorktreeManager:
         bare repo (left over from a prior session that ran out of
         max_fix_attempts with its PR pushed to origin), the worktree creator
         must reuse that branch instead of tripping
-        ``fatal: a branch named 'X' already exists`` from ``worktree add -b``."""
+        ``fatal: a branch named 'X' already exists`` from ``worktree add -b``,
+        AND refresh the local ref from origin/<branch> first so a mid-flight
+        out-of-band push doesn't start the retry on stale state."""
         from ctrlrelay.core.worktree import WorktreeManager
 
         manager = WorktreeManager(
             worktrees_dir=tmp_path / "worktrees",
             bare_repos_dir=tmp_path / "repos",
         )
-        # branch_exists_locally short-circuits if the bare dir is missing;
-        # make it real so the show-ref path is exercised.
         bare = tmp_path / "repos" / "owner-repo.git"
         bare.mkdir(parents=True)
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Both show-ref (branch exists: exit 0) and worktree add (success)
-            # return empty stdout successfully.
-            mock_git.return_value = ""
+            # show-ref (exists), ls-remote (branch on origin), branch -f, worktree add
+            mock_git.side_effect = [
+                "",                                  # show-ref --verify ok
+                "abc123\trefs/heads/fix/issue-5\n",  # ls-remote --heads origin fix/...
+                "",                                  # branch -f fix/issue-5 origin/...
+                "",                                  # worktree add (reuse)
+            ]
 
             wt = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
@@ -140,18 +144,64 @@ class TestWorktreeManager:
             )
 
         assert "retry-1" in str(wt)
+        # A branch -f call must have happened, targeting origin/<branch>.
+        branch_f_calls = [
+            c for c in mock_git.call_args_list
+            if "branch" in c[0] and "-f" in c[0]
+        ]
+        assert len(branch_f_calls) == 1
+        bf_args = branch_f_calls[0][0]
+        assert "fix/issue-5" in bf_args
+        assert "origin/fix/issue-5" in bf_args
+
         worktree_add_calls = [
-            call_ for call_ in mock_git.call_args_list
-            if "worktree" in call_[0] and "add" in call_[0]
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
         ]
         assert len(worktree_add_calls) == 1
         args = worktree_add_calls[0][0]
-        # Reuse path MUST NOT pass -b (that creates a new branch and would
-        # fail if the branch already existed).
+        # Reuse path MUST NOT pass -b.
         assert "-b" not in args, (
             f"reuse path must not use -b; git call args: {args}"
         )
         assert "fix/issue-5" in args
+
+    @pytest.mark.asyncio
+    async def test_reuse_when_branch_not_on_remote_skips_sync(
+        self, tmp_path: Path
+    ) -> None:
+        """If the local branch exists but origin has no copy (e.g. a prior
+        session never got as far as pushing), don't attempt the branch -f
+        sync — just reuse the local ref."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",   # show-ref --verify ok (local branch exists)
+                "",   # ls-remote --heads origin (empty → not on remote)
+                "",   # worktree add (reuse)
+            ]
+
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-2",
+                new_branch="fix/issue-9",
+            )
+
+        assert "retry-2" in str(wt)
+        # No branch -f should have been called when origin had nothing.
+        branch_f_calls = [
+            c for c in mock_git.call_args_list
+            if "branch" in c[0] and "-f" in c[0]
+        ]
+        assert branch_f_calls == []
 
     @pytest.mark.asyncio
     async def test_create_worktree_with_new_branch_uses_default_branch(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -109,6 +109,51 @@ class TestWorktreeManager:
             assert "add" in args
 
     @pytest.mark.asyncio
+    async def test_create_worktree_with_new_branch_reuses_existing_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Regression for #28: if the target branch already exists in the
+        bare repo (left over from a prior session that ran out of
+        max_fix_attempts with its PR pushed to origin), the worktree creator
+        must reuse that branch instead of tripping
+        ``fatal: a branch named 'X' already exists`` from ``worktree add -b``."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        # branch_exists_locally short-circuits if the bare dir is missing;
+        # make it real so the show-ref path is exercised.
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Both show-ref (branch exists: exit 0) and worktree add (success)
+            # return empty stdout successfully.
+            mock_git.return_value = ""
+
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-1",
+                new_branch="fix/issue-5",
+            )
+
+        assert "retry-1" in str(wt)
+        worktree_add_calls = [
+            call_ for call_ in mock_git.call_args_list
+            if "worktree" in call_[0] and "add" in call_[0]
+        ]
+        assert len(worktree_add_calls) == 1
+        args = worktree_add_calls[0][0]
+        # Reuse path MUST NOT pass -b (that creates a new branch and would
+        # fail if the branch already existed).
+        assert "-b" not in args, (
+            f"reuse path must not use -b; git call args: {args}"
+        )
+        assert "fix/issue-5" in args
+
+    @pytest.mark.asyncio
     async def test_create_worktree_with_new_branch_uses_default_branch(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -287,6 +287,55 @@ class TestWorktreeManager:
         assert worktree_add_calls == []
 
     @pytest.mark.asyncio
+    async def test_reuse_falls_back_to_local_when_remote_probe_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2: if ls-remote itself fails (auth, network), we must NOT
+        treat the probe failure as "remote exists" (that would skip the
+        stale-merged recreate) nor as "remote doesn't exist" (that would
+        potentially recreate a branch that DOES exist on origin). Safest
+        is to reuse the local ref as-is, no mutations."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                  # show-ref
+                "",                                  # worktree list --porcelain
+                WorktreeError("gh ls-remote auth"),  # strict ls-remote raises
+                "",                                  # worktree add (reuse as-is)
+            ]
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-probe-fail",
+                new_branch="fix/issue-77",
+            )
+
+        assert "retry-probe-fail" in str(wt)
+        # No ref mutation happened — nothing to the live branch.
+        mutating = [
+            c for c in mock_git.call_args_list
+            if ("update-ref" in c[0]) or ("branch" in c[0] and "-f" in c[0])
+            or ("fetch" in c[0])
+        ]
+        assert mutating == [], (
+            f"no mutations allowed when remote probe fails; got {mutating}"
+        )
+        worktree_add = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add) == 1
+        # Reuse path (no -b).
+        assert "-b" not in worktree_add[0][0]
+
+    @pytest.mark.asyncio
     async def test_reuse_survives_fetch_timeout(self, tmp_path: Path) -> None:
         """Codex P2: if the sync fetch times out (asyncio.TimeoutError), the
         retry must still proceed with the local branch as-is rather than

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -137,7 +137,7 @@ class TestWorktreeManager:
             #  update-ref -d refs/ctrlrelay/sync/<b> → worktree add
             mock_git.side_effect = [
                 "",                                  # show-ref --verify
-                "",                                  # worktree list --porcelain (no other checkouts)
+                "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-5\n",     # ls-remote --heads origin
                 "",                                  # fetch into scratch
                 "",                                  # merge-base --is-ancestor (ok)


### PR DESCRIPTION
Closes #28.

## Problem
After a dev run exhausted \`max_fix_attempts\` (verify loop couldn't get the PR green), \`run_dev_issue\` preserves the pushed branch so the operator can inspect the commits on origin. But the next retry for the **same issue** then trips immediately on worktree creation:

\`\`\`
git failed: Preparing worktree (new branch 'fix/issue-N')
fatal: a branch named 'fix/issue-N' already exists
\`\`\`

\`git worktree add -b\` requires the branch to NOT exist locally. Any issue that hit max_fix_attempts once was effectively disabled — no automated retry could get past the worktree-add step until someone manually deleted the branch.

## Fix
In \`WorktreeManager.create_worktree_with_new_branch\`: probe \`branch_exists_locally\` first. If it exists (e.g. left over from a prior session's pushed PR), check it out into the new worktree **without** \`-b\`. Retry inherits the prior commits and can push updates to the same PR.

If the branch doesn't exist (the normal first-run path), fall through to the existing \`worktree add -b <new_branch> <base>\` logic unchanged.

## No infinite-loop risk
Each session is still bounded by \`max_fix_attempts\` inside \`_verify_and_fix_pr\`, and the poller only re-processes issues that appear as newly-assigned (seen_issues gating). A persistently broken issue just fails its one retry and stops — it doesn't keep spawning sessions.

## Test
\`test_create_worktree_with_new_branch_reuses_existing_branch\`:
- Creates the bare dir so \`branch_exists_locally\`'s \`show-ref\` probe runs.
- Mocks both calls to succeed.
- Asserts the final \`git worktree add\` did NOT use \`-b\` (reuse path).
- Asserts the target branch name was passed.

Full suite: 226 passed, 1 deselected.

## Option 1 and 2 from the issue were evaluated but not chosen:
- **Option 1** (close PR + delete remote + delete local): destructive, loses the operator's ability to inspect. Overkill when the simpler "reuse" path works.
- **Option 2** (per-attempt branch names \`fix/issue-N-attempt-2\`): clutters the repo, adds renaming complexity, and still doesn't fix the "wedge until human cleans up" problem.