### PR TITLE
chore(dev): rebrand issue-claim comment to 'CTRLRelay'

### DIFF
--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -24,7 +24,7 @@ DEFAULT_MAX_BLOCKED_ROUNDS = 5
 
 AGENT_CLAIM_MARKER = "<!-- ctrlrelay:claimed -->"
 AGENT_CLAIM_COMMENT = (
-    "🤖 Agent is working on this issue. A PR will be opened for review.\n\n"
+    "CTRLRelay is working on this issue. A PR will be opened for review.\n\n"
     f"{AGENT_CLAIM_MARKER}"
 )
 


### PR DESCRIPTION
## Summary

- One-line change: the claim comment on picked-up issues now starts with \`CTRLRelay\` instead of \`🤖 Agent\`, so the tool signs its own name.

## Test plan

- [x] \`uv run pytest tests/test_dev_pipeline.py tests/test_dev_integration.py\` — 23 passed
- [x] \`uv run ruff check src/ctrlrelay/pipelines/dev.py\` — clean
- [ ] After merge: restart launchd poller so the running process picks up the new string