### PR TITLE
fix(cli): print blocked question + failed error in 'run secops' output

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -592,6 +592,14 @@ def run_secops(
     for result in results:
         status = "[green]OK[/green]" if result.success else "[red]FAIL[/red]"
         console.print(f"  {status} {result.summary}")
+        # Surface the blocking question / error text so an operator
+        # running secops at the CLI doesn't have to dig into state.db
+        # to see what the agent was asking. The scheduler closure
+        # already relays these via Telegram; this is the manual path.
+        if result.blocked and result.question:
+            console.print(f"    [yellow]Question:[/yellow] {result.question}")
+        elif not result.success and result.error:
+            console.print(f"    [red]Error:[/red] {result.error}")
 
     if not all(r.success for r in results):
         raise typer.Exit(1)


### PR DESCRIPTION
## Summary

Today's manual recovery of the two abandoned blocked sessions surfaced this gap: \`ctrlrelay run secops\` was printing only \`FAIL Blocked on user input\` for blocked results, with no follow-on. The actual question lived in \`result.question\` but never made it to stdout.

Mirror what PR #74 did on the scheduled path: print the question (yellow) for blocked, the error (red) for failed-but-not-blocked, indented under each result line.

## Test plan

- [x] \`uv run pytest\` — 330 passed (no behavior change in tested paths)
- [x] \`uv run ruff check src tests\` — clean
- [x] Live: \`ctrlrelay run secops --repo AInvirion/ctrlrelay\` now prints the full agent question.