### PR TITLE
feat(poller): filter issues assigned by someone other than the operator

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Poller: filter out issues where the most recent assignment to the operator
+  was performed by someone else (e.g. a teammate or a bot). Foreign
+  assignments are logged as `poll.issue.foreign_assignment` and marked seen
+  so they aren't re-checked. Repos can opt back into the old "any assignment
+  counts" behaviour with `automation.accept_foreign_assignments: true`.
+
 ## [0.1.5] - 2026-04-20
 
 The "ready to be open-sourced" release. Apache-2.0 license, AInvirion

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -163,6 +163,7 @@ repos:
       codeql_dismiss: ask
       secret_alerts: never
       deploy_after_merge: auto
+      accept_foreign_assignments: false
     code_review: { ... }      # optional
     deploy:      { ... }      # optional
 ```
@@ -189,6 +190,7 @@ and ask the operator), or `never` (skip).
 | `codeql_dismiss` | `ask` | CodeQL alert dismissal. |
 | `secret_alerts` | `never` | Secret-scan alerts. |
 | `deploy_after_merge` | `auto` | Whether to deploy after a merged PR. |
+| `accept_foreign_assignments` | `false` | When `true`, the poller also picks up issues assigned to you by someone else. Default (`false`) runs the dev pipeline only on issues you self-assigned. |
 
 The current secops and dev pipelines read these settings to bias their prompts
 to Claude — they're not enforced by hard-coded checks.

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -904,6 +904,10 @@ def poller_start(
             console.print("[yellow]No repos configured.[/yellow]")
             return
 
+        accept_foreign = {
+            r.name for r in config.repos if r.automation.accept_foreign_assignments
+        }
+
         state_file = config.paths.state_db.parent / "poller_state.json"
 
         first_run = not state_file.exists()
@@ -913,6 +917,7 @@ def poller_start(
             username=username,
             repos=repo_names,
             state_file=state_file,
+            accept_foreign_assignments=accept_foreign,
         )
 
         # NOTE: first-run seeding moved into `_main()` so the APScheduler

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -147,6 +147,7 @@ class AutomationConfig(BaseModel):
     codeql_dismiss: AutomationPolicy = AutomationPolicy.ASK
     secret_alerts: AutomationPolicy = AutomationPolicy.NEVER
     deploy_after_merge: AutomationPolicy = AutomationPolicy.AUTO
+    accept_foreign_assignments: bool = False
 
 
 class RepoConfig(BaseModel):

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -193,6 +193,25 @@ class GitHubCLI:
         )
         return json.loads(output) if output.strip() else []
 
+    async def list_assignment_events(
+        self,
+        repo: str,
+        issue_number: int,
+    ) -> list[dict[str, Any]]:
+        """List ``assigned`` events for an issue in chronological order.
+
+        Returns the GitHub issue-events payload filtered to ``event == "assigned"``.
+        Each entry includes ``actor`` (who performed the assignment) and
+        ``assignee`` (who was assigned). Used by the poller to verify that the
+        most recent self-assignment was actually performed by the operator.
+        """
+        output = await self._run_gh(
+            "api",
+            f"/repos/{repo}/issues/{issue_number}/events",
+            "--jq", '[.[] | select(.event=="assigned")]',
+        )
+        return json.loads(output) if output.strip() else []
+
     async def get_issue(
         self,
         repo: str,

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -37,6 +37,11 @@ class IssuePoller:
 
     Maintains a set of seen issue numbers per repo so that only genuinely new
     issues are surfaced on each call to ``poll()``.
+
+    By default, new issues are filtered to those where the most recent
+    ``assigned`` event naming ``username`` was performed by ``username``
+    themselves — i.e. self-assignment only. Repos listed in
+    ``accept_foreign_assignments`` bypass this check.
     """
 
     github: GitHubCLI
@@ -44,6 +49,7 @@ class IssuePoller:
     repos: list[str]
     state_file: Path
     seen_issues: dict[str, set[int]] = field(default_factory=dict)
+    accept_foreign_assignments: set[str] = field(default_factory=set)
     # Per-repo consecutive-skip counter; populated at runtime by poll() /
     # seed_current(). Not persisted — intentionally resets on daemon
     # restart so an operator fix is exercised before we re-escalate.
@@ -195,14 +201,83 @@ class IssuePoller:
                         error=str(e)[:200],
                     )
                     continue
-                if number not in seen_for_repo:
+
+                if number in seen_for_repo:
+                    continue
+
+                # Mark seen before deciding whether to surface the issue so a
+                # filtered (foreign-assigned) issue isn't re-checked every poll.
+                seen_for_repo.add(number)
+
+                try:
+                    accepted = await self._is_self_assigned(repo, number)
+                except asyncio.CancelledError:
+                    raise
+                except Exception as e:
+                    # Treat any failure to check assignment events as
+                    # foreign-equivalent: don't run the pipeline, but leave
+                    # the issue marked seen so we don't hammer the events
+                    # endpoint on every poll.
+                    log_event(
+                        _logger,
+                        "poll.issue.assignment_check_failed",
+                        repo=repo,
+                        number=number,
+                        reason=type(e).__name__,
+                        error=str(e)[:200],
+                    )
+                    accepted = False
+
+                if accepted:
                     new_issues.append({"repo": repo, "issue": issue})
-                    seen_for_repo.add(number)
 
         # Never propagate a save_state disk failure out of poll() — the
         # caller has work to do with new_issues. Log and move on.
         self._save_state_best_effort()
         return new_issues
+
+    async def _is_self_assigned(self, repo: str, issue_number: int) -> bool:
+        """Check if the most recent ``assigned`` event naming ``self.username``
+        was performed by ``self.username`` themselves.
+
+        Repos in ``accept_foreign_assignments`` short-circuit to ``True``.
+        Foreign assignments (or an empty event list) emit a
+        ``poll.issue.foreign_assignment`` log record and return ``False``.
+        """
+        if repo in self.accept_foreign_assignments:
+            return True
+
+        events = await self.github.list_assignment_events(repo, issue_number)
+        relevant = [
+            e
+            for e in events
+            if (e.get("assignee") or {}).get("login") == self.username
+        ]
+        if not relevant:
+            log_event(
+                _logger,
+                "poll.issue.foreign_assignment",
+                repo=repo,
+                number=issue_number,
+                assigner_login=None,
+                reason="no_self_assignment_event",
+            )
+            return False
+
+        # Events endpoint returns chronological order; the last one wins.
+        latest = relevant[-1]
+        assigner_login = (latest.get("actor") or {}).get("login")
+        if assigner_login == self.username:
+            return True
+
+        log_event(
+            _logger,
+            "poll.issue.foreign_assignment",
+            repo=repo,
+            number=issue_number,
+            assigner_login=assigner_login,
+        )
+        return False
 
     def mark_seen(self, repo: str, issue_number: int) -> None:
         """Mark an issue as seen without triggering a poll.

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -292,6 +292,51 @@ class TestGitHubCLI:
             assert "55" in args
 
     @pytest.mark.asyncio
+    async def test_list_assignment_events(self) -> None:
+        """Should return only 'assigned' events for an issue."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_output = json.dumps([
+            {
+                "event": "assigned",
+                "actor": {"login": "alice"},
+                "assignee": {"login": "alice"},
+                "created_at": "2026-01-01T00:00:00Z",
+            },
+            {
+                "event": "assigned",
+                "actor": {"login": "bob"},
+                "assignee": {"login": "alice"},
+                "created_at": "2026-01-02T00:00:00Z",
+            },
+        ])
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = mock_output
+            gh = GitHubCLI()
+            events = await gh.list_assignment_events("owner/repo", 42)
+
+            assert len(events) == 2
+            assert events[0]["actor"]["login"] == "alice"
+            assert events[1]["actor"]["login"] == "bob"
+
+            args = mock_run.call_args[0]
+            assert "api" in args
+            assert "/repos/owner/repo/issues/42/events" in args
+
+    @pytest.mark.asyncio
+    async def test_list_assignment_events_empty_output(self) -> None:
+        """Should return [] when there are no assignment events."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = ""
+            gh = GitHubCLI()
+            events = await gh.list_assignment_events("owner/repo", 42)
+
+            assert events == []
+
+    @pytest.mark.asyncio
     async def test_comment_on_issue(self) -> None:
         """Should post a comment on an issue."""
         from ctrlrelay.core.github import GitHubCLI

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -29,10 +29,23 @@ def state_file(tmp_path: Path) -> Path:
     return tmp_path / "poller_state.json"
 
 
+def make_assigned_event(actor_login: str, assignee_login: str) -> dict:
+    return {
+        "event": "assigned",
+        "actor": {"login": actor_login},
+        "assignee": {"login": assignee_login},
+        "created_at": "2026-01-01T00:00:00Z",
+    }
+
+
 @pytest.fixture
 def mock_github() -> MagicMock:
     gh = MagicMock()
     gh.list_assigned_issues = AsyncMock()
+    # Default: every issue was self-assigned by "alice" so the filter is a no-op.
+    gh.list_assignment_events = AsyncMock(
+        return_value=[make_assigned_event("alice", "alice")]
+    )
     return gh
 
 
@@ -158,6 +171,9 @@ class TestIssuePoller:
         mock_github.list_assigned_issues.return_value = [
             {"number": 123, "title": "Fix bug"},
         ]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("testuser", "testuser"),
+        ]
 
         poller = IssuePoller(
             github=mock_github,
@@ -198,6 +214,9 @@ class TestIssuePoller:
 
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -230,6 +249,9 @@ class TestIssuePoller:
 
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -285,6 +307,9 @@ class TestIssuePoller:
 
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(side_effect=flaky_then_fine)
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -334,6 +359,9 @@ class TestIssuePoller:
 
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -370,6 +398,9 @@ class TestIssuePoller:
 
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(side_effect=per_repo)
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -410,6 +441,9 @@ class TestIssuePoller:
                 {"number": 2, "title": "second good AFTER the bad one"},
             ]
         )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -442,6 +476,9 @@ class TestIssuePoller:
         mock_github = MagicMock()
         mock_github.list_assigned_issues = AsyncMock(
             return_value=[{"number": 42, "title": "work to do"}]
+        )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
         )
 
         poller = IssuePoller(
@@ -568,6 +605,9 @@ class TestIssuePoller:
         mock_github.list_assigned_issues = AsyncMock(
             return_value=[{"number": 1, "title": "x"}]
         )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
+        )
 
         poller = IssuePoller(
             github=mock_github,
@@ -612,6 +652,9 @@ class TestIssuePoller:
                 {"number": 2, "title": "second"},
                 {"number": 3, "title": "third"},
             ]
+        )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("testuser", "testuser")]
         )
 
         poller = IssuePoller(
@@ -698,3 +741,161 @@ class TestUnmarkSeen:
 
         on_disk = json.loads(state_file.read_text())
         assert 55 not in on_disk["seen_issues"].get("owner/repo", [])
+
+
+class TestForeignAssignmentFilter:
+    @pytest.mark.asyncio
+    async def test_self_assigned_issue_is_accepted(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """When the operator self-assigned the issue, it is picked up."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("alice", "alice"),
+        ]
+
+        results = await poller.poll()
+
+        assert len(results) == 2  # both repos return the same issue
+        assert all(r["issue"]["number"] == 1 for r in results)
+
+    @pytest.mark.asyncio
+    async def test_foreign_assigned_issue_is_filtered(
+        self,
+        poller: IssuePoller,
+        mock_github: MagicMock,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """An issue assigned to the operator by someone else is filtered out."""
+        import logging
+
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("bob", "alice"),
+        ]
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            results = await poller.poll()
+
+        assert results == []
+        # Must still be marked seen so we don't re-check the same issue every poll
+        assert 1 in poller.seen_issues["owner/repo-a"]
+        assert 1 in poller.seen_issues["owner/repo-b"]
+
+        # Emits a foreign_assignment log event with identifying fields
+        foreign_records = [
+            r for r in caplog.records if r.getMessage() == "poll.issue.foreign_assignment"
+        ]
+        assert len(foreign_records) == 2  # one per repo
+        for rec in foreign_records:
+            assert rec.number == 1
+            assert rec.assigner_login == "bob"
+            assert rec.repo in {"owner/repo-a", "owner/repo-b"}
+
+    @pytest.mark.asyncio
+    async def test_most_recent_assigned_event_wins(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """If the issue was self-assigned first but later re-assigned by
+        someone else, the most recent assigner (bob) is what matters."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("alice", "alice"),
+            make_assigned_event("bob", "alice"),
+        ]
+
+        results = await poller.poll()
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_ignores_events_for_other_assignees(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """Only `assigned` events where assignee == operator count. A later
+        assignment to someone else on the same issue shouldn't hide an
+        earlier self-assignment of the operator."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("alice", "alice"),
+            # Irrelevant: someone else was later added as a co-assignee
+            make_assigned_event("bob", "charlie"),
+        ]
+
+        results = await poller.poll()
+
+        assert len(results) == 2
+
+    @pytest.mark.asyncio
+    async def test_bot_assignment_is_filtered(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """Assignment by a GitHub App / bot is treated as foreign."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("github-actions[bot]", "alice"),
+        ]
+
+        results = await poller.poll()
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_no_assigned_events_is_filtered(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """Defensive: if the issue shows up in `gh issue list --assignee alice`
+        but has no `assigned` events naming alice (odd edge case — e.g. the
+        events endpoint truncated), we refuse to run rather than guess."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = []
+
+        results = await poller.poll()
+
+        assert results == []
+
+    @pytest.mark.asyncio
+    async def test_accept_foreign_assignments_bypasses_filter(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """Per-repo opt-in: foreign assignments are accepted when the repo
+        is listed in `accept_foreign_assignments`."""
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a", "owner/repo-b"],
+            state_file=state_file,
+            accept_foreign_assignments={"owner/repo-a"},
+        )
+
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("bob", "alice"),
+        ]
+
+        results = await poller.poll()
+
+        # repo-a: opted in → accepts bob's assignment
+        # repo-b: default → filters out bob's assignment
+        assert len(results) == 1
+        assert results[0]["repo"] == "owner/repo-a"
+        assert results[0]["issue"]["number"] == 1
+
+    @pytest.mark.asyncio
+    async def test_filter_runs_once_per_new_issue(
+        self, poller: IssuePoller, mock_github: MagicMock
+    ) -> None:
+        """A filtered issue is marked seen, so the events endpoint is NOT hit
+        again for it on the next poll."""
+        mock_github.list_assigned_issues.return_value = [make_issue(1)]
+        mock_github.list_assignment_events.return_value = [
+            make_assigned_event("bob", "alice"),
+        ]
+
+        await poller.poll()
+        call_count_after_first = mock_github.list_assignment_events.call_count
+
+        await poller.poll()
+
+        # No additional events calls on the second poll — issue is already seen
+        assert mock_github.list_assignment_events.call_count == call_count_after_first


### PR DESCRIPTION
## Summary

- `IssuePoller` now verifies that the most recent `assigned` event naming the operator on a newly-detected issue was performed by the operator themselves. Issues assigned by a teammate, a bot, or a GitHub App are filtered out — they stay visible on GitHub but don't trigger the dev pipeline.
- Foreign assignments are logged as `poll.issue.foreign_assignment` (with `repo`, `number`, `assigner_login`) and marked seen, so the events endpoint is hit at most once per new issue, not every poll.
- Per-repo opt-out: `automation.accept_foreign_assignments: true` in `RepoConfig` restores the old "any assignment counts" behavior for specific repos.

Closes #79

## Implementation notes

- New `GitHubCLI.list_assignment_events(repo, issue_number)` wraps `gh api /repos/<owner>/<repo>/issues/<n>/events --jq '[.[] | select(.event=="assigned")]'`.
- The poller filters the events list to those where `assignee.login == username`, takes the last one (events API returns chronological ascending), and compares `actor.login == username`.
- Defensive: if the issue has no self-assignment events at all (weird edge case), it's filtered and logged with `reason=no_self_assignment_event`.
- Marked-seen semantics unchanged for accepted issues; filtered issues are also marked seen to avoid duplicate log lines / API calls on every poll tick.

## Test plan

- [x] New unit tests in `tests/test_poller.py::TestForeignAssignmentFilter` cover: self-assigned accepted, foreign-assigned filtered + logged, most-recent-event wins, events for other assignees ignored, bot assignments filtered, empty events filtered, `accept_foreign_assignments` bypasses per-repo, filter runs once per new issue.
- [x] New unit tests in `tests/test_github.py` cover `list_assignment_events` including the empty-output path.
- [x] Full suite green: `pytest -q` → 223 passed.
- [ ] Manual smoke in production once merged (watch `poll.issue.foreign_assignment` log lines).