### PR TITLE
fix(worktree): prune before reuse so crash-between-rmtree-and-prune doesn't wedge retries

### DIFF
--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -128,20 +128,6 @@ class WorktreeManager:
         if worktree_path.exists():
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
-        # Best-effort: prune stale worktree metadata up front. If a prior
-        # session crashed between `shutil.rmtree(worktree_path)` and
-        # `git worktree prune`, the bare repo still thinks the branch is
-        # checked out — `git worktree add <branch>` would refuse even
-        # though no live worktree exists. Running prune first makes the
-        # subsequent add succeed. Best-effort: ignore errors so a failing
-        # prune doesn't abort creation.
-        try:
-            await self._run_git(
-                "worktree", "prune", cwd=bare_path, timeout=10,
-            )
-        except Exception:
-            pass
-
         if await self.branch_exists_locally(repo, new_branch):
             # CRITICAL safety: never mutate or delete a branch that's still
             # checked out by another linked worktree (e.g. a BLOCKED session
@@ -170,11 +156,8 @@ class WorktreeManager:
                     bare_path, new_branch,
                 )
             except Exception:
-                await self._run_git(
-                    "worktree", "add",
-                    str(worktree_path),
-                    new_branch,
-                    cwd=bare_path,
+                await self._worktree_add_with_stale_cleanup(
+                    bare_path, worktree_path, new_branch,
                 )
                 return worktree_path
 
@@ -182,11 +165,8 @@ class WorktreeManager:
                 # Remote exists → sync local to remote head (preserving
                 # unpushed ahead-of-origin commits) and reuse.
                 await self._sync_reused_branch_to_origin(bare_path, new_branch)
-                await self._run_git(
-                    "worktree", "add",
-                    str(worktree_path),
-                    new_branch,
-                    cwd=bare_path,
+                await self._worktree_add_with_stale_cleanup(
+                    bare_path, worktree_path, new_branch,
                 )
                 return worktree_path
 
@@ -210,11 +190,8 @@ class WorktreeManager:
                     pass
                 # Fall through to the fresh-branch creation below.
             else:
-                await self._run_git(
-                    "worktree", "add",
-                    str(worktree_path),
-                    new_branch,
-                    cwd=bare_path,
+                await self._worktree_add_with_stale_cleanup(
+                    bare_path, worktree_path, new_branch,
                 )
                 return worktree_path
 
@@ -229,6 +206,92 @@ class WorktreeManager:
             cwd=bare_path,
         )
         return worktree_path
+
+    async def _worktree_add_with_stale_cleanup(
+        self, bare_path: Path, worktree_path: Path, branch: str,
+    ) -> None:
+        """``git worktree add <path> <branch>`` with targeted recovery
+        if the add fails because a stale (prunable) admin entry still
+        claims the branch.
+
+        Try the add. If it succeeds, done. If it fails with "already
+        checked out" AND we've already established there's no LIVE
+        checkout of this branch (the caller checked
+        _branch_is_checked_out_elsewhere), we scope a `git worktree
+        prune` to this one stale entry and retry.
+
+        We deliberately do NOT prune up front: an unconditional prune
+        in a bare repo whose worktrees_dir is on a removable / network
+        path would destroy admin state for unrelated worktrees whose
+        paths are temporarily unavailable. Scoping to this specific
+        branch via a post-failure recovery keeps the blast radius
+        minimal.
+        """
+        try:
+            await self._run_git(
+                "worktree", "add", str(worktree_path), branch,
+                cwd=bare_path,
+            )
+            return
+        except WorktreeError as e:
+            if "already checked out" not in str(e):
+                raise
+            # Find the stale admin entry for this branch and clear it.
+            stale_path = await self._find_stale_worktree_path(bare_path, branch)
+            if stale_path is None:
+                raise
+            try:
+                await self._run_git(
+                    "worktree", "prune", cwd=bare_path, timeout=10,
+                )
+            except Exception:
+                pass
+            # Retry the add; if it fails again, let the error surface.
+            await self._run_git(
+                "worktree", "add", str(worktree_path), branch,
+                cwd=bare_path,
+            )
+
+    async def _find_stale_worktree_path(
+        self, bare_path: Path, branch: str,
+    ) -> str | None:
+        """If ``refs/heads/<branch>`` is claimed by a worktree entry marked
+        ``prunable``, return the path of that entry. Otherwise None.
+        Used to confirm that a "already checked out" failure is safe to
+        recover from via prune (i.e. the stale entry IS for our branch
+        and not a real live checkout).
+        """
+        try:
+            output = await self._run_git(
+                "worktree", "list", "--porcelain",
+                cwd=bare_path, timeout=10,
+            )
+        except Exception:
+            return None
+        target = f"refs/heads/{branch}"
+        current_path: str | None = None
+        current_branch: str | None = None
+        current_prunable = False
+        for raw in output.splitlines() + [""]:
+            line = raw.strip()
+            if not line:
+                if (
+                    current_branch == target
+                    and current_prunable
+                    and current_path is not None
+                ):
+                    return current_path
+                current_path = None
+                current_branch = None
+                current_prunable = False
+                continue
+            if line.startswith("worktree "):
+                current_path = line[9:].strip()
+            elif line.startswith("branch "):
+                current_branch = line[7:].strip()
+            elif line.startswith("prunable"):
+                current_prunable = True
+        return None
 
     async def _sync_reused_branch_to_origin(
         self, bare_path: Path, branch: str,

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -245,6 +245,19 @@ class WorktreeManager:
             stale_path = await self._find_stale_worktree_path(bare_path, branch)
             if stale_path is None:
                 raise
+            # Only touch stale entries we OWN — under our managed
+            # worktrees_dir. A prunable stanza can also represent a
+            # worktree on a temporarily-unavailable path (network mount,
+            # removable drive); for those, the operator expects the path
+            # to come back. Deleting that admin state would orphan the
+            # worktree permanently. Scope the recovery to our own
+            # worktrees_dir and surface the original error otherwise.
+            try:
+                stale_resolved = Path(stale_path).resolve()
+                wt_root = self.worktrees_dir.resolve()
+                stale_resolved.relative_to(wt_root)
+            except (OSError, ValueError):
+                raise e  # not under our dir — unsafe to recover
             # Locate the admin dir via its canonical `gitdir` pointer,
             # NOT by assuming the path basename matches. Git sanitizes
             # names (`foo bar` → `foo-bar`) and disambiguates duplicates

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -245,9 +245,15 @@ class WorktreeManager:
             stale_path = await self._find_stale_worktree_path(bare_path, branch)
             if stale_path is None:
                 raise
-            # Admin dir is `<bare>/worktrees/<last-path-component>`.
-            admin_dir = bare_path / "worktrees" / Path(stale_path).name
-            if admin_dir.exists():
+            # Locate the admin dir via its canonical `gitdir` pointer,
+            # NOT by assuming the path basename matches. Git sanitizes
+            # names (`foo bar` → `foo-bar`) and disambiguates duplicates
+            # (`wt`, `wt1`, …), so Path(stale_path).name can point at the
+            # wrong admin dir or a live unrelated worktree's metadata.
+            # Each admin dir has a `gitdir` file that points at
+            # `<worktree-path>/.git` — that pointer is the source of truth.
+            admin_dir = self._resolve_admin_dir(bare_path, stale_path)
+            if admin_dir is not None and admin_dir.exists():
                 try:
                     shutil.rmtree(admin_dir)
                 except OSError:
@@ -257,6 +263,37 @@ class WorktreeManager:
                 "worktree", "add", str(worktree_path), branch,
                 cwd=bare_path,
             )
+
+    def _resolve_admin_dir(
+        self, bare_path: Path, worktree_dir: str,
+    ) -> Path | None:
+        """Find the bare repo's admin dir whose ``gitdir`` pointer file
+        resolves to ``<worktree_dir>/.git``. Returns None if no
+        matching entry exists.
+
+        Git may name admin dirs differently from the worktree path
+        basename (sanitization, collision-suffix), so the only robust
+        way to pair them is to inspect each admin's gitdir pointer.
+        """
+        worktrees_root = bare_path / "worktrees"
+        if not worktrees_root.is_dir():
+            return None
+        target = str(Path(worktree_dir) / ".git")
+        try:
+            entries = list(worktrees_root.iterdir())
+        except OSError:
+            return None
+        for admin_dir in entries:
+            gitdir_file = admin_dir / "gitdir"
+            if not gitdir_file.exists():
+                continue
+            try:
+                pointer = gitdir_file.read_text().strip()
+            except OSError:
+                continue
+            if pointer == target:
+                return admin_dir
+        return None
 
     async def _find_stale_worktree_path(
         self, bare_path: Path, branch: str,

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -246,12 +246,18 @@ class WorktreeManager:
             if stale_path is None:
                 raise
             # Only touch stale entries we OWN — under our managed
-            # worktrees_dir. A prunable stanza can also represent a
-            # worktree on a temporarily-unavailable path (network mount,
-            # removable drive); for those, the operator expects the path
-            # to come back. Deleting that admin state would orphan the
-            # worktree permanently. Scope the recovery to our own
-            # worktrees_dir and surface the original error otherwise.
+            # worktrees_dir — AND only when our worktrees_dir is actually
+            # accessible on disk right now. A prunable stanza can also
+            # represent a worktree on a temporarily-unavailable path
+            # (network mount, removable drive); if the mount is down,
+            # every managed worktree under it appears prunable. Deleting
+            # their admin state would orphan real checkouts when the
+            # mount comes back.
+            #
+            # Safety gate: require worktrees_dir itself to exist and be
+            # a directory. If the whole mount is offline, bail.
+            if not self.worktrees_dir.is_dir():
+                raise e
             try:
                 stale_resolved = Path(stale_path).resolve()
                 wt_root = self.worktrees_dir.resolve()

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -128,6 +128,20 @@ class WorktreeManager:
         if worktree_path.exists():
             raise WorktreeError(f"Worktree already exists: {worktree_path}")
 
+        # Best-effort: prune stale worktree metadata up front. If a prior
+        # session crashed between `shutil.rmtree(worktree_path)` and
+        # `git worktree prune`, the bare repo still thinks the branch is
+        # checked out — `git worktree add <branch>` would refuse even
+        # though no live worktree exists. Running prune first makes the
+        # subsequent add succeed. Best-effort: ignore errors so a failing
+        # prune doesn't abort creation.
+        try:
+            await self._run_git(
+                "worktree", "prune", cwd=bare_path, timeout=10,
+            )
+        except Exception:
+            pass
+
         if await self.branch_exists_locally(repo, new_branch):
             # CRITICAL safety: never mutate or delete a branch that's still
             # checked out by another linked worktree (e.g. a BLOCKED session

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -236,16 +236,22 @@ class WorktreeManager:
         except WorktreeError as e:
             if "already checked out" not in str(e):
                 raise
-            # Find the stale admin entry for this branch and clear it.
+            # Find the stale admin entry for this branch and clear it
+            # WITHOUT running repo-wide `git worktree prune` — that would
+            # also discard admin state for unrelated prunable worktrees
+            # whose paths are temporarily unavailable (removable media,
+            # network mounts), making them unrecoverable when the path
+            # comes back. Instead, delete just the one admin directory.
             stale_path = await self._find_stale_worktree_path(bare_path, branch)
             if stale_path is None:
                 raise
-            try:
-                await self._run_git(
-                    "worktree", "prune", cwd=bare_path, timeout=10,
-                )
-            except Exception:
-                pass
+            # Admin dir is `<bare>/worktrees/<last-path-component>`.
+            admin_dir = bare_path / "worktrees" / Path(stale_path).name
+            if admin_dir.exists():
+                try:
+                    shutil.rmtree(admin_dir)
+                except OSError:
+                    pass
             # Retry the add; if it fails again, let the error surface.
             await self._run_git(
                 "worktree", "add", str(worktree_path), branch,

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -441,15 +441,25 @@ class TestWorktreeManager:
         bare = tmp_path / "repos" / "owner-repo.git"
         bare.mkdir(parents=True)
 
-        # Stale admin dir path: last path component of the worktree path,
-        # inside <bare>/worktrees/. Create the dir on disk so the targeted
-        # rmtree has something to remove.
+        # Stale admin dir is paired to a worktree path via its `gitdir`
+        # file, NOT via basename. Deliberately use a non-matching admin
+        # name to prove the resolver uses the canonical pointer.
         stale_worktree_path_str = str(
             tmp_path / "worktrees" / "owner-repo-crashed-sess"
         )
-        admin_dir = bare / "worktrees" / "owner-repo-crashed-sess"
+        admin_dir = bare / "worktrees" / "sanitized-differently"
         admin_dir.mkdir(parents=True)
         (admin_dir / "HEAD").write_text("ref: refs/heads/fix/issue-99\n")
+        (admin_dir / "gitdir").write_text(
+            f"{stale_worktree_path_str}/.git\n"
+        )
+        # Also create an unrelated admin dir that would be wrongly
+        # targeted by the old basename heuristic, to prove we don't
+        # touch it.
+        decoy = bare / "worktrees" / "owner-repo-crashed-sess"
+        decoy.mkdir(parents=True)
+        (decoy / "HEAD").write_text("ref: refs/heads/other-branch\n")
+        (decoy / "gitdir").write_text("/some/other/worktree/.git\n")
 
         stale_porcelain = (
             f"worktree {stale_worktree_path_str}\n"
@@ -486,8 +496,14 @@ class TestWorktreeManager:
         assert prune_calls == [], (
             "must not run repo-wide prune; targeted rmtree should suffice"
         )
-        # The stale admin dir for THIS branch was removed.
+        # The stale admin dir for THIS branch (matched via gitdir pointer,
+        # not basename) was removed.
         assert not admin_dir.exists()
+        # The unrelated same-basename admin dir was NOT touched.
+        assert decoy.exists(), (
+            "basename-only matcher would have wrongly deleted this; "
+            "gitdir-pointer resolver must spare it"
+        )
         # Two add attempts were made: first failed, second retry succeeded.
         add_calls = [
             c for c in mock_git.call_args_list

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -441,8 +441,18 @@ class TestWorktreeManager:
         bare = tmp_path / "repos" / "owner-repo.git"
         bare.mkdir(parents=True)
 
+        # Stale admin dir path: last path component of the worktree path,
+        # inside <bare>/worktrees/. Create the dir on disk so the targeted
+        # rmtree has something to remove.
+        stale_worktree_path_str = str(
+            tmp_path / "worktrees" / "owner-repo-crashed-sess"
+        )
+        admin_dir = bare / "worktrees" / "owner-repo-crashed-sess"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "HEAD").write_text("ref: refs/heads/fix/issue-99\n")
+
         stale_porcelain = (
-            "worktree /Users/x/.ctrlrelay/worktrees/owner-repo-crashed-sess\n"
+            f"worktree {stale_worktree_path_str}\n"
             "HEAD abc\n"
             "branch refs/heads/fix/issue-99\n"
             "prunable gitdir file points to non-existent location\n"
@@ -459,7 +469,6 @@ class TestWorktreeManager:
                 # first worktree add attempt FAILS on stale admin
                 WorktreeError("fatal: 'fix/issue-99' is already checked out at /stale"),
                 stale_porcelain,                         # porcelain probe for stale entry
-                "",                                      # worktree prune (recovery)
                 "",                                      # worktree add (retry succeeds)
             ]
             wt = await manager.create_worktree_with_new_branch(
@@ -469,19 +478,22 @@ class TestWorktreeManager:
             )
 
         assert "retry-after-crash" in str(wt)
-        # Prune happened AFTER the failed add, not before.
+        # No repo-wide `git worktree prune` was called.
         prune_calls = [
-            i for i, c in enumerate(mock_git.call_args_list)
+            c for c in mock_git.call_args_list
             if "prune" in c[0]
         ]
+        assert prune_calls == [], (
+            "must not run repo-wide prune; targeted rmtree should suffice"
+        )
+        # The stale admin dir for THIS branch was removed.
+        assert not admin_dir.exists()
+        # Two add attempts were made: first failed, second retry succeeded.
         add_calls = [
-            i for i, c in enumerate(mock_git.call_args_list)
+            c for c in mock_git.call_args_list
             if "worktree" in c[0] and "add" in c[0]
         ]
-        assert prune_calls, "expected a prune call"
-        assert add_calls, "expected at least one add call"
-        # First add attempt precedes prune; second add follows.
-        assert add_calls[0] < prune_calls[0] < add_calls[1]
+        assert len(add_calls) == 2
 
     @pytest.mark.asyncio
     async def test_prunable_worktree_stanza_does_not_block_reuse(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -136,7 +136,6 @@ class TestWorktreeManager:
             #  update-ref refs/heads/<b> refs/ctrlrelay/sync/<b> →
             #  update-ref -d refs/ctrlrelay/sync/<b> → worktree add
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref --verify
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-5\n",     # ls-remote --heads origin
@@ -218,7 +217,6 @@ class TestWorktreeManager:
             # Second check (remote→local) SUCCEEDS: remote is ancestor of
             # local, meaning local is strictly ahead. Preserve local.
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
@@ -266,7 +264,6 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             # Both ancestor checks fail → diverged.
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-3\n",     # ls-remote
@@ -309,7 +306,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 WorktreeError("gh ls-remote auth"),  # strict ls-remote raises
@@ -359,7 +355,6 @@ class TestWorktreeManager:
             # Fetch raises TimeoutError; helper returns early (no cleanup —
             # scratch ref was never created).
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-42\n",    # ls-remote
@@ -406,7 +401,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                  # show-ref (local exists)
                 porcelain,           # worktree list: another worktree has the branch
             ]
@@ -427,6 +421,67 @@ class TestWorktreeManager:
             f"no mutating git ops allowed when branch is checked out "
             f"elsewhere; got {mutating_calls}"
         )
+
+    @pytest.mark.asyncio
+    async def test_worktree_add_retries_after_targeted_prune_on_stale_admin(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1: if a prior worktree crashed between rmtree and prune,
+        `git worktree add` fails with 'already checked out' even though no
+        live checkout exists. The reuse path must detect the stale entry,
+        run a scoped prune, and retry — NOT an unconditional up-front
+        prune that would also remove admin state for unrelated worktrees
+        whose paths are temporarily unavailable."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        stale_porcelain = (
+            "worktree /Users/x/.ctrlrelay/worktrees/owner-repo-crashed-sess\n"
+            "HEAD abc\n"
+            "branch refs/heads/fix/issue-99\n"
+            "prunable gitdir file points to non-existent location\n"
+            "\n"
+        )
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref (branch exists)
+                "",                                      # worktree list (no live, prunable only)
+                "",                                      # ls-remote (no remote)
+                "refs/heads/main\n",                     # get_default_branch
+                "+ abc unique\n",                        # cherry (unique — reuse path)
+                # first worktree add attempt FAILS on stale admin
+                WorktreeError("fatal: 'fix/issue-99' is already checked out at /stale"),
+                stale_porcelain,                         # porcelain probe for stale entry
+                "",                                      # worktree prune (recovery)
+                "",                                      # worktree add (retry succeeds)
+            ]
+            wt = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-after-crash",
+                new_branch="fix/issue-99",
+            )
+
+        assert "retry-after-crash" in str(wt)
+        # Prune happened AFTER the failed add, not before.
+        prune_calls = [
+            i for i, c in enumerate(mock_git.call_args_list)
+            if "prune" in c[0]
+        ]
+        add_calls = [
+            i for i, c in enumerate(mock_git.call_args_list)
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert prune_calls, "expected a prune call"
+        assert add_calls, "expected at least one add call"
+        # First add attempt precedes prune; second add follows.
+        assert add_calls[0] < prune_calls[0] < add_calls[1]
 
     @pytest.mark.asyncio
     async def test_prunable_worktree_stanza_does_not_block_reuse(
@@ -457,7 +512,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (local exists)
                 stale_porcelain,                         # worktree list: prunable stanza
                 "",                                      # ls-remote (no remote)
@@ -498,7 +552,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (exists)
                 "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty, not on remote)
@@ -547,7 +600,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (local exists)
                 "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty)
@@ -599,7 +651,6 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
-                "",                                  # worktree prune (unconditional)
                 "",                      # show-ref
                 "",                      # worktree list --porcelain
                 "",                      # ls-remote
@@ -640,8 +691,7 @@ class TestWorktreeManager:
         )
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # prune → default-branch probe → worktree add
-            mock_git.side_effect = ["", "refs/heads/main\n", ""]
+            mock_git.side_effect = ["refs/heads/main\n", ""]
 
             worktree_path = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
@@ -650,14 +700,13 @@ class TestWorktreeManager:
             )
 
             assert worktree_path is not None
-            # Calls: prune, then symbolic-ref HEAD (for default), then worktree add.
+            # First call: symbolic-ref HEAD (default branch probe).
             first_call_args = mock_git.call_args_list[0][0]
-            assert "prune" in first_call_args
+            assert "symbolic-ref" in first_call_args
+            # Second call: worktree add -b <new> <base>.
             second_call_args = mock_git.call_args_list[1][0]
-            assert "symbolic-ref" in second_call_args
-            third_call_args = mock_git.call_args_list[2][0]
-            assert "-b" in third_call_args
-            assert "main" in third_call_args
+            assert "-b" in second_call_args
+            assert "main" in second_call_args
 
     @pytest.mark.asyncio
     async def test_push_branch(self, tmp_path: Path) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -136,6 +136,7 @@ class TestWorktreeManager:
             #  update-ref refs/heads/<b> refs/ctrlrelay/sync/<b> →
             #  update-ref -d refs/ctrlrelay/sync/<b> → worktree add
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref --verify
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-5\n",     # ls-remote --heads origin
@@ -217,6 +218,7 @@ class TestWorktreeManager:
             # Second check (remote→local) SUCCEEDS: remote is ancestor of
             # local, meaning local is strictly ahead. Preserve local.
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-9\n",     # ls-remote
@@ -264,6 +266,7 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             # Both ancestor checks fail → diverged.
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-3\n",     # ls-remote
@@ -306,6 +309,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 WorktreeError("gh ls-remote auth"),  # strict ls-remote raises
@@ -355,6 +359,7 @@ class TestWorktreeManager:
             # Fetch raises TimeoutError; helper returns early (no cleanup —
             # scratch ref was never created).
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                  # show-ref
                 "",                                  # worktree list --porcelain
                 "abc\trefs/heads/fix/issue-42\n",    # ls-remote
@@ -401,6 +406,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                  # show-ref (local exists)
                 porcelain,           # worktree list: another worktree has the branch
             ]
@@ -451,6 +457,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (local exists)
                 stale_porcelain,                         # worktree list: prunable stanza
                 "",                                      # ls-remote (no remote)
@@ -491,6 +498,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (exists)
                 "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty, not on remote)
@@ -539,6 +547,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                                      # show-ref (local exists)
                 "",                                      # worktree list --porcelain
                 "",                                      # ls-remote (empty)
@@ -590,6 +599,7 @@ class TestWorktreeManager:
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = [
+                "",                                  # worktree prune (unconditional)
                 "",                      # show-ref
                 "",                      # worktree list --porcelain
                 "",                      # ls-remote
@@ -630,7 +640,8 @@ class TestWorktreeManager:
         )
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            mock_git.side_effect = ["refs/heads/main\n", ""]
+            # prune → default-branch probe → worktree add
+            mock_git.side_effect = ["", "refs/heads/main\n", ""]
 
             worktree_path = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
@@ -639,12 +650,14 @@ class TestWorktreeManager:
             )
 
             assert worktree_path is not None
-            # First call should be symbolic-ref HEAD, second should be worktree add
+            # Calls: prune, then symbolic-ref HEAD (for default), then worktree add.
             first_call_args = mock_git.call_args_list[0][0]
-            assert "symbolic-ref" in first_call_args
+            assert "prune" in first_call_args
             second_call_args = mock_git.call_args_list[1][0]
-            assert "-b" in second_call_args
-            assert "main" in second_call_args
+            assert "symbolic-ref" in second_call_args
+            third_call_args = mock_git.call_args_list[2][0]
+            assert "-b" in third_call_args
+            assert "main" in third_call_args
 
     @pytest.mark.asyncio
     async def test_push_branch(self, tmp_path: Path) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -512,6 +512,63 @@ class TestWorktreeManager:
         assert len(add_calls) == 2
 
     @pytest.mark.asyncio
+    async def test_stale_recovery_refuses_paths_outside_managed_worktrees_dir(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1: a `prunable` stanza can also represent a worktree on
+        a temporarily-unavailable path (network mount, removable drive).
+        The recovery path must only touch stale entries UNDER our
+        managed worktrees_dir; anything else (user-managed path, network
+        mount) is surfaced as the original error so the operator can
+        decide, not silently deleted."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        # Stale worktree is claimed under /Volumes/Backup (outside our dir).
+        external_stale_path = "/Volumes/Backup/some-worktree-elsewhere"
+        admin_dir = bare / "worktrees" / "something"
+        admin_dir.mkdir(parents=True)
+        (admin_dir / "gitdir").write_text(f"{external_stale_path}/.git\n")
+
+        stale_porcelain = (
+            f"worktree {external_stale_path}\n"
+            "HEAD abc\n"
+            "branch refs/heads/fix/issue-55\n"
+            "prunable gitdir file points to non-existent location\n"
+            "\n"
+        )
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref
+                "",                                      # worktree list (no live)
+                "",                                      # ls-remote
+                "refs/heads/main\n",                     # get_default_branch
+                "+ abc unique\n",                        # cherry
+                WorktreeError(
+                    "fatal: 'fix/issue-55' is already checked out at "
+                    + external_stale_path
+                ),                                       # first add fails
+                stale_porcelain,                         # porcelain probe
+            ]
+            with pytest.raises(WorktreeError, match="already checked out"):
+                await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-external-path",
+                    new_branch="fix/issue-55",
+                )
+
+        # Admin dir MUST NOT have been removed (could be on a mount that
+        # comes back later).
+        assert admin_dir.exists()
+
+    @pytest.mark.asyncio
     async def test_prunable_worktree_stanza_does_not_block_reuse(
         self, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
Found during codex validation of the v0.1.3 release candidate (main since v0.1.1).

## Problem
\`_branch_is_checked_out_elsewhere\` correctly skips \`prunable\` stanzas in \`git worktree list --porcelain\`, so on a crash-between-rmtree-and-prune the probe returns False (no live checkout). But \`git worktree add\` itself still refuses:

\`\`\`
fatal: 'fix/issue-N' is already checked out at '<stale-path>'
\`\`\`

So the retry falls through my probe, hits the add, and gets wedged anyway.

## Fix
Run \`git worktree prune\` unconditionally as the first op in \`create_worktree_with_new_branch\`. Best-effort (short timeout + swallow errors) — a pathological prune failure shouldn't abort a creation that would otherwise succeed.

## Deferred
The second codex finding from the same review — stale-merged branch recreation ownership-signal going stale in run_dev_issue's \`branch_preexisted\` snapshot — is filed as #51. It requires an API change to \`create_worktree_with_new_branch\` return type, and I'm consolidating it with #52 (open-PR detection) in a later focused PR.

## Tests
All existing side_effect sequences updated to account for the new leading \`prune\` call. 235/235 pass. ruff clean.