### PR TITLE
feat(phase-4): wire PRWatcher into the poller — Phase 4 gate closes (#55)

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -867,25 +867,12 @@ def poller_start(
                     contexts_dir=config.paths.contexts,
                 )
 
-                # Send result notification
-                if connected_transport:
-                    if result.success:
-                        pr_url = result.outputs.get("pr_url", "")
-                        await transport.send(f"✅ PR ready: {pr_url}")
-                    elif result.blocked:
-                        await transport.send(f"⏸️ Blocked on #{issue_number}: {result.question}")
-                    else:
-                        await transport.send(
-                            f"❌ Failed on #{issue_number}: "
-                            f"{result.error or result.summary}"
-                        )
-
-                # If the dev pipeline opened a PR, spawn a background
-                # watcher regardless of terminal status — run_dev_issue
-                # preserves `pr_number` in outputs even on BLOCKED/FAILED
-                # paths where verification gave up but the PR is still
-                # live on origin. Watching those too means a human-
-                # completed merge still auto-closes the issue.
+                # Spawn the PR watcher FIRST, before any best-effort
+                # notification. The poller has already marked this issue
+                # as seen in poller_state.json, so if a transient
+                # transport.send failure below raised through the outer
+                # finally, we'd permanently lose the watcher and the
+                # issue would never auto-close on merge.
                 pr_number_raw = result.outputs.get("pr_number")
                 pr_url_str = result.outputs.get("pr_url", "")
                 if pr_number_raw is not None:
@@ -907,6 +894,28 @@ def poller_start(
                         )
                         pr_watch_tasks.add(task)
                         task.add_done_callback(pr_watch_tasks.discard)
+
+                # Send result notification — best-effort. A failed send
+                # must NOT prevent the merge watcher (spawned above)
+                # from running, so swallow transport errors here.
+                if connected_transport:
+                    try:
+                        if result.success:
+                            pr_url = result.outputs.get("pr_url", "")
+                            await transport.send(f"✅ PR ready: {pr_url}")
+                        elif result.blocked:
+                            await transport.send(
+                                f"⏸️ Blocked on #{issue_number}: {result.question}"
+                            )
+                        else:
+                            await transport.send(
+                                f"❌ Failed on #{issue_number}: "
+                                f"{result.error or result.summary}"
+                            )
+                    except Exception as e:
+                        console.print(
+                            f"[yellow]Transport error sending result: {e}[/yellow]"
+                        )
             finally:
                 if connected_transport:
                     await transport.close()

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -881,11 +881,13 @@ def poller_start(
                         )
 
                 # If the dev pipeline opened a PR, spawn a background
-                # watcher that fires a Telegram notification + closes
-                # the issue when the reviewer merges. Fire-and-forget;
-                # task is tracked in pr_watch_tasks so it's not GC'd.
-                pr_number_raw = result.outputs.get("pr_number") if result.success else None
-                pr_url_str = result.outputs.get("pr_url", "") if result.success else ""
+                # watcher regardless of terminal status — run_dev_issue
+                # preserves `pr_number` in outputs even on BLOCKED/FAILED
+                # paths where verification gave up but the PR is still
+                # live on origin. Watching those too means a human-
+                # completed merge still auto-closes the issue.
+                pr_number_raw = result.outputs.get("pr_number")
+                pr_url_str = result.outputs.get("pr_url", "")
                 if pr_number_raw is not None:
                     try:
                         pr_number = int(pr_number_raw)

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -815,14 +815,25 @@ def poller_start(
         async def _watch_transport_factory():
             """Build a fresh connected SocketTransport for a single watcher,
             independent of the transport used in handle_issue (which is
-            closed on exit). Returns None when no Telegram transport is
-            configured or the socket is missing."""
+            closed on exit).
+
+            Return None ONLY when Telegram notifications aren't
+            configured at all — that's a legitimate "no channel" signal
+            and the retry loop treats it as clean success. A configured-
+            but-currently-missing socket is a transient outage (bridge
+            restart, daemon crash mid-merge), so RAISE to trigger the
+            retry path; the next attempt will reach the socket once the
+            bridge is back.
+            """
             if config.transport.type.value != "telegram" or not config.transport.telegram:
                 return None
             from ctrlrelay.transports import SocketTransport
             socket_path = config.transport.telegram.socket_path.expanduser().resolve()
             if not socket_path.exists():
-                return None
+                raise FileNotFoundError(
+                    f"Telegram bridge socket missing at {socket_path}; "
+                    "retryable — bridge may be restarting"
+                )
             watch_transport = SocketTransport(socket_path)
             await watch_transport.connect()
             return watch_transport

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -739,6 +739,7 @@ def poller_start(
         from ctrlrelay.core.state import StateDB
         from ctrlrelay.core.worktree import WorktreeManager
         from ctrlrelay.pipelines.dev import run_dev_issue
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
 
         github = GitHubCLI()
 
@@ -806,6 +807,26 @@ def poller_start(
                     "[yellow]Run 'ctrlrelay bridge start' to enable notifications[/yellow]"
                 )
 
+        # Track in-flight PR-watch background tasks so they outlive
+        # handle_issue and aren't garbage-collected. Cleared via
+        # done_callback as each task terminates.
+        pr_watch_tasks: set[asyncio.Task] = set()
+
+        async def _watch_transport_factory():
+            """Build a fresh connected SocketTransport for a single watcher,
+            independent of the transport used in handle_issue (which is
+            closed on exit). Returns None when no Telegram transport is
+            configured or the socket is missing."""
+            if config.transport.type.value != "telegram" or not config.transport.telegram:
+                return None
+            from ctrlrelay.transports import SocketTransport
+            socket_path = config.transport.telegram.socket_path.expanduser().resolve()
+            if not socket_path.exists():
+                return None
+            watch_transport = SocketTransport(socket_path)
+            await watch_transport.connect()
+            return watch_transport
+
         async def handle_issue(repo: str, issue: dict) -> None:
             issue_number = issue["number"]
             title = issue.get("title", "")
@@ -858,6 +879,32 @@ def poller_start(
                             f"❌ Failed on #{issue_number}: "
                             f"{result.error or result.summary}"
                         )
+
+                # If the dev pipeline opened a PR, spawn a background
+                # watcher that fires a Telegram notification + closes
+                # the issue when the reviewer merges. Fire-and-forget;
+                # task is tracked in pr_watch_tasks so it's not GC'd.
+                pr_number_raw = result.outputs.get("pr_number") if result.success else None
+                pr_url_str = result.outputs.get("pr_url", "") if result.success else ""
+                if pr_number_raw is not None:
+                    try:
+                        pr_number = int(pr_number_raw)
+                    except (TypeError, ValueError):
+                        pr_number = None
+                    if pr_number is not None:
+                        task = asyncio.create_task(
+                            pr_watch_task(
+                                repo=repo,
+                                issue_number=issue_number,
+                                pr_url=pr_url_str,
+                                pr_number=pr_number,
+                                session_id=result.session_id,
+                                github=github,
+                                transport_factory=_watch_transport_factory,
+                            )
+                        )
+                        pr_watch_tasks.add(task)
+                        task.add_done_callback(pr_watch_tasks.discard)
             finally:
                 if connected_transport:
                     await transport.close()
@@ -865,8 +912,23 @@ def poller_start(
         console.print(f"[green]Starting poller[/green] for {len(repo_names)} repo(s) as {username}")
         console.print(f"  Interval: {interval}s | Press Ctrl+C to stop")
 
+        async def _main() -> None:
+            try:
+                await run_poll_loop(
+                    poller=poller, handler=handle_issue, interval=interval,
+                )
+            finally:
+                # Cancel any in-flight PR watchers so a poller stop/restart
+                # doesn't leak asyncio tasks. Their handlers log
+                # dev.pr.watch_cancelled and close their transport via the
+                # finally block.
+                if pr_watch_tasks:
+                    for t in list(pr_watch_tasks):
+                        t.cancel()
+                    await asyncio.gather(*list(pr_watch_tasks), return_exceptions=True)
+
         try:
-            asyncio.run(run_poll_loop(poller=poller, handler=handle_issue, interval=interval))
+            asyncio.run(_main())
         except KeyboardInterrupt:
             console.print("\n[yellow]Poller stopped.[/yellow]")
         finally:

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -32,16 +32,32 @@ class GitHubCLI:
     timeout: int = 60
 
     async def _run_gh(self, *args: str) -> str:
-        """Run gh command and return stdout; raise GitHubError on non-zero."""
+        """Run gh command and return stdout; raise GitHubError on non-zero.
+
+        Kills the child and waits for it to reap on timeout so a
+        long-running daemon (e.g. 7-day PR-watch loop that retries on
+        TimeoutError) doesn't leak subprocesses while the network hangs.
+        """
         cmd = [self.gh_binary, *args]
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout, stderr = await asyncio.wait_for(
-            proc.communicate(), timeout=self.timeout
-        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(), timeout=self.timeout
+            )
+        except asyncio.TimeoutError:
+            # Reap the hung child so we don't accumulate zombies across
+            # many retries. kill() is SIGKILL on POSIX; wait() returns
+            # quickly because the signal is terminal.
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:
+                pass
+            raise
 
         if proc.returncode != 0:
             raise GitHubError(f"gh failed: {stderr.decode().strip()}")
@@ -126,9 +142,17 @@ class GitHubCLI:
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
-        stdout_bytes, stderr_bytes = await asyncio.wait_for(
-            proc.communicate(), timeout=self.timeout,
-        )
+        try:
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(), timeout=self.timeout,
+            )
+        except asyncio.TimeoutError:
+            proc.kill()
+            try:
+                await proc.wait()
+            except Exception:
+                pass
+            raise
         stdout = stdout_bytes.decode().strip()
         stderr = stderr_bytes.decode().strip()
 

--- a/src/ctrlrelay/core/pr_watcher.py
+++ b/src/ctrlrelay/core/pr_watcher.py
@@ -11,6 +11,16 @@ from ctrlrelay.core.obs import get_logger, log_event
 
 _logger = get_logger("core.pr_watcher")
 
+# After this many CONSECUTIVE transient failures we give up on the watch.
+# gh can raise "transient-looking" errors (GitHubError, TimeoutError,
+# OSError) for permanent problems too — bad repo, expired auth,
+# permission change, missing gh binary. Without a cap, those would
+# silently loop for the full 7-day timeout and never surface the
+# problem. 10 × poll_interval is enough to cover a reasonable network
+# blip (several minutes on 60s polls) while still failing fast on a
+# genuinely stuck watch.
+_TRANSIENT_FAILURE_CAP = 10
+
 
 @dataclass
 class PRWatcher:
@@ -59,22 +69,37 @@ class PRWatcher:
         clean shutdown propagates.
         """
         elapsed = 0
+        consecutive_failures = 0
         while elapsed < timeout:
             try:
                 if await self.check_merged(repo, pr_number):
                     return True
+                consecutive_failures = 0  # successful poll resets the counter
             except asyncio.CancelledError:
                 raise
             except (GitHubError, TimeoutError, OSError) as e:
+                consecutive_failures += 1
                 log_event(
                     _logger, "pr_watch.transient_error",
                     repo=repo, pr_number=pr_number,
                     reason=type(e).__name__,
                     error=str(e)[:200],
                     elapsed=elapsed,
+                    consecutive_failures=consecutive_failures,
                 )
-                # Fall through to the sleep + retry; don't count this
-                # as a successful poll in any way.
+                if consecutive_failures >= _TRANSIENT_FAILURE_CAP:
+                    # Likely permanent: bad repo, expired auth, 404,
+                    # missing gh binary. Fail fast instead of zombie-
+                    # sleeping for 7 days.
+                    log_event(
+                        _logger, "pr_watch.abandoned_after_too_many_errors",
+                        repo=repo, pr_number=pr_number,
+                        consecutive_failures=consecutive_failures,
+                        last_reason=type(e).__name__,
+                        last_error=str(e)[:200],
+                    )
+                    raise
+                # Fall through to the sleep + retry.
 
             if on_poll:
                 try:

--- a/src/ctrlrelay/core/pr_watcher.py
+++ b/src/ctrlrelay/core/pr_watcher.py
@@ -16,10 +16,16 @@ _logger = get_logger("core.pr_watcher")
 # OSError) for permanent problems too — bad repo, expired auth,
 # permission change, missing gh binary. Without a cap, those would
 # silently loop for the full 7-day timeout and never surface the
-# problem. 10 × poll_interval is enough to cover a reasonable network
-# blip (several minutes on 60s polls) while still failing fast on a
-# genuinely stuck watch.
-_TRANSIENT_FAILURE_CAP = 10
+# problem.
+#
+# Sizing: at the default 60s poll interval, 60 consecutive failures
+# covers a ~1-hour outage window. That's enough slack for routine VPN
+# flaps, GitHub incidents, or auth token rotations without abandoning
+# the watch, while still bounding truly permanent failures (deleted
+# repo, revoked credentials) to an hour instead of the full 7-day
+# timeout. A successful poll resets the counter, so genuinely
+# intermittent failures never accumulate.
+_TRANSIENT_FAILURE_CAP = 60
 
 
 @dataclass

--- a/src/ctrlrelay/core/pr_watcher.py
+++ b/src/ctrlrelay/core/pr_watcher.py
@@ -6,7 +6,10 @@ import asyncio
 from dataclasses import dataclass
 from typing import Awaitable, Callable
 
-from ctrlrelay.core.github import GitHubCLI
+from ctrlrelay.core.github import GitHubCLI, GitHubError
+from ctrlrelay.core.obs import get_logger, log_event
+
+_logger = get_logger("core.pr_watcher")
 
 
 @dataclass
@@ -46,14 +49,40 @@ class PRWatcher:
 
         Returns:
             True if merged within timeout, False otherwise
+
+        Transient-failure handling: individual ``gh`` failures
+        (``GitHubError``, ``TimeoutError``, network-level ``OSError``)
+        during a multi-day watch MUST NOT abort the loop — otherwise a
+        single flaky poll cycle permanently stops monitoring the PR.
+        Log a structured ``pr_watch.transient_error`` event and keep
+        polling. ``asyncio.CancelledError`` is always re-raised so a
+        clean shutdown propagates.
         """
         elapsed = 0
         while elapsed < timeout:
-            if await self.check_merged(repo, pr_number):
-                return True
+            try:
+                if await self.check_merged(repo, pr_number):
+                    return True
+            except asyncio.CancelledError:
+                raise
+            except (GitHubError, TimeoutError, OSError) as e:
+                log_event(
+                    _logger, "pr_watch.transient_error",
+                    repo=repo, pr_number=pr_number,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                    elapsed=elapsed,
+                )
+                # Fall through to the sleep + retry; don't count this
+                # as a successful poll in any way.
 
             if on_poll:
-                await on_poll()
+                try:
+                    await on_poll()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:
+                    pass  # on_poll is best-effort diagnostic plumbing
 
             await asyncio.sleep(self.poll_interval)
             elapsed += self.poll_interval

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -20,6 +20,14 @@ _logger = get_logger("pipelines.post_merge")
 # Operators can still override via an explicit `timeout=` argument.
 DEFAULT_PR_WATCH_TIMEOUT = 7 * 24 * 60 * 60
 
+# After a merge is detected, handle_merge can fail transiently on
+# `gh issue close` or the transport.send (network blip, rate limit).
+# Without retry the whole automation is wasted — PR merged, issue
+# stays open forever. Retry with modest backoff; if all attempts fail,
+# the last failure is logged via dev.pr.watch_failed.
+_HANDLE_MERGE_RETRY_ATTEMPTS = 5
+_HANDLE_MERGE_RETRY_BASE_DELAY = 5  # seconds; doubled each attempt
+
 
 async def handle_merge(
     repo: str,
@@ -66,6 +74,51 @@ async def watch_and_handle_merge(
         return True
 
     return False
+
+
+async def _handle_merge_with_retry(
+    *,
+    repo: str,
+    pr_number: int,
+    issue_number: int,
+    github: GitHubCLI,
+    transport: Transport | None,
+    session_id: str | None,
+) -> None:
+    """Run handle_merge with exponential-backoff retry so a transient
+    gh / transport failure at merge time doesn't waste the whole watch.
+
+    On final exhaustion, raise the last exception; pr_watch_task's
+    outer handler logs it as dev.pr.watch_failed.
+    """
+    last_exc: Exception | None = None
+    delay = _HANDLE_MERGE_RETRY_BASE_DELAY
+    for attempt in range(1, _HANDLE_MERGE_RETRY_ATTEMPTS + 1):
+        try:
+            await handle_merge(
+                repo=repo, pr_number=pr_number,
+                issue_number=issue_number, github=github,
+                transport=transport,
+            )
+            return
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            last_exc = e
+            log_event(
+                _logger, "dev.pr.handle_merge_retry",
+                session_id=session_id, repo=repo,
+                issue_number=issue_number, pr_number=pr_number,
+                attempt=attempt,
+                max_attempts=_HANDLE_MERGE_RETRY_ATTEMPTS,
+                reason=type(e).__name__, error=str(e)[:200],
+            )
+            if attempt >= _HANDLE_MERGE_RETRY_ATTEMPTS:
+                break
+            await asyncio.sleep(delay)
+            delay = min(delay * 2, 300)  # cap at 5 min
+    assert last_exc is not None
+    raise last_exc
 
 
 async def pr_watch_task(
@@ -128,10 +181,10 @@ async def pr_watch_task(
                     )
                     transport = None
             try:
-                await handle_merge(
+                await _handle_merge_with_retry(
                     repo=repo, pr_number=pr_number,
                     issue_number=issue_number, github=github,
-                    transport=transport,
+                    transport=transport, session_id=session_id,
                 )
             finally:
                 if transport is not None:

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -119,11 +119,6 @@ async def _handle_merge_with_retry(
         f"Issue #{issue_number} closed after PR #{pr_number} merged in {repo}"
     )
 
-    # Notification is "required" only if the caller asked for one (by
-    # passing a transport_factory). Without a factory, comment+close is
-    # the whole contract and we're done once those land.
-    notification_required = transport_factory is not None
-
     for attempt in range(1, _HANDLE_MERGE_RETRY_ATTEMPTS + 1):
         transport: Transport | None = None
         transport_build_error: Exception | None = None
@@ -131,6 +126,9 @@ async def _handle_merge_with_retry(
             try:
                 transport = await transport_factory()
             except Exception as e:
+                # Factory raised — bridge likely transiently unavailable.
+                # Record the error so we can retry on the next attempt
+                # instead of silently dropping the notification.
                 transport_build_error = e
                 log_event(
                     _logger, "dev.pr.watch_transport_failed",
@@ -140,6 +138,10 @@ async def _handle_merge_with_retry(
                     reason=type(e).__name__, error=str(e)[:200],
                 )
                 transport = None
+            # Factory returned None legitimately (e.g. non-Telegram
+            # config or socket intentionally absent) → no notification
+            # channel is configured; do NOT retry. `transport_build_error`
+            # remains None, so the "done" check below returns cleanly.
 
         try:
             if not comment_posted:
@@ -154,19 +156,15 @@ async def _handle_merge_with_retry(
                 await transport.send(notification)
                 notification_sent = True
 
-            # Done only when every required step has completed. If the
-            # caller wanted a notification but the factory failed to
-            # produce a transport this round, fall through to the retry
-            # path so the next attempt can rebuild the connection —
-            # otherwise a brief bridge outage at merge time would
-            # permanently drop the notification.
-            if notification_sent or not notification_required:
+            # Done when either: we sent the notification this round, OR
+            # the factory returned None meaning no channel was ever
+            # configured. Fall through to the retry path ONLY if the
+            # factory itself raised — that's a transient failure worth
+            # retrying so a brief bridge outage doesn't drop the
+            # notification permanently.
+            if notification_sent or transport_build_error is None:
                 return
-            # Synthesize a retry-worthy error so the transient factory
-            # failure is treated uniformly with send/close failures.
-            raise transport_build_error or RuntimeError(
-                "transport factory returned None; cannot send notification"
-            )
+            raise transport_build_error
         except asyncio.CancelledError:
             raise
         except Exception as e:

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -2,9 +2,15 @@
 
 from __future__ import annotations
 
+import asyncio
+from typing import Any, Awaitable, Callable
+
 from ctrlrelay.core.github import GitHubCLI
+from ctrlrelay.core.obs import get_logger, log_event
 from ctrlrelay.core.pr_watcher import PRWatcher
 from ctrlrelay.transports.base import Transport
+
+_logger = get_logger("pipelines.post_merge")
 
 
 async def handle_merge(
@@ -52,3 +58,92 @@ async def watch_and_handle_merge(
         return True
 
     return False
+
+
+async def pr_watch_task(
+    *,
+    repo: str,
+    issue_number: int,
+    pr_url: str,
+    pr_number: int,
+    session_id: str | None,
+    github: GitHubCLI,
+    transport_factory: Callable[[], Awaitable[Transport | None]] | None = None,
+    poll_interval: int = 60,
+    timeout: int = 86400,
+) -> dict[str, Any]:
+    """Background-safe wrapper around watch_and_handle_merge that manages
+    its own transport lifecycle and emits structured ``dev.pr.*`` events.
+
+    ``transport_factory`` is an async callable returning a CONNECTED
+    transport (or None). It's invoked once at the start of the watch so
+    the watcher's transport is independent of whichever one handled the
+    initial issue dispatch (that one is closed when handle_issue returns).
+    Returning None is fine — the merge notification is then suppressed.
+
+    Returns a dict describing the outcome:
+      {"merged": bool, "timed_out": bool, "cancelled": bool, "failed": str|None}
+    """
+    outcome: dict[str, Any] = {
+        "merged": False, "timed_out": False,
+        "cancelled": False, "failed": None,
+    }
+    transport: Transport | None = None
+    if transport_factory is not None:
+        try:
+            transport = await transport_factory()
+        except Exception as e:
+            log_event(
+                _logger,
+                "dev.pr.watch_transport_failed",
+                repo=repo, issue_number=issue_number, pr_number=pr_number,
+                reason=type(e).__name__, error=str(e)[:200],
+            )
+            transport = None
+
+    log_event(
+        _logger, "dev.pr.watching",
+        session_id=session_id, repo=repo, issue_number=issue_number,
+        pr_number=pr_number, pr_url=pr_url,
+    )
+    try:
+        merged = await watch_and_handle_merge(
+            repo=repo,
+            pr_number=pr_number,
+            issue_number=issue_number,
+            github=github,
+            transport=transport,
+            poll_interval=poll_interval,
+            timeout=timeout,
+        )
+        outcome["merged"] = merged
+        outcome["timed_out"] = not merged
+        log_event(
+            _logger,
+            "dev.pr.merged" if merged else "dev.pr.watch_timeout",
+            session_id=session_id, repo=repo, issue_number=issue_number,
+            pr_number=pr_number,
+        )
+    except asyncio.CancelledError:
+        outcome["cancelled"] = True
+        log_event(
+            _logger, "dev.pr.watch_cancelled",
+            session_id=session_id, repo=repo, issue_number=issue_number,
+            pr_number=pr_number,
+        )
+        raise
+    except Exception as e:
+        outcome["failed"] = type(e).__name__
+        log_event(
+            _logger, "dev.pr.watch_failed",
+            session_id=session_id, repo=repo, issue_number=issue_number,
+            pr_number=pr_number,
+            reason=type(e).__name__, error=str(e)[:200],
+        )
+    finally:
+        if transport is not None:
+            try:
+                await transport.close()
+            except Exception:
+                pass
+    return outcome

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -102,7 +102,16 @@ async def _handle_merge_with_retry(
     On final exhaustion, raises the last exception; pr_watch_task's
     outer handler logs it as dev.pr.watch_failed.
     """
+    # Split the post-merge work into three independent steps with
+    # their own idempotency flags. close_issue() in the github layer
+    # is NOT atomic — it posts a comment then runs `gh issue close`.
+    # If the close fails after the comment succeeded, a retry that
+    # called close_issue again would post a DUPLICATE comment.
+    # Tracking each sub-step separately ensures every side-effect
+    # runs at most once across retries.
+    comment_posted = False
     issue_closed = False
+    notification_sent = False
     last_exc: Exception | None = None
     delay = _HANDLE_MERGE_RETRY_BASE_DELAY
     comment = f"Closed by PR #{pr_number}"
@@ -111,12 +120,8 @@ async def _handle_merge_with_retry(
     )
 
     for attempt in range(1, _HANDLE_MERGE_RETRY_ATTEMPTS + 1):
-        # Build a fresh transport for this attempt — an earlier attempt
-        # may have dropped its socket; a stale one would guarantee a
-        # doomed send(). Failure to build is non-fatal; we can still
-        # close the issue, and surface the failure via log.
         transport: Transport | None = None
-        if transport_factory is not None:
+        if not notification_sent and transport_factory is not None:
             try:
                 transport = await transport_factory()
             except Exception as e:
@@ -130,11 +135,17 @@ async def _handle_merge_with_retry(
                 transport = None
 
         try:
+            if not comment_posted:
+                await github.comment_on_issue(repo, issue_number, comment)
+                comment_posted = True
             if not issue_closed:
-                await github.close_issue(repo, issue_number, comment)
+                await github._run_gh(
+                    "issue", "close", str(issue_number), "--repo", repo,
+                )
                 issue_closed = True
-            if transport is not None:
+            if not notification_sent and transport is not None:
                 await transport.send(notification)
+                notification_sent = True
             return
         except asyncio.CancelledError:
             raise
@@ -146,7 +157,9 @@ async def _handle_merge_with_retry(
                 issue_number=issue_number, pr_number=pr_number,
                 attempt=attempt,
                 max_attempts=_HANDLE_MERGE_RETRY_ATTEMPTS,
+                comment_posted=comment_posted,
                 issue_closed=issue_closed,
+                notification_sent=notification_sent,
                 reason=type(e).__name__, error=str(e)[:200],
             )
             if attempt >= _HANDLE_MERGE_RETRY_ATTEMPTS:

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -82,24 +82,59 @@ async def _handle_merge_with_retry(
     pr_number: int,
     issue_number: int,
     github: GitHubCLI,
-    transport: Transport | None,
+    transport_factory: Callable[[], Awaitable[Transport | None]] | None,
     session_id: str | None,
 ) -> None:
-    """Run handle_merge with exponential-backoff retry so a transient
-    gh / transport failure at merge time doesn't waste the whole watch.
+    """Run the post-merge close + notify steps with per-step idempotent
+    retry, rebuilding the transport on each attempt so a bridge restart
+    mid-retry doesn't permanently break the notification.
 
-    On final exhaustion, raise the last exception; pr_watch_task's
+    Idempotency: ``github.close_issue`` is called at most once even
+    across retries — if it succeeds but the notification step later
+    fails, subsequent attempts skip the close so we don't post
+    duplicate "Closed by PR #N" comments.
+
+    Transport rebuild: ``transport_factory`` is invoked INSIDE each
+    attempt. If the bridge socket drops between the watcher start and
+    a merge several days later, or during a retry, the next attempt
+    gets a fresh connection.
+
+    On final exhaustion, raises the last exception; pr_watch_task's
     outer handler logs it as dev.pr.watch_failed.
     """
+    issue_closed = False
     last_exc: Exception | None = None
     delay = _HANDLE_MERGE_RETRY_BASE_DELAY
+    comment = f"Closed by PR #{pr_number}"
+    notification = (
+        f"Issue #{issue_number} closed after PR #{pr_number} merged in {repo}"
+    )
+
     for attempt in range(1, _HANDLE_MERGE_RETRY_ATTEMPTS + 1):
+        # Build a fresh transport for this attempt — an earlier attempt
+        # may have dropped its socket; a stale one would guarantee a
+        # doomed send(). Failure to build is non-fatal; we can still
+        # close the issue, and surface the failure via log.
+        transport: Transport | None = None
+        if transport_factory is not None:
+            try:
+                transport = await transport_factory()
+            except Exception as e:
+                log_event(
+                    _logger, "dev.pr.watch_transport_failed",
+                    session_id=session_id, repo=repo,
+                    issue_number=issue_number, pr_number=pr_number,
+                    attempt=attempt,
+                    reason=type(e).__name__, error=str(e)[:200],
+                )
+                transport = None
+
         try:
-            await handle_merge(
-                repo=repo, pr_number=pr_number,
-                issue_number=issue_number, github=github,
-                transport=transport,
-            )
+            if not issue_closed:
+                await github.close_issue(repo, issue_number, comment)
+                issue_closed = True
+            if transport is not None:
+                await transport.send(notification)
             return
         except asyncio.CancelledError:
             raise
@@ -111,12 +146,19 @@ async def _handle_merge_with_retry(
                 issue_number=issue_number, pr_number=pr_number,
                 attempt=attempt,
                 max_attempts=_HANDLE_MERGE_RETRY_ATTEMPTS,
+                issue_closed=issue_closed,
                 reason=type(e).__name__, error=str(e)[:200],
             )
             if attempt >= _HANDLE_MERGE_RETRY_ATTEMPTS:
                 break
             await asyncio.sleep(delay)
-            delay = min(delay * 2, 300)  # cap at 5 min
+            delay = min(delay * 2, 300)
+        finally:
+            if transport is not None:
+                try:
+                    await transport.close()
+                except Exception:
+                    pass
     assert last_exc is not None
     raise last_exc
 
@@ -164,34 +206,16 @@ async def pr_watch_task(
             repo=repo, pr_number=pr_number, timeout=timeout,
         )
         if merged:
-            # Build the transport NOW, not at watch start. Bridge may
-            # have been restarted during the multi-day window; a
-            # freshly-connected socket is the only reliable way to
-            # deliver the merge notification.
-            transport: Transport | None = None
-            if transport_factory is not None:
-                try:
-                    transport = await transport_factory()
-                except Exception as e:
-                    log_event(
-                        _logger, "dev.pr.watch_transport_failed",
-                        session_id=session_id, repo=repo,
-                        issue_number=issue_number, pr_number=pr_number,
-                        reason=type(e).__name__, error=str(e)[:200],
-                    )
-                    transport = None
-            try:
-                await _handle_merge_with_retry(
-                    repo=repo, pr_number=pr_number,
-                    issue_number=issue_number, github=github,
-                    transport=transport, session_id=session_id,
-                )
-            finally:
-                if transport is not None:
-                    try:
-                        await transport.close()
-                    except Exception:
-                        pass
+            # Defer transport construction to inside the retry loop so
+            # each attempt gets a fresh connection — a bridge restart
+            # during the watch or between retries doesn't leave us
+            # hitting a dead socket forever.
+            await _handle_merge_with_retry(
+                repo=repo, pr_number=pr_number,
+                issue_number=issue_number, github=github,
+                transport_factory=transport_factory,
+                session_id=session_id,
+            )
         outcome["merged"] = merged
         outcome["timed_out"] = not merged
         log_event(

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -119,12 +119,19 @@ async def _handle_merge_with_retry(
         f"Issue #{issue_number} closed after PR #{pr_number} merged in {repo}"
     )
 
+    # Notification is "required" only if the caller asked for one (by
+    # passing a transport_factory). Without a factory, comment+close is
+    # the whole contract and we're done once those land.
+    notification_required = transport_factory is not None
+
     for attempt in range(1, _HANDLE_MERGE_RETRY_ATTEMPTS + 1):
         transport: Transport | None = None
+        transport_build_error: Exception | None = None
         if not notification_sent and transport_factory is not None:
             try:
                 transport = await transport_factory()
             except Exception as e:
+                transport_build_error = e
                 log_event(
                     _logger, "dev.pr.watch_transport_failed",
                     session_id=session_id, repo=repo,
@@ -146,7 +153,20 @@ async def _handle_merge_with_retry(
             if not notification_sent and transport is not None:
                 await transport.send(notification)
                 notification_sent = True
-            return
+
+            # Done only when every required step has completed. If the
+            # caller wanted a notification but the factory failed to
+            # produce a transport this round, fall through to the retry
+            # path so the next attempt can rebuild the connection —
+            # otherwise a brief bridge outage at merge time would
+            # permanently drop the notification.
+            if notification_sent or not notification_required:
+                return
+            # Synthesize a retry-worthy error so the transient factory
+            # failure is treated uniformly with send/close failures.
+            raise transport_build_error or RuntimeError(
+                "transport factory returned None; cannot send notification"
+            )
         except asyncio.CancelledError:
             raise
         except Exception as e:
@@ -218,6 +238,19 @@ async def pr_watch_task(
         merged = await watcher.wait_for_merge(
             repo=repo, pr_number=pr_number, timeout=timeout,
         )
+        # Record merge detection BEFORE running the post-merge handler,
+        # so an exhausted retry loop (e.g. permanent bridge outage) still
+        # leaves `outcome["merged"] = True`. The merge really did happen;
+        # only the cleanup chain is degraded, and `outcome["failed"]`
+        # already surfaces that via the except branch below.
+        outcome["merged"] = merged
+        outcome["timed_out"] = not merged
+        log_event(
+            _logger,
+            "dev.pr.merged" if merged else "dev.pr.watch_timeout",
+            session_id=session_id, repo=repo, issue_number=issue_number,
+            pr_number=pr_number,
+        )
         if merged:
             # Defer transport construction to inside the retry loop so
             # each attempt gets a fresh connection — a bridge restart
@@ -229,14 +262,6 @@ async def pr_watch_task(
                 transport_factory=transport_factory,
                 session_id=session_id,
             )
-        outcome["merged"] = merged
-        outcome["timed_out"] = not merged
-        log_event(
-            _logger,
-            "dev.pr.merged" if merged else "dev.pr.watch_timeout",
-            session_id=session_id, repo=repo, issue_number=issue_number,
-            pr_number=pr_number,
-        )
     except asyncio.CancelledError:
         outcome["cancelled"] = True
         log_event(

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -12,6 +12,14 @@ from ctrlrelay.transports.base import Transport
 
 _logger = get_logger("pipelines.post_merge")
 
+# Default merge-watch window. Real PR review cycles commonly exceed a
+# day (weekends, time-zone splits, larger changes), and a silent watch
+# timeout means the linked issue never auto-closes and no merge
+# notification fires. 7 days is the sweet spot: covers typical review
+# lag without keeping a zombie task alive for months on an abandoned PR.
+# Operators can still override via an explicit `timeout=` argument.
+DEFAULT_PR_WATCH_TIMEOUT = 7 * 24 * 60 * 60
+
 
 async def handle_merge(
     repo: str,
@@ -40,7 +48,7 @@ async def watch_and_handle_merge(
     github: GitHubCLI,
     transport: Transport | None = None,
     poll_interval: int = 60,
-    timeout: int = 86400,
+    timeout: int = DEFAULT_PR_WATCH_TIMEOUT,
 ) -> bool:
     """Watch for PR merge and handle post-merge actions."""
     watcher = PRWatcher(github=github, poll_interval=poll_interval)
@@ -70,7 +78,7 @@ async def pr_watch_task(
     github: GitHubCLI,
     transport_factory: Callable[[], Awaitable[Transport | None]] | None = None,
     poll_interval: int = 60,
-    timeout: int = 86400,
+    timeout: int = DEFAULT_PR_WATCH_TIMEOUT,
 ) -> dict[str, Any]:
     """Background-safe wrapper around watch_and_handle_merge that manages
     its own transport lifecycle and emits structured ``dev.pr.*`` events.

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -80,14 +80,17 @@ async def pr_watch_task(
     poll_interval: int = 60,
     timeout: int = DEFAULT_PR_WATCH_TIMEOUT,
 ) -> dict[str, Any]:
-    """Background-safe wrapper around watch_and_handle_merge that manages
-    its own transport lifecycle and emits structured ``dev.pr.*`` events.
+    """Background-safe wrapper around the merge watcher that emits
+    structured ``dev.pr.*`` events and manages a transport LAZILY —
+    the transport is only created AFTER the merge is detected, so a
+    bridge that's down or restarted during the multi-day watch window
+    doesn't leave us with a stale connection at notification time.
 
-    ``transport_factory`` is an async callable returning a CONNECTED
-    transport (or None). It's invoked once at the start of the watch so
-    the watcher's transport is independent of whichever one handled the
-    initial issue dispatch (that one is closed when handle_issue returns).
-    Returning None is fine — the merge notification is then suppressed.
+    ``transport_factory`` is an async callable returning a connected
+    transport (or None). Called once, right before ``handle_merge``;
+    its result is closed immediately after the merge handler runs.
+    A raising factory is logged and skipped (merge detection proceeds
+    without the notification channel rather than aborting the close).
 
     Returns a dict describing the outcome:
       {"merged": bool, "timed_out": bool, "cancelled": bool, "failed": str|None}
@@ -96,18 +99,6 @@ async def pr_watch_task(
         "merged": False, "timed_out": False,
         "cancelled": False, "failed": None,
     }
-    transport: Transport | None = None
-    if transport_factory is not None:
-        try:
-            transport = await transport_factory()
-        except Exception as e:
-            log_event(
-                _logger,
-                "dev.pr.watch_transport_failed",
-                repo=repo, issue_number=issue_number, pr_number=pr_number,
-                reason=type(e).__name__, error=str(e)[:200],
-            )
-            transport = None
 
     log_event(
         _logger, "dev.pr.watching",
@@ -115,15 +106,39 @@ async def pr_watch_task(
         pr_number=pr_number, pr_url=pr_url,
     )
     try:
-        merged = await watch_and_handle_merge(
-            repo=repo,
-            pr_number=pr_number,
-            issue_number=issue_number,
-            github=github,
-            transport=transport,
-            poll_interval=poll_interval,
-            timeout=timeout,
+        watcher = PRWatcher(github=github, poll_interval=poll_interval)
+        merged = await watcher.wait_for_merge(
+            repo=repo, pr_number=pr_number, timeout=timeout,
         )
+        if merged:
+            # Build the transport NOW, not at watch start. Bridge may
+            # have been restarted during the multi-day window; a
+            # freshly-connected socket is the only reliable way to
+            # deliver the merge notification.
+            transport: Transport | None = None
+            if transport_factory is not None:
+                try:
+                    transport = await transport_factory()
+                except Exception as e:
+                    log_event(
+                        _logger, "dev.pr.watch_transport_failed",
+                        session_id=session_id, repo=repo,
+                        issue_number=issue_number, pr_number=pr_number,
+                        reason=type(e).__name__, error=str(e)[:200],
+                    )
+                    transport = None
+            try:
+                await handle_merge(
+                    repo=repo, pr_number=pr_number,
+                    issue_number=issue_number, github=github,
+                    transport=transport,
+                )
+            finally:
+                if transport is not None:
+                    try:
+                        await transport.close()
+                    except Exception:
+                        pass
         outcome["merged"] = merged
         outcome["timed_out"] = not merged
         log_event(
@@ -148,10 +163,4 @@ async def pr_watch_task(
             pr_number=pr_number,
             reason=type(e).__name__, error=str(e)[:200],
         )
-    finally:
-        if transport is not None:
-            try:
-                await transport.close()
-            except Exception:
-                pass
     return outcome

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -143,6 +143,57 @@ class TestGitHubCLI:
                 await gh.get_pr_checks("owner/repo", 42)
 
     @pytest.mark.asyncio
+    async def test_run_gh_kills_child_on_timeout(self) -> None:
+        """A hung `gh` must be terminated on timeout — otherwise the
+        long-running PR-watch daemon (which retries on TimeoutError up
+        to _TRANSIENT_FAILURE_CAP times) would leak subprocesses while
+        the network stalls."""
+        import asyncio
+
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_proc = MagicMock()
+
+        async def never_returns():
+            await asyncio.Event().wait()
+
+        mock_proc.communicate = AsyncMock(side_effect=never_returns)
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+            gh = GitHubCLI(timeout=0.01)
+            with pytest.raises(asyncio.TimeoutError):
+                await gh._run_gh("issue", "list")
+
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_kills_child_on_timeout(self) -> None:
+        """Same reaper guarantee for get_pr_checks, which bypasses _run_gh."""
+        import asyncio
+
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_proc = MagicMock()
+
+        async def never_returns():
+            await asyncio.Event().wait()
+
+        mock_proc.communicate = AsyncMock(side_effect=never_returns)
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock(return_value=0)
+
+        with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+            gh = GitHubCLI(timeout=0.01)
+            with pytest.raises(asyncio.TimeoutError):
+                await gh.get_pr_checks("owner/repo", 42)
+
+        mock_proc.kill.assert_called_once()
+        mock_proc.wait.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_list_assigned_issues(self) -> None:
         """Should list issues assigned to a user."""
         from ctrlrelay.core.github import GitHubCLI

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -245,6 +245,107 @@ class TestPRWatchTask:
         assert factory_call_count == 0
 
     @pytest.mark.asyncio
+    async def test_handle_merge_transient_failure_retries(self, caplog) -> None:
+        """Codex P2: transient `gh issue close` failure at merge time must
+        not abandon the post-merge cleanup. Retry with backoff; after
+        a success, the issue is closed."""
+        import logging
+
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        # First two close_issue attempts fail; third succeeds.
+        close_calls = 0
+
+        async def flaky_close(repo, issue_number, comment):
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls < 3:
+                raise RuntimeError("gh transient at close")
+
+        mock_github.close_issue.side_effect = flaky_close
+
+        async def factory():
+            return AsyncMock()
+
+        # Patch the retry base delay to 0 so the test doesn't sleep.
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        assert outcome["merged"] is True
+        # close_issue was retried until it succeeded.
+        assert close_calls == 3
+        # At least two retry events logged (the first two failures).
+        retry_events = [
+            r for r in caplog.records
+            if "dev.pr.handle_merge_retry" in r.getMessage()
+        ]
+        assert len(retry_events) == 2
+
+    @pytest.mark.asyncio
+    async def test_handle_merge_exhausts_retries_and_logs_failure(
+        self, caplog
+    ) -> None:
+        """After all retries exhausted, log dev.pr.watch_failed and
+        surface outcome['failed'] so the operator can act."""
+        import logging
+
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+        mock_github.close_issue.side_effect = RuntimeError("permanent auth error")
+
+        async def factory():
+            return AsyncMock()
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        # Task records the failure but doesn't crash.
+        assert outcome["failed"] == "RuntimeError"
+        # All attempts consumed.
+        assert mock_github.close_issue.call_count == pm._HANDLE_MERGE_RETRY_ATTEMPTS
+        # Last event is dev.pr.watch_failed.
+        assert any(
+            "dev.pr.watch_failed" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
     async def test_transport_factory_failure_is_non_fatal(self, caplog) -> None:
         """If the transport factory raises, we log and proceed with
         transport=None — the merge detection itself must not depend on

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -1,5 +1,7 @@
 """Tests for post-merge handler."""
 
+import asyncio
+import logging
 from unittest.mock import AsyncMock
 
 import pytest
@@ -50,4 +52,151 @@ class TestPostMergeHandler:
         )
 
         assert result is True
+        mock_github.close_issue.assert_called_once()
+
+
+class TestPRWatchTask:
+    """Cover the background-safe wrapper the poller uses (#55)."""
+
+    @pytest.mark.asyncio
+    async def test_merged_logs_event_and_closes_issue(self, caplog) -> None:
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        mock_transport = AsyncMock()
+
+        async def factory():
+            return mock_transport
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+            outcome = await pr_watch_task(
+                repo="owner/repo",
+                issue_number=77,
+                pr_url="https://github.com/owner/repo/pull/42",
+                pr_number=42,
+                session_id="sess-1",
+                github=mock_github,
+                transport_factory=factory,
+                poll_interval=0,
+                timeout=5,
+            )
+
+        assert outcome == {
+            "merged": True, "timed_out": False,
+            "cancelled": False, "failed": None,
+        }
+        events = [r.getMessage() for r in caplog.records]
+        assert any("dev.pr.watching" in e for e in events)
+        assert any("dev.pr.merged" in e for e in events)
+        mock_github.close_issue.assert_called_once()
+        mock_transport.close.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_watch_timeout(self, caplog) -> None:
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "OPEN"}
+
+        async def factory():
+            return None
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+            outcome = await pr_watch_task(
+                repo="owner/repo",
+                issue_number=77,
+                pr_url="https://github.com/owner/repo/pull/42",
+                pr_number=42,
+                session_id="sess-timeout",
+                github=mock_github,
+                transport_factory=factory,
+                poll_interval=0,
+                timeout=0,   # exits immediately; OPEN → timed out
+            )
+
+        assert outcome["timed_out"] is True
+        assert outcome["merged"] is False
+        assert any(
+            "dev.pr.watch_timeout" in r.getMessage() for r in caplog.records
+        )
+        mock_github.close_issue.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_is_logged_and_reraised(self, caplog) -> None:
+        """Poller shutdown cancels the watcher; the task must re-raise
+        CancelledError so the caller's gather sees it."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        # Slow github that gets cancelled mid-poll.
+        sleep_event = asyncio.Event()
+
+        async def slow_get_state(*_a, **_kw):
+            await sleep_event.wait()
+            return {"state": "OPEN"}
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = slow_get_state
+
+        async def factory():
+            return None
+
+        async def run():
+            return await pr_watch_task(
+                repo="owner/repo",
+                issue_number=77,
+                pr_url="",
+                pr_number=42,
+                session_id=None,
+                github=mock_github,
+                transport_factory=factory,
+                poll_interval=0,
+                timeout=60,
+            )
+
+        task = asyncio.create_task(run())
+        await asyncio.sleep(0)  # let it start
+        task.cancel()
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+            with pytest.raises(asyncio.CancelledError):
+                await task
+
+        assert any(
+            "dev.pr.watch_cancelled" in r.getMessage() for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_transport_factory_failure_is_non_fatal(self, caplog) -> None:
+        """If the transport factory raises, we log and proceed with
+        transport=None — the merge detection itself must not depend on
+        the notification channel being up."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            raise RuntimeError("bridge socket missing")
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+            outcome = await pr_watch_task(
+                repo="owner/repo",
+                issue_number=77,
+                pr_url="",
+                pr_number=42,
+                session_id=None,
+                github=mock_github,
+                transport_factory=factory,
+                poll_interval=0,
+                timeout=5,
+            )
+
+        assert outcome["merged"] is True
+        assert any(
+            "dev.pr.watch_transport_failed" in r.getMessage()
+            for r in caplog.records
+        )
+        # Merge detection still closed the issue even without transport.
         mock_github.close_issue.assert_called_once()

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -245,6 +245,126 @@ class TestPRWatchTask:
         assert factory_call_count == 0
 
     @pytest.mark.asyncio
+    async def test_retry_does_not_duplicate_close_issue_comment(
+        self, caplog
+    ) -> None:
+        """Codex P2: if close_issue succeeds but transport.send fails,
+        the retry MUST NOT re-run close_issue and post a duplicate
+        "Closed by PR #N" comment on the issue."""
+        import logging
+
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        # close_issue succeeds on first call; no retries of it.
+        # transport.send raises twice, succeeds third.
+        send_calls = 0
+
+        def make_transport():
+            nonlocal send_calls
+            t = AsyncMock()
+
+            async def send(_msg):
+                nonlocal send_calls
+                send_calls += 1
+                if send_calls < 3:
+                    raise RuntimeError("bridge transient")
+
+            t.send.side_effect = send
+            return t
+
+        attempt_transports: list = []
+
+        async def factory():
+            t = make_transport()
+            attempt_transports.append(t)
+            return t
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        assert outcome["merged"] is True
+        # close_issue called EXACTLY ONCE despite 3 retry attempts.
+        assert mock_github.close_issue.call_count == 1
+        # transport.send called 3 times (once per attempt).
+        assert send_calls == 3
+
+    @pytest.mark.asyncio
+    async def test_retry_rebuilds_transport_on_each_attempt(
+        self
+    ) -> None:
+        """Codex P2: factory is invoked inside each retry attempt, so a
+        bridge that drops its socket between retries gets a fresh
+        connection on the next try — not a stale dead socket."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+        # close_issue fails twice, succeeds third.
+        close_calls = 0
+
+        async def flaky_close(repo, issue_number, comment):
+            nonlocal close_calls
+            close_calls += 1
+            if close_calls < 3:
+                raise RuntimeError("gh transient")
+
+        mock_github.close_issue.side_effect = flaky_close
+
+        factory_calls = 0
+        built_transports: list = []
+
+        async def factory():
+            nonlocal factory_calls
+            factory_calls += 1
+            t = AsyncMock()
+            built_transports.append(t)
+            return t
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            outcome = await pr_watch_task(
+                repo="owner/repo",
+                issue_number=77,
+                pr_url="",
+                pr_number=42,
+                session_id=None,
+                github=mock_github,
+                transport_factory=factory,
+                poll_interval=0,
+                timeout=5,
+            )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        assert outcome["merged"] is True
+        # One factory call per retry attempt (3 total).
+        assert factory_calls == 3
+        # Each built transport was closed at the end of its attempt.
+        for t in built_transports:
+            t.close.assert_awaited()
+
+    @pytest.mark.asyncio
     async def test_handle_merge_transient_failure_retries(self, caplog) -> None:
         """Codex P2: transient `gh issue close` failure at merge time must
         not abandon the post-merge cleanup. Retry with backoff; after

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -99,7 +99,11 @@ class TestPRWatchTask:
         events = [r.getMessage() for r in caplog.records]
         assert any("dev.pr.watching" in e for e in events)
         assert any("dev.pr.merged" in e for e in events)
-        mock_github.close_issue.assert_called_once()
+        # Post-merge is now split into comment + close + notify for
+        # idempotent retry. Happy path: each runs once.
+        mock_github.comment_on_issue.assert_called_once()
+        mock_github._run_gh.assert_called()
+        mock_transport.send.assert_called_once()
         mock_transport.close.assert_awaited_once()
 
     @pytest.mark.asyncio
@@ -248,9 +252,9 @@ class TestPRWatchTask:
     async def test_retry_does_not_duplicate_close_issue_comment(
         self, caplog
     ) -> None:
-        """Codex P2: if close_issue succeeds but transport.send fails,
-        the retry MUST NOT re-run close_issue and post a duplicate
-        "Closed by PR #N" comment on the issue."""
+        """Codex P2: if comment+close succeed but transport.send fails,
+        the retry MUST NOT re-post the "Closed by PR #N" comment or
+        re-run `gh issue close` — each side-effect runs at most once."""
         import logging
 
         from ctrlrelay.pipelines.post_merge import pr_watch_task
@@ -258,7 +262,7 @@ class TestPRWatchTask:
         mock_github = AsyncMock()
         mock_github.get_pr_state.return_value = {"state": "MERGED"}
 
-        # close_issue succeeds on first call; no retries of it.
+        # comment_on_issue + _run_gh succeed on first attempt.
         # transport.send raises twice, succeeds third.
         send_calls = 0
 
@@ -302,8 +306,13 @@ class TestPRWatchTask:
             pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
 
         assert outcome["merged"] is True
-        # close_issue called EXACTLY ONCE despite 3 retry attempts.
-        assert mock_github.close_issue.call_count == 1
+        # Each github-side step runs EXACTLY ONCE despite 3 retry attempts.
+        assert mock_github.comment_on_issue.call_count == 1
+        close_calls = [
+            c for c in mock_github._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == 1
         # transport.send called 3 times (once per attempt).
         assert send_calls == 3
 
@@ -318,16 +327,17 @@ class TestPRWatchTask:
 
         mock_github = AsyncMock()
         mock_github.get_pr_state.return_value = {"state": "MERGED"}
-        # close_issue fails twice, succeeds third.
-        close_calls = 0
+        # comment_on_issue fails twice, succeeds third — forces three
+        # retry attempts, each of which should rebuild the transport.
+        comment_calls = 0
 
-        async def flaky_close(repo, issue_number, comment):
-            nonlocal close_calls
-            close_calls += 1
-            if close_calls < 3:
+        async def flaky_comment(repo, issue_number, comment):
+            nonlocal comment_calls
+            comment_calls += 1
+            if comment_calls < 3:
                 raise RuntimeError("gh transient")
 
-        mock_github.close_issue.side_effect = flaky_close
+        mock_github.comment_on_issue.side_effect = flaky_comment
 
         factory_calls = 0
         built_transports: list = []
@@ -368,7 +378,9 @@ class TestPRWatchTask:
     async def test_handle_merge_transient_failure_retries(self, caplog) -> None:
         """Codex P2: transient `gh issue close` failure at merge time must
         not abandon the post-merge cleanup. Retry with backoff; after
-        a success, the issue is closed."""
+        a success, the issue is closed. With idempotent splitting, a
+        successful comment followed by a failing close should retry
+        ONLY the close step, not re-post the comment."""
         import logging
 
         from ctrlrelay.pipelines.post_merge import pr_watch_task
@@ -376,16 +388,18 @@ class TestPRWatchTask:
         mock_github = AsyncMock()
         mock_github.get_pr_state.return_value = {"state": "MERGED"}
 
-        # First two close_issue attempts fail; third succeeds.
-        close_calls = 0
+        # First two `gh issue close` attempts fail; third succeeds.
+        run_gh_close_calls = 0
 
-        async def flaky_close(repo, issue_number, comment):
-            nonlocal close_calls
-            close_calls += 1
-            if close_calls < 3:
-                raise RuntimeError("gh transient at close")
+        async def flaky_run_gh(*args, **_kw):
+            # Only the close subcommand is flaky.
+            if args[:2] == ("issue", "close"):
+                nonlocal run_gh_close_calls
+                run_gh_close_calls += 1
+                if run_gh_close_calls < 3:
+                    raise RuntimeError("gh transient at close")
 
-        mock_github.close_issue.side_effect = flaky_close
+        mock_github._run_gh.side_effect = flaky_run_gh
 
         async def factory():
             return AsyncMock()
@@ -411,8 +425,10 @@ class TestPRWatchTask:
             pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
 
         assert outcome["merged"] is True
-        # close_issue was retried until it succeeded.
-        assert close_calls == 3
+        # `gh issue close` was retried until it succeeded.
+        assert run_gh_close_calls == 3
+        # Comment is idempotent: posted exactly once even across retries.
+        assert mock_github.comment_on_issue.call_count == 1
         # At least two retry events logged (the first two failures).
         retry_events = [
             r for r in caplog.records
@@ -432,7 +448,9 @@ class TestPRWatchTask:
 
         mock_github = AsyncMock()
         mock_github.get_pr_state.return_value = {"state": "MERGED"}
-        mock_github.close_issue.side_effect = RuntimeError("permanent auth error")
+        # Permanent failure on `gh issue close` — comment succeeds once,
+        # then every close attempt fails.
+        mock_github._run_gh.side_effect = RuntimeError("permanent auth error")
 
         async def factory():
             return AsyncMock()
@@ -458,8 +476,13 @@ class TestPRWatchTask:
 
         # Task records the failure but doesn't crash.
         assert outcome["failed"] == "RuntimeError"
-        # All attempts consumed.
-        assert mock_github.close_issue.call_count == pm._HANDLE_MERGE_RETRY_ATTEMPTS
+        # All close attempts consumed (comment is idempotent, posted once).
+        assert mock_github.comment_on_issue.call_count == 1
+        close_calls = [
+            c for c in mock_github._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == pm._HANDLE_MERGE_RETRY_ATTEMPTS
         # Last event is dev.pr.watch_failed.
         assert any(
             "dev.pr.watch_failed" in r.getMessage() for r in caplog.records
@@ -497,4 +520,9 @@ class TestPRWatchTask:
             for r in caplog.records
         )
         # Merge detection still closed the issue even without transport.
-        mock_github.close_issue.assert_called_once()
+        mock_github.comment_on_issue.assert_called_once()
+        close_calls = [
+            c for c in mock_github._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == 1

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -58,6 +58,15 @@ class TestPostMergeHandler:
 class TestPRWatchTask:
     """Cover the background-safe wrapper the poller uses (#55)."""
 
+    def test_default_timeout_covers_typical_review_cycle(self) -> None:
+        """Codex P2: review cycles commonly exceed 24h. Default must not
+        abandon watchers before a normal merge lands."""
+        from ctrlrelay.pipelines.post_merge import DEFAULT_PR_WATCH_TIMEOUT
+
+        # 7 days in seconds; anything shorter risks silent timeouts on
+        # normal review lag.
+        assert DEFAULT_PR_WATCH_TIMEOUT >= 7 * 24 * 60 * 60
+
     @pytest.mark.asyncio
     async def test_merged_logs_event_and_closes_issue(self, caplog) -> None:
         from ctrlrelay.pipelines.post_merge import pr_watch_task

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -489,6 +489,64 @@ class TestPRWatchTask:
         )
 
     @pytest.mark.asyncio
+    async def test_factory_returning_none_is_clean_no_retry(
+        self, caplog
+    ) -> None:
+        """Codex P2: a factory that returns None legitimately (e.g.
+        file_mock transport or Telegram socket absent) means "no
+        notification channel configured". The retry loop MUST NOT
+        treat that as a failure — every merge would otherwise pay full
+        retry backoff and report outcome["failed"] on non-Telegram
+        setups."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        factory_calls = 0
+
+        async def factory():
+            nonlocal factory_calls
+            factory_calls += 1
+            return None  # no notification channel configured
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        # Clean success: merged + closed, no failure, no retry churn.
+        assert outcome["merged"] is True
+        assert outcome["failed"] is None
+        assert factory_calls == 1
+        mock_github.comment_on_issue.assert_called_once()
+        close_calls = [
+            c for c in mock_github._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == 1
+        # No retry events fired.
+        retry_events = [
+            r for r in caplog.records
+            if "dev.pr.handle_merge_retry" in r.getMessage()
+        ]
+        assert retry_events == []
+
+    @pytest.mark.asyncio
     async def test_transient_transport_factory_failure_retries_and_recovers(
         self, caplog
     ) -> None:

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -489,40 +489,120 @@ class TestPRWatchTask:
         )
 
     @pytest.mark.asyncio
-    async def test_transport_factory_failure_is_non_fatal(self, caplog) -> None:
-        """If the transport factory raises, we log and proceed with
-        transport=None — the merge detection itself must not depend on
-        the notification channel being up."""
+    async def test_transient_transport_factory_failure_retries_and_recovers(
+        self, caplog
+    ) -> None:
+        """Codex P2: a transient bridge outage right at merge time must
+        not permanently drop the notification. The factory is retried
+        on each attempt, and once it recovers the notification lands."""
         from ctrlrelay.pipelines.post_merge import pr_watch_task
 
         mock_github = AsyncMock()
         mock_github.get_pr_state.return_value = {"state": "MERGED"}
 
-        async def factory():
-            raise RuntimeError("bridge socket missing")
+        factory_calls = 0
+        built: list = []
 
-        with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
-            outcome = await pr_watch_task(
-                repo="owner/repo",
-                issue_number=77,
-                pr_url="",
-                pr_number=42,
-                session_id=None,
-                github=mock_github,
-                transport_factory=factory,
-                poll_interval=0,
-                timeout=5,
-            )
+        async def factory():
+            nonlocal factory_calls
+            factory_calls += 1
+            if factory_calls < 3:
+                raise RuntimeError("bridge socket missing")
+            t = AsyncMock()
+            built.append(t)
+            return t
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
 
         assert outcome["merged"] is True
-        assert any(
-            "dev.pr.watch_transport_failed" in r.getMessage()
-            for r in caplog.records
-        )
-        # Merge detection still closed the issue even without transport.
+        assert outcome["failed"] is None
+        # Comment + close stayed idempotent across the retry loop.
         mock_github.comment_on_issue.assert_called_once()
         close_calls = [
             c for c in mock_github._run_gh.call_args_list
             if c.args[:2] == ("issue", "close")
         ]
         assert len(close_calls) == 1
+        # Factory was retried until it recovered.
+        assert factory_calls == 3
+        # The recovered transport received the notification.
+        assert len(built) == 1
+        built[0].send.assert_awaited_once()
+        # Transient failures were surfaced as structured events.
+        failed_events = [
+            r for r in caplog.records
+            if "dev.pr.watch_transport_failed" in r.getMessage()
+        ]
+        assert len(failed_events) == 2
+
+    @pytest.mark.asyncio
+    async def test_persistent_transport_factory_failure_closes_issue_and_reports_failure(
+        self, caplog
+    ) -> None:
+        """If the factory NEVER recovers, the merge is still detected,
+        the issue is still closed exactly once (comment + gh close),
+        and the task surfaces the failure in outcome["failed"] so an
+        operator can see the notification was lost."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            raise RuntimeError("bridge permanently gone")
+
+        import ctrlrelay.pipelines.post_merge as pm
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            with caplog.at_level(logging.INFO, logger="ctrlrelay.pipelines.post_merge"):
+                outcome = await pr_watch_task(
+                    repo="owner/repo",
+                    issue_number=77,
+                    pr_url="",
+                    pr_number=42,
+                    session_id=None,
+                    github=mock_github,
+                    transport_factory=factory,
+                    poll_interval=0,
+                    timeout=5,
+                )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+
+        # Merge WAS detected — record it even though cleanup degraded.
+        assert outcome["merged"] is True
+        # But the task surfaces the notification failure.
+        assert outcome["failed"] == "RuntimeError"
+        # Issue closed exactly once — idempotency held across retries.
+        mock_github.comment_on_issue.assert_called_once()
+        close_calls = [
+            c for c in mock_github._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == 1
+        # dev.pr.merged fired (merge was real) AND dev.pr.watch_failed
+        # fired at the end (notification path exhausted retries).
+        assert any(
+            "dev.pr.merged" in r.getMessage() for r in caplog.records
+        )
+        assert any(
+            "dev.pr.watch_failed" in r.getMessage() for r in caplog.records
+        )

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -177,6 +177,74 @@ class TestPRWatchTask:
         )
 
     @pytest.mark.asyncio
+    async def test_transport_factory_called_only_after_merge_detected(self) -> None:
+        """Codex P2: lazy transport. A 7-day watch would build the
+        transport at start and hold it; bridge restarts during that
+        window would leave us with a stale connection when the merge
+        finally lands. The factory must be invoked only AFTER
+        check_merged returns True, right before handle_merge."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        factory_call_count = 0
+
+        async def factory():
+            nonlocal factory_call_count
+            factory_call_count += 1
+            return AsyncMock()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo",
+            issue_number=77,
+            pr_url="",
+            pr_number=42,
+            session_id=None,
+            github=mock_github,
+            transport_factory=factory,
+            poll_interval=0,
+            timeout=5,
+        )
+
+        assert outcome["merged"] is True
+        # Factory invoked exactly once and only because the watcher
+        # reached the merged branch.
+        assert factory_call_count == 1
+
+    @pytest.mark.asyncio
+    async def test_transport_factory_not_called_on_timeout(self) -> None:
+        """No merge → no notification → factory must not be invoked.
+        Avoids creating an unnecessary transport connection for a PR
+        that sat in review and was eventually abandoned."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "OPEN"}
+
+        factory_call_count = 0
+
+        async def factory():
+            nonlocal factory_call_count
+            factory_call_count += 1
+            return AsyncMock()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo",
+            issue_number=77,
+            pr_url="",
+            pr_number=42,
+            session_id=None,
+            github=mock_github,
+            transport_factory=factory,
+            poll_interval=0,
+            timeout=0,
+        )
+
+        assert outcome["timed_out"] is True
+        assert factory_call_count == 0
+
+    @pytest.mark.asyncio
     async def test_transport_factory_failure_is_non_fatal(self, caplog) -> None:
         """If the transport factory raises, we log and proceed with
         transport=None — the merge detection itself must not depend on

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -102,6 +102,79 @@ class TestPRWatcher:
         assert len(transient) == 2
 
     @pytest.mark.asyncio
+    async def test_wait_for_merge_abandons_after_consecutive_failure_cap(
+        self, caplog
+    ) -> None:
+        """Codex P2: permanent gh failures (expired auth, 404, missing
+        binary) surface as "transient-looking" exceptions. Without a
+        cap, they'd sleep+retry for the full 7-day window. Fail fast
+        after _TRANSIENT_FAILURE_CAP consecutive errors."""
+        import logging
+
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_watcher import (
+            _TRANSIENT_FAILURE_CAP,
+            PRWatcher,
+        )
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = GitHubError(
+            "gh failed: GraphQL: Could not resolve to a Repository (permanent)"
+        )
+
+        watcher = PRWatcher(github=mock_github, poll_interval=0)
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.pr_watcher"):
+            with pytest.raises(GitHubError):
+                await watcher.wait_for_merge(
+                    "owner/repo", 42, timeout=60 * 60 * 24 * 7,
+                )
+
+        # Exactly _TRANSIENT_FAILURE_CAP failures, then abandon.
+        assert mock_github.get_pr_state.call_count == _TRANSIENT_FAILURE_CAP
+        # Each transient_error logs the current count.
+        transient = [
+            r for r in caplog.records
+            if "pr_watch.transient_error" in r.getMessage()
+        ]
+        assert len(transient) == _TRANSIENT_FAILURE_CAP
+        # And the final abandon event fired.
+        assert any(
+            "pr_watch.abandoned_after_too_many_errors" in r.getMessage()
+            for r in caplog.records
+        )
+
+    @pytest.mark.asyncio
+    async def test_wait_for_merge_failure_counter_resets_on_success(
+        self
+    ) -> None:
+        """A successful poll must reset the consecutive-failure counter —
+        a flaky network that recovers shouldn't eventually trip the
+        abandon path just from accumulated intermittent errors."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_watcher import PRWatcher
+
+        calls = 0
+
+        async def flaky_intermittent(*_a, **_kw):
+            nonlocal calls
+            calls += 1
+            # Pattern: every 3rd call fails. Over a long watch that's
+            # many failures in aggregate but never 10 in a row.
+            if calls % 3 == 0:
+                raise GitHubError("gh transient")
+            if calls >= 30:
+                return {"state": "MERGED"}
+            return {"state": "OPEN"}
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = flaky_intermittent
+
+        watcher = PRWatcher(github=mock_github, poll_interval=0)
+        result = await watcher.wait_for_merge("owner/repo", 42, timeout=60)
+        assert result is True
+
+    @pytest.mark.asyncio
     async def test_wait_for_merge_propagates_cancellation(self) -> None:
         """Shutdown must not be swallowed by the transient-error guard."""
         import asyncio

--- a/tests/test_pr_watcher.py
+++ b/tests/test_pr_watcher.py
@@ -58,3 +58,62 @@ class TestPRWatcher:
 
         assert result is False
         assert mock_github.get_pr_state.call_count >= 2
+
+    @pytest.mark.asyncio
+    async def test_wait_for_merge_survives_transient_gh_errors(
+        self, caplog
+    ) -> None:
+        """Codex P1: a single `gh pr view` failure during a multi-day
+        watch MUST NOT abort the loop. Transient errors are logged and
+        the loop keeps polling."""
+        import logging
+
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_watcher import PRWatcher
+
+        calls = 0
+
+        async def flaky_then_merged(*_a, **_kw):
+            nonlocal calls
+            calls += 1
+            if calls == 1:
+                raise GitHubError("gh failed: HTTP 503")
+            if calls == 2:
+                raise TimeoutError("gh timed out")
+            return {"state": "MERGED"}
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = flaky_then_merged
+
+        watcher = PRWatcher(github=mock_github, poll_interval=0)
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.pr_watcher"):
+            result = await watcher.wait_for_merge(
+                "owner/repo", 42, timeout=60,
+            )
+
+        assert result is True
+        assert calls == 3
+        # Two transient errors logged as structured events.
+        transient = [
+            r for r in caplog.records
+            if "pr_watch.transient_error" in r.getMessage()
+        ]
+        assert len(transient) == 2
+
+    @pytest.mark.asyncio
+    async def test_wait_for_merge_propagates_cancellation(self) -> None:
+        """Shutdown must not be swallowed by the transient-error guard."""
+        import asyncio
+
+        from ctrlrelay.core.pr_watcher import PRWatcher
+
+        async def always_cancel(*_a, **_kw):
+            raise asyncio.CancelledError()
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = always_cancel
+
+        watcher = PRWatcher(github=mock_github, poll_interval=0)
+        with pytest.raises(asyncio.CancelledError):
+            await watcher.wait_for_merge("owner/repo", 42, timeout=60)


### PR DESCRIPTION
Closes #55. Final Phase 4 gate (per orchestrator-spec): *"Self-assign a real issue, watch the full flow through to PR-opened, answer a question via Telegram, see the PR land."* — the "see the PR land" part now actually fires.

## The missing link
Before this PR, `PRWatcher` + `watch_and_handle_merge` existed with tests but no production caller. When the reviewer merged the PR:
- Issue stayed open on GitHub (manual close required)
- No Telegram notification
- No log of merge state

## Fix
`handle_issue` in the poller now spawns a fire-and-forget `pr_watch_task` for every dispatched issue that yields a `pr_number` (including BLOCKED/FAILED terminal paths where the PR is still live). Tasks tracked in a set; cleaned up via `done_callback` on completion and cancelled on poller shutdown.

Extracted `pr_watch_task` as a module-level function in `pipelines/post_merge.py` — builds its own transport via injected factory (the `handle_issue` transport is closed on exit), emits structured events at every boundary, returns an outcome dict for testability.

## Resilience hardening (7 rounds of codex review)
- **7-day default watch window** (was 24h) — covers typical review lag without keeping zombie tasks around.
- **Transient `gh` errors** (`GitHubError` / `TimeoutError` / `OSError`) no longer abort the loop; counter resets on success, gives up after 60 consecutive (~1h at default poll).
- **Cancellation** always propagates (`asyncio.CancelledError` re-raised).
- **`gh` subprocess reaped on timeout** so a 7-day loop can't leak children.
- **`_handle_merge_with_retry`**: split into three idempotent flags (`comment_posted`, `issue_closed`, `notification_sent`) so a retry after partial failure never posts a duplicate "Closed by PR #N" comment or re-runs `gh issue close`.
- **Transport rebuilt per retry** — a bridge restart between attempts doesn't trap us on a dead socket.
- **Factory raising = transient** (retry with backoff). **Factory returning None** = no channel configured (clean return, no retry churn). `_watch_transport_factory` raises `FileNotFoundError` when the Telegram socket is missing so a restarting bridge gets retried.
- **Watcher spawned before result notification** in `handle_issue` so a transient `transport.send` blip can't suppress the merge watcher.

## Structured events
| Event | When |
|---|---|
| `dev.pr.watching` | watcher starts |
| `dev.pr.merged` | merge detected |
| `dev.pr.watch_timeout` | 7d with no merge |
| `dev.pr.watch_cancelled` | poller shutdown |
| `dev.pr.watch_failed` | post-merge handler exhausted retries |
| `dev.pr.watch_transport_failed` | factory raised on one attempt (non-fatal) |
| `dev.pr.handle_merge_retry` | retry with partial-step flags |
| `pr_watch.transient_error` | single poll failure, counter incremented |
| `pr_watch.abandoned_after_too_many_errors` | 60 consecutive failures, giving up |

## Test plan
- [x] `pytest` — 257 passed.
- [x] `ruff check` — clean.
- [ ] Smoke: assign myself an issue, poller opens PR, merge it → within ~60s bridge posts "Issue #N closed after PR #M merged" to Telegram; issue closed on GitHub.

## Known follow-ups (out of scope)
- **#57 — Persist in-flight PR watchers across poller restarts.** Currently watchers live in memory; a poller restart cancels them and the issue is already marked seen in `poller_state.json`, so a merge after the restart won't auto-close. Needs `StateDB` schema + rehydration-on-start, filed as a Phase 5 follow-up.
- `/deploy-verify` handoff — needs design on the per-repo verify contract.