### PR TITLE
feat(agent): multi-agent config surface (claude -> agent, with type field)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Multi-agent config surface.** The top-level config section
+  renamed from `claude:` to `agent:` and gained a `type:` field
+  selecting which backend adapter the dispatcher uses. Today the
+  only implemented type is `"claude"`; `codex`, `opencode`, `hermes`,
+  `kiro`, etc. are planned. The new `AgentAdapter` protocol (in
+  `src/ctrlrelay/core/dispatcher.py`) defines the seam every backend
+  must satisfy, and `make_agent_dispatcher()` is the factory that
+  routes by `type`. Unknown types fail loudly at daemon startup
+  with a pointer to the adapter interface so a config typo doesn't
+  silently fall back to Claude.
+
+### Changed
+
+- **`claude:` config key is deprecated.** The legacy `claude:`
+  top-level YAML key is still accepted as an alias (with a
+  `DeprecationWarning` at load time), and the Python attribute
+  `config.claude` still works via a property that mirrors
+  `config.agent`. Both will be removed in a future release; rename
+  the key in your `orchestrator.yaml` at your convenience.
+
 ## [0.1.4] - 2026-04-20
 
 Big day: daemon UX, a security fix, and the scheduler finally lands. The

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -12,7 +12,12 @@ paths:
   contexts: "~/.ctrlrelay/contexts"
   skills: "~/.ctrlrelay/claude-config/skills"
 
-claude:
+# Headless coding agent. `type` selects the adapter (currently only
+# "claude" is implemented; other backends — codex, opencode, hermes,
+# kiro — are planned). Legacy `claude:` key is still accepted as an
+# alias for backwards compatibility but is deprecated.
+agent:
+  type: "claude"
   binary: "claude"
   default_timeout_seconds: 1800
   output_format: "json"

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -518,7 +518,7 @@ def run_secops(
     """Run secops pipeline on configured repos."""
     import asyncio
 
-    from ctrlrelay.core.dispatcher import ClaudeDispatcher
+    from ctrlrelay.core.dispatcher import make_agent_dispatcher
     from ctrlrelay.core.github import GitHubCLI
     from ctrlrelay.core.state import StateDB
     from ctrlrelay.core.worktree import WorktreeManager
@@ -545,10 +545,7 @@ def run_secops(
         return
 
     db = StateDB(config.paths.state_db)
-    dispatcher = ClaudeDispatcher(
-        claude_binary=config.claude.binary,
-        default_timeout=config.claude.default_timeout_seconds,
-    )
+    dispatcher = make_agent_dispatcher(config.agent)
     github = GitHubCLI()
     worktree = WorktreeManager(
         worktrees_dir=config.paths.worktrees,
@@ -624,7 +621,7 @@ def run_dev(
     """Run dev pipeline for a GitHub issue."""
     import asyncio
 
-    from ctrlrelay.core.dispatcher import ClaudeDispatcher
+    from ctrlrelay.core.dispatcher import make_agent_dispatcher
     from ctrlrelay.core.github import GitHubCLI
     from ctrlrelay.core.state import StateDB
     from ctrlrelay.core.worktree import WorktreeManager
@@ -660,10 +657,7 @@ def run_dev(
     branch_template = repo_config.dev_branch_template
 
     db = StateDB(config.paths.state_db)
-    dispatcher = ClaudeDispatcher(
-        claude_binary=config.claude.binary,
-        default_timeout=config.claude.default_timeout_seconds,
-    )
+    dispatcher = make_agent_dispatcher(config.agent)
     github = GitHubCLI()
     worktree = WorktreeManager(
         worktrees_dir=config.paths.worktrees,
@@ -850,7 +844,7 @@ def poller_start(
 
     pid_file.write_text(str(os.getpid()))
     try:
-        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+        from ctrlrelay.core.dispatcher import make_agent_dispatcher
         from ctrlrelay.core.github import GitHubCLI
         from ctrlrelay.core.poller import IssuePoller, run_poll_loop
         from ctrlrelay.core.scheduler import make_scheduler
@@ -920,10 +914,7 @@ def poller_start(
         # grace only catches up on fires that happened AFTER registration.
 
         state_db = StateDB(config.paths.state_db)
-        dispatcher = ClaudeDispatcher(
-            claude_binary=config.claude.binary,
-            default_timeout=config.claude.default_timeout_seconds,
-        )
+        dispatcher = make_agent_dispatcher(config.agent)
         worktree = WorktreeManager(
             worktrees_dir=config.paths.worktrees,
             bare_repos_dir=config.paths.bare_repos,

--- a/src/ctrlrelay/core/__init__.py
+++ b/src/ctrlrelay/core/__init__.py
@@ -15,7 +15,12 @@ from ctrlrelay.core.config import (
     RepoConfig,
     load_config,
 )
-from ctrlrelay.core.dispatcher import ClaudeDispatcher, SessionResult
+from ctrlrelay.core.dispatcher import (
+    AgentAdapter,
+    ClaudeDispatcher,
+    SessionResult,
+    make_agent_dispatcher,
+)
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.poller import IssuePoller
 from ctrlrelay.core.pr_verifier import PRVerifier, VerificationResult
@@ -27,7 +32,9 @@ __all__ = [
     "CheckpointError",
     "CheckpointState",
     "CheckpointStatus",
+    "AgentAdapter",
     "ClaudeDispatcher",
+    "make_agent_dispatcher",
     "Config",
     "ConfigError",
     "GitHubCLI",

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -42,12 +42,29 @@ class PathsConfig(BaseModel):
         return v
 
 
-class ClaudeConfig(BaseModel):
-    """Claude CLI configuration."""
+class AgentConfig(BaseModel):
+    """Headless coding-agent configuration.
 
+    ``type`` selects which adapter the dispatcher uses to talk to the
+    agent CLI. Today only ``claude`` is implemented; the field exists
+    so future adapters (e.g. ``codex``, ``opencode``, ``hermes``) can
+    be plugged in without a config schema change. The other fields
+    (``binary``, ``default_timeout_seconds``, ``output_format``) are
+    common across most CLI-driven agents; adapters that need agent-
+    specific knobs can add a nested sub-model later.
+    """
+
+    type: str = "claude"
     binary: str = "claude"
     default_timeout_seconds: int = 1800
     output_format: str = "json"
+
+
+# Backwards-compat alias. Older code and docs reference ``ClaudeConfig``;
+# keep the name importable but have it resolve to the renamed class so
+# `isinstance(cfg, ClaudeConfig)` and `ClaudeConfig(...)` still work.
+# Scheduled for removal once downstream repos migrate.
+ClaudeConfig = AgentConfig
 
 
 class TelegramConfig(BaseModel):
@@ -186,11 +203,40 @@ class Config(BaseModel):
     node_id: str
     timezone: str = "UTC"
     paths: PathsConfig
-    claude: ClaudeConfig = Field(default_factory=ClaudeConfig)
+    agent: AgentConfig = Field(default_factory=AgentConfig)
     transport: TransportConfig
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
     schedules: SchedulesConfig = Field(default_factory=SchedulesConfig)
     repos: list[RepoConfig] = Field(default_factory=list)
+
+    @model_validator(mode="before")
+    @classmethod
+    def migrate_claude_to_agent(cls, data: Any) -> Any:
+        """Accept the legacy ``claude:`` top-level key as an alias for
+        ``agent:``. Emits a ``DeprecationWarning`` so operators see the
+        migration hint in logs. Removed in a future release.
+
+        If both keys are present, ``agent`` wins and ``claude`` is
+        ignored (fail-loud would break supervised daemons; we prefer
+        silent win-on-new-name during the migration window)."""
+        if isinstance(data, dict) and "claude" in data and "agent" not in data:
+            import warnings
+            warnings.warn(
+                "config key 'claude:' is deprecated; rename to 'agent:'. "
+                "See https://github.com/AInvirion/ctrlrelay/blob/main/"
+                "CHANGELOG.md for the migration.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+            data["agent"] = data.pop("claude")
+        return data
+
+    @property
+    def claude(self) -> AgentConfig:
+        """Legacy attribute alias so callers still writing
+        ``config.claude.binary`` keep working. New code should prefer
+        ``config.agent.*``."""
+        return self.agent
 
     @field_validator("timezone")
     @classmethod

--- a/src/ctrlrelay/core/dispatcher.py
+++ b/src/ctrlrelay/core/dispatcher.py
@@ -1,4 +1,11 @@
-"""Claude subprocess dispatcher for ctrlrelay."""
+"""Headless coding-agent subprocess dispatcher for ctrlrelay.
+
+Today the only concrete adapter is :class:`ClaudeDispatcher` (wraps
+``claude -p``). The :func:`make_agent_dispatcher` factory is the seam
+where additional backends (Codex, OpenCode, Hermes, Kiro, …) will plug
+in: each adapter must expose the same async ``spawn_session`` shape
+so pipelines can stay agent-agnostic.
+"""
 
 from __future__ import annotations
 
@@ -7,8 +14,12 @@ import os
 import shutil
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import TYPE_CHECKING, Protocol
 
 from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus, read_checkpoint
+
+if TYPE_CHECKING:
+    from ctrlrelay.core.config import AgentConfig
 
 
 def _find_claude() -> str:
@@ -142,3 +153,50 @@ class ClaudeDispatcher:
             stdout=stdout.decode(),
             stderr=stderr.decode(),
         )
+
+
+class AgentAdapter(Protocol):
+    """Protocol every coding-agent adapter must satisfy.
+
+    An adapter is a thin wrapper over an agent CLI that handles:
+    spawning the subprocess, passing the prompt and state-file path,
+    enforcing the timeout, and translating the checkpoint JSON the
+    agent writes into a :class:`SessionResult`.
+
+    Pipelines (dev, secops) only ever interact with this protocol —
+    they never import concrete adapters — so adding a new backend
+    means implementing this and registering it in
+    :func:`make_agent_dispatcher`.
+    """
+
+    async def spawn_session(
+        self,
+        session_id: str,
+        prompt: str,
+        working_dir: Path,
+        state_file: Path,
+        timeout: int | None = None,
+        resume_session_id: str | None = None,
+    ) -> SessionResult:
+        ...
+
+
+def make_agent_dispatcher(agent_config: "AgentConfig") -> AgentAdapter:
+    """Build an adapter for the configured ``agent.type``.
+
+    Raises :class:`NotImplementedError` with a clear error message if
+    the configured type has no adapter — makes a typo surface loudly
+    at daemon startup instead of silently falling back to Claude.
+    """
+    t = agent_config.type
+    if t == "claude":
+        return ClaudeDispatcher(
+            claude_binary=agent_config.binary,
+            default_timeout=agent_config.default_timeout_seconds,
+        )
+    raise NotImplementedError(
+        f"agent.type={t!r} has no adapter yet. Implement one that "
+        "satisfies the AgentAdapter protocol in "
+        "src/ctrlrelay/core/dispatcher.py and register it here, then "
+        "open a PR. Supported today: 'claude'."
+    )

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -9,7 +9,7 @@ from pathlib import Path
 from typing import Any
 
 from ctrlrelay.core.checkpoint import CheckpointStatus
-from ctrlrelay.core.dispatcher import ClaudeDispatcher, SessionResult
+from ctrlrelay.core.dispatcher import AgentAdapter, SessionResult
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
 from ctrlrelay.core.pr_verifier import PRVerifier, VerificationResult
@@ -35,7 +35,7 @@ _logger = get_logger("pipeline.dev")
 class DevPipeline:
     """Dev pipeline for implementing issues and opening PRs."""
 
-    dispatcher: ClaudeDispatcher
+    dispatcher: AgentAdapter
     github: GitHubCLI
     worktree: WorktreeManager
     dashboard: DashboardClient | None
@@ -316,7 +316,7 @@ async def run_dev_issue(
     repo: str,
     issue_number: int,
     branch_template: str,
-    dispatcher: ClaudeDispatcher,
+    dispatcher: AgentAdapter,
     github: GitHubCLI,
     worktree: WorktreeManager,
     dashboard: DashboardClient | None,

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -10,7 +10,7 @@ from pathlib import Path
 from typing import Any
 
 from ctrlrelay.core.checkpoint import CheckpointStatus
-from ctrlrelay.core.dispatcher import ClaudeDispatcher, SessionResult
+from ctrlrelay.core.dispatcher import AgentAdapter, SessionResult
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
 from ctrlrelay.core.state import StateDB
@@ -26,7 +26,7 @@ _logger = get_logger("pipeline.secops")
 class SecopsPipeline:
     """Security operations pipeline for daily triage."""
 
-    dispatcher: ClaudeDispatcher
+    dispatcher: AgentAdapter
     github: GitHubCLI
     worktree: WorktreeManager
     dashboard: DashboardClient | None
@@ -167,7 +167,7 @@ printf '{{"version":"1","status":"FAILED","session_id":"{session_id}",'\
 
 async def run_secops_all(
     repos: list[Any],
-    dispatcher: ClaudeDispatcher,
+    dispatcher: AgentAdapter,
     github: GitHubCLI,
     worktree: WorktreeManager,
     dashboard: DashboardClient | None,

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -78,6 +78,92 @@ class TestSchedulesConfig:
             load_config(cfg_path)
 
 
+class TestAgentConfig:
+    """The `agent:` section replaces the legacy `claude:` section.
+    Schema must accept the new key, keep the old one as a deprecated
+    alias, and still expose `config.claude` as a property so existing
+    callers keep working."""
+
+    def test_agent_section_is_accepted(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        import yaml
+
+        sample_config_dict.pop("claude", None)
+        sample_config_dict["agent"] = {
+            "type": "claude",
+            "binary": "/opt/homebrew/bin/claude",
+            "default_timeout_seconds": 600,
+        }
+        cfg_path = tmp_path / "orchestrator.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+        config = load_config(cfg_path)
+        assert config.agent.type == "claude"
+        assert str(config.agent.binary) == "/opt/homebrew/bin/claude"
+        assert config.agent.default_timeout_seconds == 600
+
+    def test_legacy_claude_key_is_aliased_to_agent(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """The YAML `claude:` key is migrated to `agent:` at load time
+        with a DeprecationWarning, so pre-migration configs keep
+        working until the operator renames."""
+        import warnings
+
+        import yaml
+
+        sample_config_dict["claude"] = {
+            "binary": "/usr/local/bin/claude",
+            "default_timeout_seconds": 900,
+        }
+        cfg_path = tmp_path / "orchestrator.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter("always")
+            config = load_config(cfg_path)
+
+        assert config.agent.binary == "/usr/local/bin/claude"
+        assert config.agent.default_timeout_seconds == 900
+        # DeprecationWarning must fire so the operator sees the hint.
+        msgs = [str(w.message) for w in captured if issubclass(w.category, DeprecationWarning)]
+        assert any("'claude:' is deprecated" in m for m in msgs), msgs
+
+    def test_claude_property_mirrors_agent(
+        self, sample_config_file: Path
+    ) -> None:
+        """`config.claude` must still work at the Python attribute
+        level — existing callers that haven't migrated stay green."""
+        config = load_config(sample_config_file)
+        assert config.claude is config.agent
+
+
+class TestMakeAgentDispatcher:
+    """The factory is the seam where future agent backends plug in.
+    Today only `claude` is wired up; other types must fail loudly so
+    a config typo doesn't silently fall back to Claude."""
+
+    def test_claude_type_returns_claude_dispatcher(self) -> None:
+        from ctrlrelay.core.config import AgentConfig
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher, make_agent_dispatcher
+
+        cfg = AgentConfig(type="claude", binary="claude", default_timeout_seconds=60)
+        adapter = make_agent_dispatcher(cfg)
+        assert isinstance(adapter, ClaudeDispatcher)
+        assert adapter.default_timeout == 60
+
+    def test_unknown_type_raises_not_implemented_with_hint(self) -> None:
+        from ctrlrelay.core.config import AgentConfig
+        from ctrlrelay.core.dispatcher import make_agent_dispatcher
+
+        cfg = AgentConfig(type="codex")
+        with pytest.raises(NotImplementedError) as excinfo:
+            make_agent_dispatcher(cfg)
+        msg = str(excinfo.value).lower()
+        assert "codex" in msg
+        assert "agentadapter" in msg or "adapter" in msg
+
+
 class TestTimezoneValidation:
     """Regression for codex [P2]: invalid IANA zones must fail at load,
     not at poller startup. Since the scheduler feeds timezone directly


### PR DESCRIPTION
## Summary

Sets up the **seam** for pluggable coding-agent backends. Behavior is unchanged — Claude is still the only working adapter — but a new config shape, a protocol, and a factory make it trivial to land a Codex / OpenCode / Hermes / Kiro adapter in a follow-up PR without touching pipelines or callers.

## Config: \`claude:\` → \`agent:\`

- \`ClaudeConfig\` renamed to \`AgentConfig\`; new \`type: str = \"claude\"\` field.
- YAML root key: \`claude:\` → \`agent:\`.
- Legacy compat:
  - YAML \`claude:\` still accepted, emits \`DeprecationWarning\`.
  - Python \`config.claude\` preserved as a \`@property\` returning \`config.agent\`.
  - \`ClaudeConfig\` alias of \`AgentConfig\` so downstream imports don't break.

## Dispatcher: \`AgentAdapter\` protocol + factory

- New \`AgentAdapter\` Protocol in \`core/dispatcher.py\` — defines the \`spawn_session\` shape every backend must satisfy. \`ClaudeDispatcher\` already matches (duck-typed).
- \`make_agent_dispatcher(agent_config) -> AgentAdapter\` routes by \`type\`; \`\"claude\"\` returns \`ClaudeDispatcher\`, anything else raises \`NotImplementedError\` with a clear hint pointing at the protocol + registration site.

## Pipeline call sites

- \`run_dev\`, \`run_secops\`, poller foreground — all build their dispatcher via \`make_agent_dispatcher(config.agent)\` now.
- Type annotations in \`pipelines/dev.py\` and \`pipelines/secops.py\` broadened \`ClaudeDispatcher\` → \`AgentAdapter\`.
- \`ctrlrelay.core\` re-exports \`AgentAdapter\` and \`make_agent_dispatcher\`.

## Test plan

- [x] \`uv run pytest\` — 330 passed (was 325, +5 regression tests for config migration + factory)
- [x] \`uv run ruff check src tests\` — clean
- [x] Local \`ctrlrelay config validate\` against a recovered orchestrator.yaml that uses the new \`agent:\` key — passes.

## What's next

Once this merges, a Codex / OpenCode / Hermes / Kiro adapter is ~30 lines:

1. Implement \`AgentAdapter.spawn_session\` (subprocess spawn, checkpoint-file parsing).
2. Register the type in \`make_agent_dispatcher\`.
3. Done — pipelines stay untouched.