### PR TITLE
chore(pypi): add publish workflow (Trusted Publishing) + README polish

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,67 @@
+name: Publish to PyPI
+
+# Publishes the built sdist + wheel to PyPI on every GitHub release.
+#
+# Uses PyPI Trusted Publishing (OIDC) — no API tokens stored as GitHub
+# secrets. The project must be registered on PyPI with a trusted
+# publisher pointing at this exact workflow:
+#
+#   Project:     ctrlrelay
+#   Owner:       AInvirion
+#   Repository:  ctrlrelay
+#   Workflow:    publish.yml
+#   Environment: pypi
+#
+# The `pypi` environment adds a manual approval gate — releases pause
+# at the "Publish" step until a repo maintainer approves, so a
+# compromised tag alone can't silently push to PyPI.
+
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: read
+
+jobs:
+  build:
+    name: Build sdist and wheel
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build
+        run: uv build
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: dist
+          path: dist/*
+          if-no-files-found: error
+
+  publish:
+    name: Publish to PyPI
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/ctrlrelay/
+    permissions:
+      id-token: write   # required for OIDC token exchange with PyPI
+
+    steps:
+      - name: Download built artifacts
+        uses: actions/download-artifact@v4
+        with:
+          name: dist
+          path: dist/
+
+      - name: Publish to PyPI (trusted publishing)
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/README.md
+++ b/README.md
@@ -1,23 +1,94 @@
 # ctrlrelay
 
-Local-first orchestrator that drives headless Claude Code (`claude -p`)
-across your GitHub repos. Watches for assigned issues, runs the dev pipeline
-in an isolated git worktree, opens a PR, and asks you on Telegram when it
-gets stuck.
+[![Tests and lint](https://github.com/AInvirion/ctrlrelay/actions/workflows/test.yml/badge.svg)](https://github.com/AInvirion/ctrlrelay/actions/workflows/test.yml)
+[![Build](https://github.com/AInvirion/ctrlrelay/actions/workflows/build.yml/badge.svg)](https://github.com/AInvirion/ctrlrelay/actions/workflows/build.yml)
+[![Python](https://img.shields.io/badge/python-3.12%20%7C%203.13%20%7C%203.14-blue)](https://pypi.org/project/ctrlrelay/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](LICENSE)
+
+Local-first orchestrator that drives headless Claude Code (`claude -p`) across
+your GitHub repos. Watches for assigned issues, runs a dev pipeline in an
+isolated git worktree, opens a PR, and asks you on Telegram when it gets stuck.
+
+---
+
+## Why
+
+Claude Code is great interactively. Running it across half a dozen repos
+without staring at a terminal is a different problem: who schedules the
+runs, who watches for new work, who hands you the "I'm blocked, what do
+you want?" question, who tracks the PR until it merges.
+
+`ctrlrelay` is a small daemon that does all of that on your laptop. It's
+local-first on purpose: no server, no queue, no multi-tenant anything. Your
+Claude subscription, your GitHub credentials, your repos, your machine.
+
+## Features
+
+- **Issue poller** — detects issues assigned to you across every configured
+  repo, spawns a Claude Code dev session in a dedicated git worktree, and
+  opens a PR.
+- **Telegram bridge** — when a session hits a blocking question, the bridge
+  relays it to you as a DM and resumes the session once you reply.
+- **PR watcher** — tracks the PR to merge and closes the loop with a
+  notification when your PR ships.
+- **In-process scheduler** (APScheduler) — runs periodic jobs inside the
+  poller daemon. The built-in `secops` job reviews Dependabot alerts and PRs
+  across every repo daily at 6am; cron expressions are standard 5-field with
+  proper Vixie semantics (Sun=0, DOM-OR-DOW, etc.).
+- **Checkpoint protocol** — Claude writes a structured state file at the
+  end of every session so the orchestrator knows whether it succeeded,
+  failed, or is blocked on input.
+- **Cross-platform supervision** — launchd (macOS) and systemd (Linux)
+  plist/unit examples in `docs/operations.md`. One codebase, identical
+  behavior.
+
+## How it works
+
+```
+             ┌───────────────┐
+             │  GitHub API   │
+             └───────┬───────┘
+                     │ (poll: issues assigned to me)
+             ┌───────▼───────┐         ┌──────────────┐
+             │ poller daemon │◄────────┤   APScheduler│
+             │  (launchd /   │         │ (secops cron)│
+             │   systemd)    │         └──────────────┘
+             └───┬───────┬───┘
+      new issue  │       │  blocked session
+                 │       │
+      ┌──────────▼──┐  ┌─▼───────────────────┐
+      │ dev pipeline│  │ Telegram bridge     │
+      │ in worktree │  │ (socket ↔ bot API)  │
+      │   Claude -p │  └──────────┬──────────┘
+      └──────┬──────┘             │
+             │ PR opened          │ DM you
+             ▼                    ▼
+      ┌────────────┐         ┌─────────┐
+      │ PR watcher │         │   You   │
+      └────────────┘         └─────────┘
+```
+
+Under the hood it's Python + `asyncio` + `sqlite` for state, shelling out to
+`claude -p` for the model work and `gh` for GitHub. No web server, no queue,
+no database dependency — just a launchd/systemd-supervised daemon.
 
 ## Install
 
-Requires Python 3.12+, the `claude` CLI, the `gh` CLI, and `git` 2.20+.
+Requires Python 3.12+, the [`claude` CLI][claude-cli], the [`gh` CLI][gh-cli], and `git` 2.20+.
+
+**From PyPI** (once published):
+
+```bash
+pip install ctrlrelay
+# or: uv pip install ctrlrelay
+```
+
+**From source** (current path while in alpha):
 
 ```bash
 git clone https://github.com/AInvirion/ctrlrelay.git
 cd ctrlrelay
-
-# With uv (recommended):
-uv pip install -e .
-
-# Or with pip:
-pip install -e .
+uv pip install -e .   # or: pip install -e .
 ```
 
 ## Quick start
@@ -32,23 +103,43 @@ ctrlrelay config validate
 # Run the dev pipeline against an issue you're assigned:
 ctrlrelay run dev --issue 42 --repo your-org/your-repo
 
-# Or start the poller to auto-process newly assigned issues:
-ctrlrelay poller start --interval 300
+# Or start the poller to auto-process newly assigned issues + run the
+# scheduled secops sweep daily at 6am:
+ctrlrelay poller start   # daemonizes; returns the terminal
+ctrlrelay poller status  # verify it's running
 ```
 
-For everything beyond this — the full config schema, Telegram setup, the
-checkpoint protocol, running as a launchd/systemd service, the architecture,
-and contributing — see the documentation site:
+Run as a supervised daemon (launchd on macOS / systemd on Linux) — see
+[operations docs][ops-docs].
 
-- [Getting started](https://ainvirion.github.io/ctrlrelay/getting-started/)
-- [Configuration](https://ainvirion.github.io/ctrlrelay/configuration/)
-- [Telegram bridge](https://ainvirion.github.io/ctrlrelay/bridge/)
-- [Feedback loop](https://ainvirion.github.io/ctrlrelay/feedback-loop/)
-- [CLI reference](https://ainvirion.github.io/ctrlrelay/cli/)
-- [Operations](https://ainvirion.github.io/ctrlrelay/operations/)
-- [Architecture](https://ainvirion.github.io/ctrlrelay/architecture/)
-- [Development](https://ainvirion.github.io/ctrlrelay/development/)
+## Documentation
+
+- [Getting started][docs-start]
+- [Configuration][docs-config]
+- [Telegram bridge][docs-bridge]
+- [Feedback loop][docs-feedback]
+- [CLI reference][docs-cli]
+- [Operations (launchd / systemd / scheduled jobs)][ops-docs]
+- [Architecture][docs-arch]
+- [Development][docs-dev]
+
+## Contributing
+
+Bug reports, PRs, and design discussion all welcome. Please read
+[`SECURITY.md`](SECURITY.md) before filing anything that looks like a
+vulnerability — use a private GitHub advisory instead.
 
 ## License
 
-MIT
+MIT — see [`LICENSE`](LICENSE).
+
+[claude-cli]: https://docs.anthropic.com/claude/docs/claude-cli
+[gh-cli]: https://cli.github.com/
+[docs-start]: https://ainvirion.github.io/ctrlrelay/getting-started/
+[docs-config]: https://ainvirion.github.io/ctrlrelay/configuration/
+[docs-bridge]: https://ainvirion.github.io/ctrlrelay/bridge/
+[docs-feedback]: https://ainvirion.github.io/ctrlrelay/feedback-loop/
+[docs-cli]: https://ainvirion.github.io/ctrlrelay/cli/
+[ops-docs]: https://ainvirion.github.io/ctrlrelay/operations/
+[docs-arch]: https://ainvirion.github.io/ctrlrelay/architecture/
+[docs-dev]: https://ainvirion.github.io/ctrlrelay/development/


### PR DESCRIPTION
## Summary

Part B of the open-source-release prep. Adds the machinery to actually push a GitHub release to PyPI, plus a README rewrite aimed at the PyPI landing page.

## What's in it

- **\`.github/workflows/publish.yml\`** — fires on \`release: published\`, uses PyPI OIDC Trusted Publishing (no API tokens stored). Two jobs: \`build\` (sdist + wheel), \`publish\` (gated by the \`pypi\` GitHub Actions environment for manual approval). A compromised tag alone can't silently push.
- **README** — new "Why", "Features", "How it works" ASCII diagram, CI / Python / License badges, plus the existing docs links. Install section now covers both \`pip install ctrlrelay\` (once published) and the from-source path.

## One-time setup (not in this repo)

After this merges, you'll need to:

1. Register the project name \`ctrlrelay\` on PyPI.
2. Under the project's "Trusted Publishers" tab on PyPI, add a GitHub publisher:
   - Owner: \`AInvirion\`
   - Repository: \`ctrlrelay\`
   - Workflow: \`publish.yml\`
   - Environment: \`pypi\`
3. In this repo's Settings → Environments, create an environment named \`pypi\` and add required reviewers (yourself) so the publish step pauses for approval.

After that, cutting a GitHub release on a \`vX.Y.Z\` tag auto-builds, waits for your approval, and publishes to PyPI.

## Test plan

- [x] \`uv run pytest\` — 325 passed
- [x] \`uv run ruff check src tests\` — clean
- [x] \`uv build\` locally — sdist + wheel both build
- [x] Wheel metadata inspected: Project-URL (Homepage/Documentation/Repository/Issues/Changelog), License-File: LICENSE, classifiers (Python 3.12/3.13/3.14, macOS + Linux) all present.
- [ ] After merge: complete the one-time PyPI setup above, then cut a \`v0.1.4\` GitHub release to test the publish flow live.