### PR TITLE
docs: use security@ainvirion.com for vulnerability reports

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -14,7 +14,7 @@ us a private channel to triage the report and lets you get credit in the
 published advisory when we release a fix.
 
 If you cannot use GitHub for any reason, email
-`oscar.valenzuela.b@gmail.com` with the subject line
+`security@ainvirion.com` with the subject line
 `ctrlrelay: security report`.
 
 We aim to acknowledge reports within **72 hours** and ship a fix or


### PR DESCRIPTION
## Summary
- Replace the maintainer's personal gmail address in SECURITY.md with the org alias `security@ainvirion.com` so security reports land in the right place.

Closes #77

## Test plan
- [x] `git diff` shows only the email swap in SECURITY.md — no other changes.
- [ ] CI green.