### PR TITLE
fix(cli): daemonize poller/bridge start by default; add --foreground

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **`ctrlrelay bridge start` / `ctrlrelay poller start` now daemonize by
+  default** and return to the shell immediately, writing a PID file so
+  `status`/`stop` can find the process. This matches the normal "start a
+  service" UX expectation and fixes the previous behavior where the
+  terminal would block until Ctrl+C.
+- Added `--foreground` / `-F` flag to both commands. Under a process
+  supervisor (launchd, systemd) pass this so the supervisor — not the
+  CLI's own fork — owns the long-lived PID. Existing supervisor unit
+  files must be updated to include this flag; examples in
+  `docs/operations.md` are revised.
+- `ctrlrelay bridge status` and `poller status` rely on the PID file as
+  before. If a supervisor runs the old (pre-`--foreground`) command, no
+  PID file is written and `status` now prints a migration hint instead
+  of a misleading "not running".
+- The deprecated `--daemon` / `-d` flag has been removed; the daemonize
+  behavior is now the default. Scripts using `--daemon` will need to
+  drop the flag.
+
 ## [0.1.3] - 2026-04-18
 
 Reliability pass on the poller + retry flow, plus CI gating. No runtime

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   behavior is now the default. Scripts using `--daemon` will need to
   drop the flag.
 
+### Security
+
+- **Telegram bot token is no longer passed via subprocess argv.** Before
+  this release, daemon-mode `bridge start` invoked the child with
+  `--bot-token <TOKEN>` on the command line, exposing the secret to any
+  local user or tool that reads `ps` / `/proc/*/cmdline`. The daemon
+  parent now tells the child which env var to read (`--bot-token-env`)
+  and relies on the inherited process environment instead. Since
+  daemonize mode is now the default, this would have leaked the token on
+  every vanilla `ctrlrelay bridge start` — rotate your bot token if you
+  ran a pre-release `main` build of this branch in a shared environment.
+
+### Fixed
+
+- **Daemon `start` no longer reports success for a crashed child.** The
+  parent now waits briefly for the child after `subprocess.Popen` and
+  reports failure if it exited (e.g. `gh` missing, env var unset,
+  crash-on-import). Previously the parent printed `Poller started
+  (PID N)` even when the child died within milliseconds.
+- **Foreground `poller start` now handles `SIGTERM` cleanly.** Under
+  launchd/systemd, service stop sends SIGTERM; the prior code only
+  caught `KeyboardInterrupt`, so the outer `finally` that unlinks
+  `poller.pid` and closes the state DB never ran. A recycled PID could
+  then be mistaken for a live poller by the next `start`/`status`. The
+  foreground path now installs SIGTERM/SIGINT handlers, cancels the poll
+  loop task, and lets cleanup run.
+
 ## [0.1.3] - 2026-04-18
 
 Reliability pass on the poller + retry flow, plus CI gating. No runtime

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -87,14 +87,16 @@ See [Telegram bridge]({{ '/bridge/' | relative_url }}) for the full setup walkth
 ### `bridge start`
 
 ```bash
-ctrlrelay bridge start [-c PATH] [-d|--daemon]
+ctrlrelay bridge start [-c PATH] [-F|--foreground]
 ```
 
 Starts the bridge listening on `transport.telegram.socket_path`. Reads the
 bot token from the env var named in `transport.telegram.bot_token_env`
-(default `CTRLRELAY_TELEGRAM_TOKEN`). Without `--daemon` runs in the
-foreground; with `--daemon` spawns a detached process and writes a PID file
-alongside the socket.
+(default `CTRLRELAY_TELEGRAM_TOKEN`). Daemonizes by default — forks a
+detached process, writes a PID file alongside the socket, and returns to
+the shell. Pass `--foreground` / `-F` under launchd/systemd or when
+debugging interactively; the process runs in the foreground and still
+writes its PID file so `ctrlrelay bridge status` works.
 
 Fails if `transport.type` is not `telegram`, the token env var is unset, or a
 PID file already exists for a live process.
@@ -113,8 +115,11 @@ Reads the PID file and sends `SIGTERM`.
 ctrlrelay bridge status [-c PATH]
 ```
 
-Reports running / not-running. Detects orphan socket files (socket exists but
-the process is gone).
+Reports running / not-running by consulting the PID file. If the PID file is
+missing but the socket exists (e.g. the bridge was started by an older
+launchd plist that pre-dates the PID-file change), exits non-zero with a
+hint to restart the bridge — a restart on the new version will regenerate
+the PID file and let `status` work.
 
 ### `bridge test`
 
@@ -161,13 +166,13 @@ any repo failed.
 ### `poller start`
 
 ```bash
-ctrlrelay poller start [-c PATH] [-d|--daemon] [-i SECONDS]
+ctrlrelay poller start [-c PATH] [-F|--foreground] [-i SECONDS]
 ```
 
 | Flag | Default | Description |
 |---|---|---|
 | `--interval` / `-i` | `300` | Seconds between polls. |
-| `--daemon` / `-d` | off | Background mode (writes PID file). |
+| `--foreground` / `-F` | off | Run in the foreground. Default is to daemonize (fork + return to shell). Pass this under launchd/systemd. |
 | `--config` / `-c` | `config/orchestrator.yaml` | Config path. |
 
 Polls each configured repo for issues assigned to your GitHub user (resolved

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -23,6 +23,11 @@ ctrlrelay ships with no service files — you write your own. The two daemons:
 
 Both should restart on failure and on login.
 
+`ctrlrelay bridge start` and `ctrlrelay poller start` daemonize by default
+(fork, write a PID file, return to the shell). Under a process supervisor
+(launchd, systemd) pass `--foreground` so the supervisor can track the PID
+and restart on failure — the unit examples below already do this.
+
 ### macOS — launchd
 
 Save plist files under `~/Library/LaunchAgents/`. Use the **absolute** path to
@@ -43,6 +48,7 @@ Save plist files under `~/Library/LaunchAgents/`. Use the **absolute** path to
         <string>/opt/homebrew/bin/ctrlrelay</string>
         <string>bridge</string>
         <string>start</string>
+        <string>--foreground</string>
     </array>
     <key>EnvironmentVariables</key>
     <dict>
@@ -81,6 +87,7 @@ Save plist files under `~/Library/LaunchAgents/`. Use the **absolute** path to
         <string>/opt/homebrew/bin/ctrlrelay</string>
         <string>poller</string>
         <string>start</string>
+        <string>--foreground</string>
         <string>--interval</string>
         <string>300</string>
     </array>
@@ -137,7 +144,7 @@ After=network-online.target
 Type=simple
 WorkingDirectory=%h/Projects/ctrlrelay
 Environment=CTRLRELAY_TELEGRAM_TOKEN=your-bot-token-here
-ExecStart=%h/.local/bin/ctrlrelay bridge start
+ExecStart=%h/.local/bin/ctrlrelay bridge start --foreground
 Restart=always
 RestartSec=5
 StandardOutput=append:%h/.ctrlrelay/logs/bridge.log
@@ -158,7 +165,7 @@ After=network-online.target ctrlrelay-bridge.service
 Type=simple
 WorkingDirectory=%h/Projects/ctrlrelay
 Environment=CTRLRELAY_TELEGRAM_TOKEN=your-bot-token-here
-ExecStart=%h/.local/bin/ctrlrelay poller start --interval 300
+ExecStart=%h/.local/bin/ctrlrelay poller start --foreground --interval 300
 Restart=always
 RestartSec=5
 StandardOutput=append:%h/.ctrlrelay/logs/poller.log

--- a/src/ctrlrelay/bridge/__main__.py
+++ b/src/ctrlrelay/bridge/__main__.py
@@ -4,7 +4,9 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import os
 import signal
+import sys
 from pathlib import Path
 
 from ctrlrelay.bridge.server import BridgeServer
@@ -13,14 +15,26 @@ from ctrlrelay.bridge.server import BridgeServer
 def main() -> None:
     parser = argparse.ArgumentParser(description="ctrlrelay Telegram bridge")
     parser.add_argument("--socket-path", required=True, help="Unix socket path")
-    parser.add_argument("--bot-token", required=True, help="Telegram bot token")
+    parser.add_argument(
+        "--bot-token-env",
+        default="CTRLRELAY_TELEGRAM_TOKEN",
+        help="Environment variable holding the Telegram bot token",
+    )
     parser.add_argument("--chat-id", type=int, required=True, help="Telegram chat ID")
     args = parser.parse_args()
+
+    bot_token = os.environ.get(args.bot_token_env)
+    if not bot_token:
+        print(
+            f"error: bot token env var '{args.bot_token_env}' is unset",
+            file=sys.stderr,
+        )
+        sys.exit(2)
 
     socket_path = Path(args.socket_path)
     server = BridgeServer(
         socket_path=socket_path,
-        bot_token=args.bot_token,
+        bot_token=bot_token,
         chat_id=args.chat_id,
     )
 

--- a/src/ctrlrelay/bridge/__main__.py
+++ b/src/ctrlrelay/bridge/__main__.py
@@ -41,14 +41,24 @@ def main() -> None:
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
 
+    async def _run_server() -> None:
+        # Wrap start() in a finally that awaits stop() so the loop can't
+        # close before _telegram.close() and the socket unlink complete.
+        try:
+            await server.start()
+        finally:
+            await server.stop()
+
+    main_task = loop.create_task(_run_server())
+
     def handle_signal(sig: int) -> None:
-        loop.create_task(server.stop())
+        main_task.cancel()
 
     for sig in (signal.SIGTERM, signal.SIGINT):
         loop.add_signal_handler(sig, handle_signal, sig)
 
     try:
-        loop.run_until_complete(server.start())
+        loop.run_until_complete(main_task)
     except asyncio.CancelledError:
         pass
     finally:

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -286,6 +286,7 @@ def bridge_start(
 
     if foreground:
         import asyncio
+        import signal
 
         from ctrlrelay.bridge import BridgeServer
 
@@ -299,11 +300,22 @@ def bridge_start(
             chat_id=telegram_config.chat_id,
         )
 
+        loop = asyncio.new_event_loop()
         try:
-            asyncio.run(server.start())
-        except KeyboardInterrupt:
-            console.print("\n[yellow]Shutting down...[/yellow]")
+            asyncio.set_event_loop(loop)
+
+            def _handle_stop(sig: int) -> None:
+                loop.create_task(server.stop())
+
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, _handle_stop, sig)
+
+            try:
+                loop.run_until_complete(server.start())
+            except asyncio.CancelledError:
+                pass
         finally:
+            loop.close()
             pid_file.unlink(missing_ok=True)
     else:
         cmd = [
@@ -726,9 +738,14 @@ def poller_start(
     if pid_file.exists():
         try:
             pid = int(pid_file.read_text().strip())
-            os.kill(pid, 0)
-            console.print(f"[yellow]Poller already running (PID {pid})[/yellow]")
-            raise typer.Exit(1)
+            if pid == os.getpid():
+                # The daemon parent wrote our own PID here before spawning us
+                # as the `--foreground` child. Don't treat it as a conflict.
+                pass
+            else:
+                os.kill(pid, 0)
+                console.print(f"[yellow]Poller already running (PID {pid})[/yellow]")
+                raise typer.Exit(1)
         except (ProcessLookupError, ValueError):
             pid_file.unlink(missing_ok=True)
     pid_file.parent.mkdir(parents=True, exist_ok=True)

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -318,14 +318,16 @@ def bridge_start(
             loop.close()
             pid_file.unlink(missing_ok=True)
     else:
+        # Pass the token via environment, never argv. Putting it on the command
+        # line would expose it to anyone who can read `ps` / /proc/*/cmdline.
         cmd = [
             sys.executable,
             "-m",
             "ctrlrelay.bridge",
             "--socket-path",
             str(socket_path),
-            "--bot-token",
-            bot_token,
+            "--bot-token-env",
+            telegram_config.bot_token_env,
             "--chat-id",
             str(telegram_config.chat_id),
         ]
@@ -335,8 +337,17 @@ def bridge_start(
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
-        pid_file.write_text(str(proc.pid))
-        console.print(f"[green]Bridge started (PID {proc.pid})[/green]")
+        try:
+            proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            pid_file.write_text(str(proc.pid))
+            console.print(f"[green]Bridge started (PID {proc.pid})[/green]")
+        else:
+            console.print(
+                f"[red]Bridge failed to start[/red] "
+                f"(child exited with code {proc.returncode})"
+            )
+            raise typer.Exit(1)
 
 
 @bridge_app.command("stop")
@@ -725,6 +736,7 @@ def poller_start(
     """
     import asyncio
     import os
+    import signal
     import subprocess
     import sys
 
@@ -769,8 +781,17 @@ def poller_start(
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
-        pid_file.write_text(str(proc.pid))
-        console.print(f"[green]Poller started (PID {proc.pid})[/green]")
+        try:
+            proc.wait(timeout=1.0)
+        except subprocess.TimeoutExpired:
+            pid_file.write_text(str(proc.pid))
+            console.print(f"[green]Poller started (PID {proc.pid})[/green]")
+        else:
+            console.print(
+                f"[red]Poller failed to start[/red] "
+                f"(child exited with code {proc.returncode})"
+            )
+            raise typer.Exit(1)
         return
 
     pid_file.write_text(str(os.getpid()))
@@ -991,11 +1012,23 @@ def poller_start(
                         t.cancel()
                     await asyncio.gather(*list(pr_watch_tasks), return_exceptions=True)
 
+        loop = asyncio.new_event_loop()
         try:
-            asyncio.run(_main())
-        except KeyboardInterrupt:
-            console.print("\n[yellow]Poller stopped.[/yellow]")
+            asyncio.set_event_loop(loop)
+            main_task = loop.create_task(_main())
+
+            def _handle_stop(sig: int) -> None:
+                main_task.cancel()
+
+            for sig in (signal.SIGTERM, signal.SIGINT):
+                loop.add_signal_handler(sig, _handle_stop, sig)
+
+            try:
+                loop.run_until_complete(main_task)
+            except asyncio.CancelledError:
+                console.print("\n[yellow]Poller stopped.[/yellow]")
         finally:
+            loop.close()
             state_db.close()
     finally:
         pid_file.unlink(missing_ok=True)

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -314,14 +314,26 @@ def bridge_start(
         try:
             asyncio.set_event_loop(loop)
 
+            async def _run_server() -> None:
+                # Wrap start() in a finally that awaits stop() so the loop
+                # can't close before _telegram.close() and the socket unlink
+                # have actually completed. Scheduling stop() as a bare task
+                # in the signal handler would not guarantee that ordering.
+                try:
+                    await server.start()
+                finally:
+                    await server.stop()
+
+            main_task = loop.create_task(_run_server())
+
             def _handle_stop(sig: int) -> None:
-                loop.create_task(server.stop())
+                main_task.cancel()
 
             for sig in (signal.SIGTERM, signal.SIGINT):
                 loop.add_signal_handler(sig, _handle_stop, sig)
 
             try:
-                loop.run_until_complete(server.start())
+                loop.run_until_complete(main_task)
             except asyncio.CancelledError:
                 pass
         finally:
@@ -355,13 +367,19 @@ def bridge_start(
             proc.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
             console.print(f"[green]Bridge started (PID {proc.pid})[/green]")
-        else:
-            pid_file.unlink(missing_ok=True)
+            return
+        # Child exited within 1s. Zero = clean no-op; non-zero = crash.
+        pid_file.unlink(missing_ok=True)
+        if proc.returncode == 0:
             console.print(
-                f"[red]Bridge failed to start[/red] "
-                f"(child exited with code {proc.returncode})"
+                "[yellow]Bridge exited immediately with no work to do.[/yellow]"
             )
-            raise typer.Exit(1)
+            return
+        console.print(
+            f"[red]Bridge failed to start[/red] "
+            f"(child exited with code {proc.returncode})"
+        )
+        raise typer.Exit(1)
 
 
 @bridge_app.command("stop")
@@ -803,14 +821,20 @@ def poller_start(
             proc.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
             console.print(f"[green]Poller started (PID {proc.pid})[/green]")
-        else:
-            pid_file.unlink(missing_ok=True)
+            return
+        # Child exited. Zero = clean no-op (e.g. `repos: []`); non-zero = crash.
+        pid_file.unlink(missing_ok=True)
+        if proc.returncode == 0:
             console.print(
-                f"[red]Poller failed to start[/red] "
-                f"(child exited with code {proc.returncode})"
+                "[yellow]Poller exited immediately with no work to do "
+                "(check `repos:` in your config).[/yellow]"
             )
-            raise typer.Exit(1)
-        return
+            return
+        console.print(
+            f"[red]Poller failed to start[/red] "
+            f"(child exited with code {proc.returncode})"
+        )
+        raise typer.Exit(1)
 
     # Install SIGTERM/SIGINT handlers BEFORE any startup work so a supervisor
     # stop during `gh api user` / `seed_current()` still unwinds through the

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -231,14 +231,19 @@ def bridge_start(
         "-c",
         help="Path to orchestrator.yaml",
     ),
-    daemon: bool = typer.Option(
+    foreground: bool = typer.Option(
         False,
-        "--daemon",
-        "-d",
-        help="Run in background",
+        "--foreground",
+        "-F",
+        help="Run in the foreground (for launchd/systemd/debugging). Default is to daemonize.",
     ),
 ) -> None:
-    """Start the Telegram bridge."""
+    """Start the Telegram bridge.
+
+    Daemonizes by default so the terminal returns to you. Pass --foreground
+    under a process supervisor (launchd Type=simple, systemd Type=simple) or
+    when debugging interactively.
+    """
     import os
     import subprocess
     import sys
@@ -277,7 +282,30 @@ def bridge_start(
         console.print(f"[red]Bot token not found.[/red] Set {env_var} environment variable.")
         raise typer.Exit(1)
 
-    if daemon:
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
+
+    if foreground:
+        import asyncio
+
+        from ctrlrelay.bridge import BridgeServer
+
+        pid_file.write_text(str(os.getpid()))
+        console.print(f"Starting bridge on {socket_path}")
+        console.print("Press Ctrl+C to stop")
+
+        server = BridgeServer(
+            socket_path=socket_path,
+            bot_token=bot_token,
+            chat_id=telegram_config.chat_id,
+        )
+
+        try:
+            asyncio.run(server.start())
+        except KeyboardInterrupt:
+            console.print("\n[yellow]Shutting down...[/yellow]")
+        finally:
+            pid_file.unlink(missing_ok=True)
+    else:
         cmd = [
             sys.executable,
             "-m",
@@ -297,24 +325,6 @@ def bridge_start(
         )
         pid_file.write_text(str(proc.pid))
         console.print(f"[green]Bridge started (PID {proc.pid})[/green]")
-    else:
-        import asyncio
-
-        from ctrlrelay.bridge import BridgeServer
-
-        console.print(f"Starting bridge on {socket_path}")
-        console.print("Press Ctrl+C to stop")
-
-        server = BridgeServer(
-            socket_path=socket_path,
-            bot_token=bot_token,
-            chat_id=telegram_config.chat_id,
-        )
-
-        try:
-            asyncio.run(server.start())
-        except KeyboardInterrupt:
-            console.print("\n[yellow]Shutting down...[/yellow]")
 
 
 @bridge_app.command("stop")
@@ -376,10 +386,16 @@ def bridge_status(
             pass
 
     if socket_path.exists():
-        console.print("[yellow]Socket exists but no running process[/yellow]")
+        console.print("[yellow]Socket exists but no PID file[/yellow]")
+        console.print(
+            "[dim]The bridge may be running under a supervisor that pre-dates "
+            "the PID-file change — restart it to refresh state.[/dim]"
+        )
         console.print(f"Socket: {socket_path}")
-    else:
-        console.print("[dim]Bridge not running[/dim]")
+        raise typer.Exit(1)
+
+    console.print("[dim]Bridge not running[/dim]")
+    raise typer.Exit(1)
 
 
 @bridge_app.command("test")
@@ -676,11 +692,11 @@ def poller_start(
         "-c",
         help="Path to orchestrator.yaml",
     ),
-    daemon: bool = typer.Option(
+    foreground: bool = typer.Option(
         False,
-        "--daemon",
-        "-d",
-        help="Run in background",
+        "--foreground",
+        "-F",
+        help="Run in the foreground (for launchd/systemd/debugging). Default is to daemonize.",
     ),
     interval: int = typer.Option(
         300,
@@ -689,8 +705,14 @@ def poller_start(
         help="Polling interval in seconds",
     ),
 ) -> None:
-    """Start the issue poller."""
+    """Start the issue poller.
+
+    Daemonizes by default so the terminal returns to you. Pass --foreground
+    under a process supervisor (launchd Type=simple, systemd Type=simple) or
+    when debugging interactively.
+    """
     import asyncio
+    import os
     import subprocess
     import sys
 
@@ -700,18 +722,18 @@ def poller_start(
         console.print(f"[red]Error loading config:[/red] {e}")
         raise typer.Exit(1)
 
-    if daemon:
-        pid_file = _get_poller_pid_file(config_path)
-        if pid_file.exists():
-            import os
-            try:
-                pid = int(pid_file.read_text().strip())
-                os.kill(pid, 0)
-                console.print(f"[yellow]Poller already running (PID {pid})[/yellow]")
-                raise typer.Exit(1)
-            except (ProcessLookupError, ValueError):
-                pid_file.unlink(missing_ok=True)
+    pid_file = _get_poller_pid_file(config_path)
+    if pid_file.exists():
+        try:
+            pid = int(pid_file.read_text().strip())
+            os.kill(pid, 0)
+            console.print(f"[yellow]Poller already running (PID {pid})[/yellow]")
+            raise typer.Exit(1)
+        except (ProcessLookupError, ValueError):
+            pid_file.unlink(missing_ok=True)
+    pid_file.parent.mkdir(parents=True, exist_ok=True)
 
+    if not foreground:
         cmd = [
             sys.executable,
             "-m",
@@ -722,6 +744,7 @@ def poller_start(
             config_path,
             "--interval",
             str(interval),
+            "--foreground",
         ]
         proc = subprocess.Popen(
             cmd,
@@ -729,10 +752,12 @@ def poller_start(
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
-        pid_file.parent.mkdir(parents=True, exist_ok=True)
         pid_file.write_text(str(proc.pid))
         console.print(f"[green]Poller started (PID {proc.pid})[/green]")
-    else:
+        return
+
+    pid_file.write_text(str(os.getpid()))
+    try:
         from ctrlrelay.core.dispatcher import ClaudeDispatcher
         from ctrlrelay.core.github import GitHubCLI
         from ctrlrelay.core.poller import IssuePoller, run_poll_loop
@@ -955,6 +980,8 @@ def poller_start(
             console.print("\n[yellow]Poller stopped.[/yellow]")
         finally:
             state_db.close()
+    finally:
+        pid_file.unlink(missing_ok=True)
 
 
 @poller_app.command("stop")

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -290,6 +290,16 @@ def bridge_start(
 
         from ctrlrelay.bridge import BridgeServer
 
+        # Install early SIGTERM/SIGINT handlers so a supervisor stop between
+        # now and loop.add_signal_handler below still runs the `finally`
+        # that unlinks the PID file. loop.add_signal_handler replaces them
+        # once the asyncio loop is running.
+        def _raise_systemexit_on_signal(sig: int, _frame: object) -> None:
+            raise SystemExit(0)
+
+        for _sig in (signal.SIGTERM, signal.SIGINT):
+            signal.signal(_sig, _raise_systemexit_on_signal)
+
         pid_file.write_text(str(os.getpid()))
         console.print(f"Starting bridge on {socket_path}")
         console.print("Press Ctrl+C to stop")
@@ -337,12 +347,16 @@ def bridge_start(
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
+        # Claim the PID file BEFORE the liveness probe; a second concurrent
+        # `bridge start` in the 1-second window would otherwise see no PID
+        # file, spawn its own child, and both would rebind the shared socket.
+        pid_file.write_text(str(proc.pid))
         try:
             proc.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
-            pid_file.write_text(str(proc.pid))
             console.print(f"[green]Bridge started (PID {proc.pid})[/green]")
         else:
+            pid_file.unlink(missing_ok=True)
             console.print(
                 f"[red]Bridge failed to start[/red] "
                 f"(child exited with code {proc.returncode})"
@@ -781,18 +795,34 @@ def poller_start(
             stderr=subprocess.DEVNULL,
             start_new_session=True,
         )
+        # Claim the PID file BEFORE the liveness probe; otherwise a second
+        # concurrent `start` in the 1-second window would see no PID file and
+        # spawn a duplicate poller.
+        pid_file.write_text(str(proc.pid))
         try:
             proc.wait(timeout=1.0)
         except subprocess.TimeoutExpired:
-            pid_file.write_text(str(proc.pid))
             console.print(f"[green]Poller started (PID {proc.pid})[/green]")
         else:
+            pid_file.unlink(missing_ok=True)
             console.print(
                 f"[red]Poller failed to start[/red] "
                 f"(child exited with code {proc.returncode})"
             )
             raise typer.Exit(1)
         return
+
+    # Install SIGTERM/SIGINT handlers BEFORE any startup work so a supervisor
+    # stop during `gh api user` / `seed_current()` still unwinds through the
+    # `finally` that unlinks poller.pid. Converting the signal into SystemExit
+    # lets Python's normal unwind run `finally` blocks. Once the asyncio loop
+    # is up below, `loop.add_signal_handler` overrides these to drive a
+    # graceful cancel of the poll loop.
+    def _raise_systemexit_on_signal(sig: int, _frame: object) -> None:
+        raise SystemExit(0)
+
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        signal.signal(sig, _raise_systemexit_on_signal)
 
     pid_file.write_text(str(os.getpid()))
     try:

--- a/tests/test_cli_dev.py
+++ b/tests/test_cli_dev.py
@@ -7,8 +7,9 @@ from typer.testing import CliRunner
 runner = CliRunner()
 
 # Typer's Rich-backed help renderer injects ANSI escapes (bold/underline/color)
-# around CLI flag names, which can split "--daemon" into "-" + bold + "-daemon"
-# in the raw output. Strip escape sequences before asserting on substrings.
+# around CLI flag names, which can split "--foreground" into "-" + bold +
+# "-foreground" in the raw output. Strip escape sequences before asserting on
+# substrings.
 _ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
 
 
@@ -46,7 +47,7 @@ class TestPollerCommands:
         result = runner.invoke(app, ["poller", "start", "--help"])
 
         assert result.exit_code == 0
-        assert "--daemon" in _plain(result.output)
+        assert "--foreground" in _plain(result.output)
 
     def test_poller_status(self) -> None:
         """Should show poller status."""

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -215,3 +215,39 @@ class TestPollerStartForeground:
         result = runner.invoke(app, ["poller", "start", "--help"])
         assert result.exit_code == 0
         assert "--foreground" in _plain(result.output)
+
+    def test_foreground_tolerates_its_own_pid_in_pidfile(
+        self, telegram_config: Path, tmp_path: Path
+    ) -> None:
+        """Regression for codex P1: when the daemon parent writes the child's
+        PID to the file before spawning `--foreground`, the child must NOT
+        treat its own PID as a conflict and exit."""
+        pid_file = tmp_path / "poller.pid"
+        pid_file.write_text(str(os.getpid()))
+
+        # Force the body of the foreground branch to short-circuit before it
+        # tries to talk to GitHub or start polling; we only care that the
+        # self-PID guard doesn't fire.
+        with patch(
+            "ctrlrelay.core.github._find_gh",
+            side_effect=RuntimeError("short-circuit"),
+        ) as find_gh:
+            result = runner.invoke(
+                app,
+                [
+                    "poller",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+
+        assert "already running" not in result.output.lower(), (
+            "foreground child must not treat its own PID in the file as a "
+            "conflict (codex [P1] regression)"
+        )
+        assert find_gh.called, (
+            "execution must proceed past the PID-file guard into the poll "
+            "setup path"
+        )

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import signal
 import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
@@ -227,6 +228,56 @@ class TestBridgeStartDaemonFailFast:
         assert "failed to start" in result.output.lower()
 
 
+class TestBridgeStartDaemonNoStartupRace:
+    """Regression for codex [P2]: PID file must be claimed BEFORE the 1-second
+    liveness probe, so a second concurrent `start` can't spawn a duplicate."""
+
+    def test_pid_file_claimed_before_liveness_probe(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        probe_seen_pid = {"value": None}
+        pid_file = telegram_config.parent / "ctrlrelay.pid"
+
+        def wait_with_assert(timeout: float) -> int:
+            probe_seen_pid["value"] = (
+                pid_file.read_text().strip() if pid_file.exists() else None
+            )
+            raise subprocess.TimeoutExpired(cmd="<test>", timeout=timeout)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 99001
+        fake_proc.wait.side_effect = wait_with_assert
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert probe_seen_pid["value"] == str(fake_proc.pid), (
+            "PID file must be written before proc.wait() so a concurrent "
+            "`start` in the probe window sees the claim"
+        )
+
+    def test_pid_file_removed_if_child_crashes_on_start(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        pid_file = telegram_config.parent / "ctrlrelay.pid"
+        fake_proc = MagicMock()
+        fake_proc.pid = 99002
+        fake_proc.wait.return_value = 5
+        fake_proc.returncode = 5
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code != 0
+        assert not pid_file.exists(), (
+            "PID file must be removed when the child crashed on start, so "
+            "subsequent `start` is not blocked by a stale claim"
+        )
+
+
 class TestBridgeStartAlreadyRunning:
     def test_refuses_when_live_pid_in_file(
         self, telegram_config: Path, bot_token_env: None, tmp_path: Path
@@ -284,6 +335,86 @@ class TestPollerStartDaemonFailFast:
 
         assert result.exit_code != 0
         assert "failed to start" in result.output.lower()
+
+
+class TestPollerStartDaemonNoStartupRace:
+    """Regression for codex [P1]: PID file must be claimed BEFORE the 1-second
+    liveness probe, so a second concurrent `start` can't spawn a duplicate
+    poller (which would process the same issue twice)."""
+
+    def test_pid_file_claimed_before_liveness_probe(
+        self, telegram_config: Path, tmp_path: Path
+    ) -> None:
+        pid_file = tmp_path / "poller.pid"
+        probe_seen_pid = {"value": None}
+
+        def wait_with_assert(timeout: float) -> int:
+            probe_seen_pid["value"] = (
+                pid_file.read_text().strip() if pid_file.exists() else None
+            )
+            raise subprocess.TimeoutExpired(cmd="<test>", timeout=timeout)
+
+        fake_proc = MagicMock()
+        fake_proc.pid = 55001
+        fake_proc.wait.side_effect = wait_with_assert
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["poller", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert probe_seen_pid["value"] == str(fake_proc.pid), (
+            "PID file must be written before proc.wait() so a concurrent "
+            "`start` in the probe window sees the claim"
+        )
+
+
+class TestPollerStartForegroundSigtermEarly:
+    """Regression for codex [P2]: SIGTERM handlers must be installed BEFORE
+    `_find_gh`/`gh api user`/`seed_current()`, otherwise a supervisor stop
+    during startup bypasses the `finally` that unlinks poller.pid."""
+
+    def test_sigterm_installed_before_startup_work(
+        self, telegram_config: Path
+    ) -> None:
+        call_order: list[str] = []
+
+        def record_signal(sig: int, handler: object) -> None:
+            if sig == signal.SIGTERM:
+                call_order.append("signal.signal(SIGTERM)")
+
+        def record_find_gh() -> None:
+            call_order.append("_find_gh")
+            raise RuntimeError("short-circuit")
+
+        with (
+            patch("signal.signal", side_effect=record_signal),
+            patch("ctrlrelay.core.github._find_gh", side_effect=record_find_gh),
+        ):
+            runner.invoke(
+                app,
+                [
+                    "poller",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+
+        assert "signal.signal(SIGTERM)" in call_order, (
+            "poller foreground must install a SIGTERM handler"
+        )
+        assert "_find_gh" in call_order, (
+            "test invariant: startup must reach _find_gh"
+        )
+        assert call_order.index("signal.signal(SIGTERM)") < call_order.index(
+            "_find_gh"
+        ), (
+            "SIGTERM handler must be installed BEFORE _find_gh() / the rest "
+            "of the startup work, so a supervisor stop during startup still "
+            "runs the PID-file cleanup finally"
+        )
 
 
 class TestPollerStartForeground:

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import os
+import re
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -13,6 +14,15 @@ from typer.testing import CliRunner
 from ctrlrelay.cli import app
 
 runner = CliRunner()
+
+# Typer/Rich injects ANSI escapes around flag names (e.g. "--foreground" becomes
+# "-" + ESC[...m + "-foreground" + ESC[0m), so substring matches on the raw
+# output fail under a TTY-emulating runner. Strip escapes before asserting.
+_ANSI_RE = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(text: str) -> str:
+    return _ANSI_RE.sub("", text)
 
 
 @pytest.fixture
@@ -204,4 +214,4 @@ class TestPollerStartForeground:
     def test_foreground_flag_accepted(self) -> None:
         result = runner.invoke(app, ["poller", "start", "--help"])
         assert result.exit_code == 0
-        assert "--foreground" in result.output
+        assert "--foreground" in _plain(result.output)

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -132,7 +132,11 @@ class TestBridgeStartForeground:
         async def _fake_start():
             return None
 
+        async def _fake_stop():
+            return None
+
         server_instance.start = _fake_start
+        server_instance.stop = _fake_stop
         with (
             patch("subprocess.Popen") as popen,
             patch(
@@ -162,7 +166,11 @@ class TestBridgeStartForeground:
         async def _fake_start():
             return None
 
+        async def _fake_stop():
+            return None
+
         server_instance.start = _fake_start
+        server_instance.stop = _fake_stop
         with patch("ctrlrelay.bridge.BridgeServer", return_value=server_instance):
             result = runner.invoke(
                 app,
@@ -179,6 +187,73 @@ class TestBridgeStartForeground:
         pid_file = telegram_config.parent / "ctrlrelay.pid"
         assert not pid_file.exists(), (
             "foreground mode must clean up the PID file on graceful exit"
+        )
+
+
+class TestBridgeForegroundShutdownOrdering:
+    """Regression for codex [P2]: when the foreground bridge is cancelled
+    (SIGTERM / SIGINT), server.stop() must actually run and complete before
+    the event loop closes. Fire-and-forget `create_task(server.stop())` from
+    the signal handler does NOT guarantee that ordering."""
+
+    def test_stop_completes_when_start_is_cancelled(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        import asyncio
+
+        calls: list[str] = []
+
+        async def fake_start():
+            calls.append("start")
+            try:
+                await asyncio.sleep(60)
+            except asyncio.CancelledError:
+                calls.append("start_cancelled")
+                raise
+
+        async def fake_stop():
+            await asyncio.sleep(0)
+            calls.append("stop_done")
+
+        server_instance = MagicMock()
+        server_instance.start = fake_start
+        server_instance.stop = fake_stop
+
+        # Monkeypatch asyncio.new_event_loop to inject a cancellation just
+        # after run_until_complete starts, simulating a SIGTERM arrival.
+        orig_new_event_loop = asyncio.new_event_loop
+
+        def tracked_new_loop():
+            loop = orig_new_event_loop()
+            orig_rc = loop.run_until_complete
+
+            def rc_with_cancel(task):
+                loop.call_soon(task.cancel)
+                return orig_rc(task)
+
+            loop.run_until_complete = rc_with_cancel
+            return loop
+
+        with (
+            patch("ctrlrelay.bridge.BridgeServer", return_value=server_instance),
+            patch("asyncio.new_event_loop", side_effect=tracked_new_loop),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "bridge",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "start_cancelled" in calls, "start() must observe the cancel"
+        assert "stop_done" in calls, (
+            "server.stop() must run to completion before the loop closes "
+            "(codex [P2] regression — stale socket would otherwise remain)"
         )
 
 
@@ -212,7 +287,7 @@ class TestBridgeStartDaemonFailFast:
     (bad env, crash-on-import, missing dep), the parent must report failure
     rather than printing 'Bridge started (PID N)' and dropping the user."""
 
-    def test_reports_failure_when_child_exits_immediately(
+    def test_reports_failure_when_child_exits_nonzero(
         self, telegram_config: Path, bot_token_env: None
     ) -> None:
         fake_proc = MagicMock()
@@ -226,6 +301,23 @@ class TestBridgeStartDaemonFailFast:
 
         assert result.exit_code != 0
         assert "failed to start" in result.output.lower()
+
+    def test_clean_child_exit_zero_is_not_a_failure(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        """Regression for codex [P3]: exit 0 must not be classified as a
+        crash (symmetry with the poller fix)."""
+        fake_proc = MagicMock()
+        fake_proc.pid = 2719
+        fake_proc.wait.return_value = 0
+        fake_proc.returncode = 0
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "failed to start" not in result.output.lower()
 
 
 class TestBridgeStartDaemonNoStartupRace:
@@ -321,7 +413,7 @@ class TestPollerStartDaemonFailFast:
     """Regression for codex [P2]: if the spawned child exits immediately
     (missing gh, bad config, etc), the parent must NOT claim success."""
 
-    def test_reports_failure_when_child_exits_immediately(
+    def test_reports_failure_when_child_exits_nonzero(
         self, telegram_config: Path
     ) -> None:
         fake_proc = MagicMock()
@@ -335,6 +427,23 @@ class TestPollerStartDaemonFailFast:
 
         assert result.exit_code != 0
         assert "failed to start" in result.output.lower()
+
+    def test_clean_child_exit_zero_is_not_a_failure(
+        self, telegram_config: Path
+    ) -> None:
+        """Regression for codex [P3]: if the child exits 0 within 1s (e.g.
+        `repos: []` no-op), the parent must NOT report 'failed to start'."""
+        fake_proc = MagicMock()
+        fake_proc.pid = 4343
+        fake_proc.wait.return_value = 0
+        fake_proc.returncode = 0
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["poller", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert "failed to start" not in result.output.lower()
 
 
 class TestPollerStartDaemonNoStartupRace:

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import os
 import re
+import subprocess
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -14,6 +15,18 @@ from typer.testing import CliRunner
 from ctrlrelay.cli import app
 
 runner = CliRunner()
+
+
+def _make_live_proc(pid: int) -> MagicMock:
+    """Build a subprocess.Popen mock that behaves like a still-running child.
+
+    `proc.wait(timeout=...)` must raise TimeoutExpired so the daemon-start
+    path interprets the child as healthy.
+    """
+    proc = MagicMock()
+    proc.pid = pid
+    proc.wait.side_effect = subprocess.TimeoutExpired(cmd="<test>", timeout=1.0)
+    return proc
 
 # Typer/Rich injects ANSI escapes around flag names (e.g. "--foreground" becomes
 # "-" + ESC[...m + "-foreground" + ESC[0m), so substring matches on the raw
@@ -72,8 +85,7 @@ class TestBridgeStartDefault:
     def test_default_spawns_subprocess_and_returns(
         self, telegram_config: Path, bot_token_env: None, tmp_path: Path
     ) -> None:
-        fake_proc = MagicMock()
-        fake_proc.pid = 99999
+        fake_proc = _make_live_proc(99999)
         with patch("subprocess.Popen", return_value=fake_proc) as popen:
             result = runner.invoke(
                 app, ["bridge", "start", "--config", str(telegram_config)]
@@ -93,8 +105,7 @@ class TestBridgeStartDefault:
         self, telegram_config: Path, bot_token_env: None
     ) -> None:
         """Default path must NOT import/run BridgeServer in-process."""
-        fake_proc = MagicMock()
-        fake_proc.pid = 42
+        fake_proc = _make_live_proc(42)
         with (
             patch("subprocess.Popen", return_value=fake_proc),
             patch("ctrlrelay.bridge.BridgeServer") as server_cls,
@@ -170,6 +181,52 @@ class TestBridgeStartForeground:
         )
 
 
+class TestBridgeStartDaemonSecrets:
+    """Regression for codex [P1]: the Telegram bot token must NEVER appear
+    in the daemon child's argv (readable via `ps` / /proc/*/cmdline)."""
+
+    def test_bot_token_not_in_argv(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        fake_proc = _make_live_proc(31415)
+        with patch("subprocess.Popen", return_value=fake_proc) as popen:
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        cmd = popen.call_args[0][0]
+        assert "dummy-token" not in cmd, (
+            "bot token leaked into daemon argv — would be visible to anyone "
+            "reading `ps`. Pass the env-var name and inherit the process env "
+            "instead."
+        )
+        assert "--bot-token-env" in cmd, (
+            "daemon should tell the child which env var holds the token"
+        )
+
+
+class TestBridgeStartDaemonFailFast:
+    """Regression for codex [P2]: if the spawned child exits immediately
+    (bad env, crash-on-import, missing dep), the parent must report failure
+    rather than printing 'Bridge started (PID N)' and dropping the user."""
+
+    def test_reports_failure_when_child_exits_immediately(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        fake_proc = MagicMock()
+        fake_proc.pid = 2718
+        fake_proc.wait.return_value = 1  # child exited with code 1
+        fake_proc.returncode = 1
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code != 0
+        assert "failed to start" in result.output.lower()
+
+
 class TestBridgeStartAlreadyRunning:
     def test_refuses_when_live_pid_in_file(
         self, telegram_config: Path, bot_token_env: None, tmp_path: Path
@@ -193,8 +250,7 @@ class TestPollerStartDefault:
     def test_default_spawns_child_with_foreground_flag(
         self, telegram_config: Path, tmp_path: Path
     ) -> None:
-        fake_proc = MagicMock()
-        fake_proc.pid = 77777
+        fake_proc = _make_live_proc(77777)
         with patch("subprocess.Popen", return_value=fake_proc) as popen:
             result = runner.invoke(
                 app, ["poller", "start", "--config", str(telegram_config)]
@@ -208,6 +264,26 @@ class TestPollerStartDefault:
             "instead of recursively daemonizing"
         )
         assert f"PID {fake_proc.pid}" in result.output
+
+
+class TestPollerStartDaemonFailFast:
+    """Regression for codex [P2]: if the spawned child exits immediately
+    (missing gh, bad config, etc), the parent must NOT claim success."""
+
+    def test_reports_failure_when_child_exits_immediately(
+        self, telegram_config: Path
+    ) -> None:
+        fake_proc = MagicMock()
+        fake_proc.pid = 4242
+        fake_proc.wait.return_value = 2  # e.g. gh not found
+        fake_proc.returncode = 2
+        with patch("subprocess.Popen", return_value=fake_proc):
+            result = runner.invoke(
+                app, ["poller", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code != 0
+        assert "failed to start" in result.output.lower()
 
 
 class TestPollerStartForeground:

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -1,0 +1,207 @@
+"""Tests for the `bridge start` / `poller start` daemonize-by-default behavior."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from ctrlrelay.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def telegram_config(tmp_path: Path) -> Path:
+    socket_path = tmp_path / "ctrlrelay.sock"
+    config = {
+        "version": "1",
+        "node_id": "test-node",
+        "timezone": "UTC",
+        "paths": {
+            "state_db": str(tmp_path / "state.db"),
+            "worktrees": str(tmp_path / "worktrees"),
+            "bare_repos": str(tmp_path / "repos"),
+            "contexts": str(tmp_path / "contexts"),
+            "skills": str(tmp_path / "skills"),
+        },
+        "claude": {
+            "binary": "claude",
+            "default_timeout_seconds": 1800,
+            "output_format": "json",
+        },
+        "transport": {
+            "type": "telegram",
+            "telegram": {
+                "socket_path": str(socket_path),
+                "bot_token_env": "CTRLRELAY_TEST_TOKEN",
+                "chat_id": 12345,
+            },
+        },
+        "dashboard": {"enabled": False},
+        "repos": [],
+    }
+    config_path = tmp_path / "orchestrator.yaml"
+    config_path.write_text(yaml.dump(config))
+    return config_path
+
+
+@pytest.fixture
+def bot_token_env():
+    with patch.dict(os.environ, {"CTRLRELAY_TEST_TOKEN": "dummy-token"}):
+        yield
+
+
+class TestBridgeStartDefault:
+    """`ctrlrelay bridge start` (no flag) must daemonize, not block."""
+
+    def test_default_spawns_subprocess_and_returns(
+        self, telegram_config: Path, bot_token_env: None, tmp_path: Path
+    ) -> None:
+        fake_proc = MagicMock()
+        fake_proc.pid = 99999
+        with patch("subprocess.Popen", return_value=fake_proc) as popen:
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert popen.called, "default invocation must spawn a detached subprocess"
+        _args, kwargs = popen.call_args
+        assert kwargs.get("start_new_session") is True
+        assert f"PID {fake_proc.pid}" in result.output
+
+        pid_file = Path(str(telegram_config.parent / "ctrlrelay.pid"))
+        assert pid_file.exists()
+        assert pid_file.read_text().strip() == str(fake_proc.pid)
+
+    def test_default_does_not_run_server_inline(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        """Default path must NOT import/run BridgeServer in-process."""
+        fake_proc = MagicMock()
+        fake_proc.pid = 42
+        with (
+            patch("subprocess.Popen", return_value=fake_proc),
+            patch("ctrlrelay.bridge.BridgeServer") as server_cls,
+        ):
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert not server_cls.called, (
+            "default path must NOT instantiate BridgeServer inline"
+        )
+
+
+class TestBridgeStartForeground:
+    """`--foreground` runs the server inline and writes our own PID to the file."""
+
+    def test_foreground_runs_server_inline(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        server_instance = MagicMock()
+
+        async def _fake_start():
+            return None
+
+        server_instance.start = _fake_start
+        with (
+            patch("subprocess.Popen") as popen,
+            patch(
+                "ctrlrelay.bridge.BridgeServer", return_value=server_instance
+            ) as server_cls,
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "bridge",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert not popen.called, "--foreground must NOT spawn a subprocess"
+        assert server_cls.called, "--foreground must run BridgeServer inline"
+
+    def test_foreground_cleans_up_pid_file_on_exit(
+        self, telegram_config: Path, bot_token_env: None
+    ) -> None:
+        server_instance = MagicMock()
+
+        async def _fake_start():
+            return None
+
+        server_instance.start = _fake_start
+        with patch("ctrlrelay.bridge.BridgeServer", return_value=server_instance):
+            result = runner.invoke(
+                app,
+                [
+                    "bridge",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+
+        assert result.exit_code == 0, result.output
+        pid_file = telegram_config.parent / "ctrlrelay.pid"
+        assert not pid_file.exists(), (
+            "foreground mode must clean up the PID file on graceful exit"
+        )
+
+
+class TestBridgeStartAlreadyRunning:
+    def test_refuses_when_live_pid_in_file(
+        self, telegram_config: Path, bot_token_env: None, tmp_path: Path
+    ) -> None:
+        pid_file = tmp_path / "ctrlrelay.pid"
+        pid_file.write_text(str(os.getpid()))
+
+        with patch("subprocess.Popen") as popen:
+            result = runner.invoke(
+                app, ["bridge", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code != 0
+        assert "already running" in result.output.lower()
+        assert not popen.called
+
+
+class TestPollerStartDefault:
+    """`ctrlrelay poller start` (no flag) must daemonize and pass --foreground to its child."""
+
+    def test_default_spawns_child_with_foreground_flag(
+        self, telegram_config: Path, tmp_path: Path
+    ) -> None:
+        fake_proc = MagicMock()
+        fake_proc.pid = 77777
+        with patch("subprocess.Popen", return_value=fake_proc) as popen:
+            result = runner.invoke(
+                app, ["poller", "start", "--config", str(telegram_config)]
+            )
+
+        assert result.exit_code == 0, result.output
+        assert popen.called
+        cmd = popen.call_args[0][0]
+        assert "--foreground" in cmd, (
+            "parent must pass --foreground to the child so the child runs inline "
+            "instead of recursively daemonizing"
+        )
+        assert f"PID {fake_proc.pid}" in result.output
+
+
+class TestPollerStartForeground:
+    def test_foreground_flag_accepted(self) -> None:
+        result = runner.invoke(app, ["poller", "start", "--help"])
+        assert result.exit_code == 0
+        assert "--foreground" in result.output


### PR DESCRIPTION
## Summary

- `ctrlrelay poller start` and `ctrlrelay bridge start` now fork into the background and return to the shell by default, matching the usual "start a service" UX.
- New `--foreground` / `-F` flag for launchd/systemd supervisors and interactive debugging.
- PID file is now written in **both** modes, so `ctrlrelay bridge status` and `poller status` finally work for supervisor-started processes (fixes the "Socket exists but no running process" / "Poller not running" false negatives).

## Why

Previous default blocked the terminal. Launchd ran the commands without `--daemon` (as shown in our own docs/example plists), so no PID file was ever written — `status` couldn't see the live process. One root cause, both symptoms.

## Breaking change

The deprecated `--daemon` / `-d` flag is removed. Existing launchd plists and systemd units **must** be updated to pass `--foreground` so the supervisor keeps owning the process instead of the CLI's own fork exiting and triggering a restart loop. Example unit files in `docs/operations.md` are updated.

## Test plan

- [x] `uv run pytest` — 264 passed (incl. 7 new tests in `tests/test_cli_start.py`)
- [x] `uv run ruff check src tests` — clean
- [ ] After merge: upgrade local ctrlrelay, patch `~/Library/LaunchAgents/com.ainvirion.ctrlrelay-*.plist` to include `--foreground`, `launchctl bootout` + `launchctl bootstrap` both agents, verify `ctrlrelay bridge status` + `ctrlrelay poller status` now report the live PIDs.