### PR TITLE
fix(dispatcher): resume with Claude's session UUID, not our composite id (#83)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so they aren't re-checked. Repos can opt back into the old "any assignment
   counts" behaviour with `automation.accept_foreign_assignments: true`.
 
+### Fixed
+
+- **Dispatcher: `--resume` now uses Claude's session UUID, not our composite
+  id** (#83). Newer `claude` CLI versions (v2.0.x+) validate that `--resume
+  <id>` is either a real UUID or a known session title, so passing our
+  `dev-<owner>-<repo>-<issue>-<hex>` composite id hard-failed on every
+  resume — blocked-question answers and post-DONE fix rounds both surfaced
+  as misleading "❌ Failed" notifications. `ClaudeDispatcher` now parses
+  `session_id` out of Claude's JSON stdout, exposes it as
+  `SessionResult.agent_session_id`, and persists it in a new
+  `sessions.agent_session_id` column so subsequent resumes feed the real
+  UUID. If state_db has no UUID (session predates the fix, or stdout
+  wasn't JSON), pipelines fall back to a fresh spawn rather than failing.
+
 ## [0.1.5] - 2026-04-20
 
 The "ready to be open-sourced" release. Apache-2.0 license, AInvirion

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -70,14 +70,19 @@ is the only place ctrlrelay calls out to Claude Code.
 - **Environment additions:** `CTRLRELAY_SESSION_ID` and `CTRLRELAY_STATE_FILE`
   are the only contract between dispatcher and child. Anything else the agent
   needs (issue body, PR rules, etc.) goes into the prompt.
-- **Result:** `SessionResult(session_id, exit_code, state, stdout, stderr)`.
-  `state` is the parsed `CheckpointState` if a state file was written, else
-  `None`. The wrapper exposes `.success`, `.blocked`, `.failed` properties for
-  pattern-matching pipelines.
-- **Resume:** `resume_session_id` translates to `--resume <id>`, which has
-  Claude rejoin the same conversation history. ctrlrelay sets the resume id to
-  the same session id it spawned with, so a single dev-pipeline session can
-  span many `BLOCKED → answer → resume` round-trips.
+- **Result:** `SessionResult(session_id, exit_code, state, stdout, stderr,
+  agent_session_id)`. `session_id` is our composite orchestrator id;
+  `agent_session_id` is Claude's own UUID, parsed from the JSON stdout and
+  the value `--resume` actually expects. `state` is the parsed
+  `CheckpointState` if a state file was written, else `None`. The wrapper
+  exposes `.success`, `.blocked`, `.failed` properties for pattern-matching
+  pipelines.
+- **Resume:** `resume_session_id` translates to `--resume <id>`. Pipelines
+  look up Claude's UUID (persisted as `sessions.agent_session_id` by the
+  prior spawn) and pass it through — newer `claude` CLI builds reject
+  non-UUID values. If state_db has no UUID (session predates capture or
+  stdout wasn't JSON), the spawn falls back to a fresh session rather than
+  hard-failing.
 
 The dispatcher does NOT proxy or wrap the Claude session — it shells out the
 same way you'd shell out to `gh` or `git`. This is deliberate.
@@ -90,15 +95,16 @@ SQLite, single file at `paths.state_db`.
 
 | Table | Columns | Notes |
 |---|---|---|
-| `sessions` | `id`, `pipeline`, `repo`, `issue_number`, `worktree_path`, `status`, `blocked_question`, `started_at`, `ended_at`, `claude_exit_code`, `summary` | Indexed on `repo` and `status`. One row per pipeline run. |
+| `sessions` | `id`, `pipeline`, `repo`, `issue_number`, `worktree_path`, `status`, `blocked_question`, `started_at`, `ended_at`, `claude_exit_code`, `summary`, `agent_session_id` | Indexed on `repo` and `status`. One row per pipeline run. `agent_session_id` stores Claude's own UUID for `--resume`. |
 | `repo_locks` | `repo` (PK), `session_id`, `acquired_at` | Acquired with `acquire_lock`, released in the pipeline's `finally`. |
 | `github_cursor` | `repo`, `last_checked_at`, `last_seen_issue_update` | Bounds GitHub API calls in the poller. |
 | `telegram_pending` | `request_id`, `session_id`, `question`, `asked_at`, `answered_at`, `answer` | Outstanding bridge questions. |
 | `automation_decisions` | `id`, `repo`, `operation`, `policy`, `item_id`, `decision`, `decided_by`, `decided_at`, `context` | Audit trail for `ask`-policy decisions. |
 
 Methods on `StateDB`: `acquire_lock`, `release_lock`, `get_lock_holder`,
-`list_locks`, plus raw `execute` / `commit`. The pipeline code uses raw SQL
-for the `sessions` table on purpose — kept thin and grep-able.
+`list_locks`, `set_agent_session_id`, `get_agent_session_id`, plus raw
+`execute` / `commit`. The pipeline code uses raw SQL for the `sessions`
+table on purpose — kept thin and grep-able.
 
 ## Worktree lifecycle
 

--- a/src/ctrlrelay/core/dispatcher.py
+++ b/src/ctrlrelay/core/dispatcher.py
@@ -10,6 +10,7 @@ so pipelines can stay agent-agnostic.
 from __future__ import annotations
 
 import asyncio
+import json
 import os
 import shutil
 from dataclasses import dataclass, field
@@ -39,13 +40,22 @@ def _find_claude() -> str:
 
 @dataclass
 class SessionResult:
-    """Result of a Claude session."""
+    """Result of a Claude session.
+
+    - ``session_id`` is the orchestrator's composite id (``dev-<owner>-<repo>-
+      <issue>-<hex>``) used as the primary key in state_db.
+    - ``agent_session_id`` is Claude's own session UUID, parsed from the JSON
+      stdout. It's the value that must be passed to ``claude --resume`` on
+      subsequent calls; newer CLI versions reject non-UUID strings.
+      ``None`` when stdout wasn't parseable JSON or didn't include the field.
+    """
 
     session_id: str
     exit_code: int
     state: CheckpointState | None
     stdout: str = ""
     stderr: str = ""
+    agent_session_id: str | None = None
 
     @property
     def success(self) -> bool:
@@ -146,13 +156,37 @@ class ClaudeDispatcher:
             except Exception:
                 pass
 
+        stdout_text = stdout.decode()
+        agent_session_id = _extract_agent_session_id(stdout_text)
+
         return SessionResult(
             session_id=session_id,
             exit_code=proc.returncode or 0,
             state=state,
-            stdout=stdout.decode(),
+            stdout=stdout_text,
             stderr=stderr.decode(),
+            agent_session_id=agent_session_id,
         )
+
+
+def _extract_agent_session_id(stdout_text: str) -> str | None:
+    """Pull Claude's session UUID out of ``claude -p --output-format json``.
+
+    Claude emits a single JSON object on stdout whose ``session_id`` field is
+    the UUID required by ``--resume``. If the output is empty or not JSON
+    (errors, interrupted runs) we return ``None`` and let the caller decide
+    how to fall back.
+    """
+    if not stdout_text.strip():
+        return None
+    try:
+        payload = json.loads(stdout_text)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(payload, dict):
+        return None
+    value = payload.get("session_id")
+    return value if isinstance(value, str) and value else None
 
 
 class AgentAdapter(Protocol):

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -19,7 +19,8 @@ CREATE TABLE IF NOT EXISTS sessions (
     started_at INTEGER NOT NULL,
     ended_at INTEGER,
     claude_exit_code INTEGER,
-    summary TEXT
+    summary TEXT,
+    agent_session_id TEXT
 );
 
 CREATE TABLE IF NOT EXISTS repo_locks (
@@ -80,7 +81,25 @@ class StateDB:
         self._conn = sqlite3.connect(str(self.db_path))
         self._conn.row_factory = sqlite3.Row
         self._conn.executescript(SCHEMA)
+        self._migrate()
         self._conn.commit()
+
+    def _migrate(self) -> None:
+        """Apply in-place schema additions to databases written by older versions.
+
+        SQLite's ``CREATE TABLE IF NOT EXISTS`` preserves the *existing* shape
+        if the table was created by a prior version, so additive column bumps
+        need a guarded ALTER. We check ``PRAGMA table_info`` and only ALTER
+        when the column is missing.
+        """
+        existing = {
+            row[1]
+            for row in self._conn.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        if "agent_session_id" not in existing:
+            self._conn.execute(
+                "ALTER TABLE sessions ADD COLUMN agent_session_id TEXT"
+            )
 
     def close(self) -> None:
         """Close the database connection."""
@@ -165,3 +184,32 @@ class StateDB:
         """
         rows = self._conn.execute("SELECT * FROM repo_locks").fetchall()
         return [dict(row) for row in rows]
+
+    # Agent session ids
+
+    def set_agent_session_id(self, session_id: str, agent_session_id: str) -> None:
+        """Persist Claude's session UUID against our composite session id.
+
+        ``agent_session_id`` is what ``claude --resume`` needs — our
+        composite id fails validation on newer CLI versions.
+        """
+        self._conn.execute(
+            "UPDATE sessions SET agent_session_id = ? WHERE id = ?",
+            (agent_session_id, session_id),
+        )
+        self._conn.commit()
+
+    def get_agent_session_id(self, session_id: str) -> str | None:
+        """Fetch Claude's session UUID for a given composite session id.
+
+        Returns ``None`` if the row is missing or the column was never set
+        (sessions that predate the agent-uuid capture).
+        """
+        row = self._conn.execute(
+            "SELECT agent_session_id FROM sessions WHERE id = ?",
+            (session_id,),
+        ).fetchone()
+        if row is None:
+            return None
+        value = row["agent_session_id"]
+        return value if value else None

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -52,18 +52,17 @@ class DevPipeline:
             state_file=ctx.state_file,
         )
 
-        result = await self.dispatcher.spawn_session(
-            session_id=ctx.session_id,
-            prompt=prompt,
-            working_dir=ctx.worktree_path,
-            state_file=ctx.state_file,
-        )
-
+        result = await self._spawn(ctx, prompt, resume=False)
         return self._session_to_result(result)
 
     async def resume(self, ctx: PipelineContext, answer: str) -> PipelineResult:
         """Resume blocked dev session with user answer."""
         prompt = f"User answered: {answer}\n\nContinue from where you left off."
+
+        # Resume uses Claude's own session UUID (captured on the first spawn
+        # and persisted to state_db). Passing our composite id here makes
+        # `claude --resume` reject the call on v2.0.x+ CLI builds.
+        resume_uuid = self.state_db.get_agent_session_id(ctx.session_id)
 
         log_event(
             _logger,
@@ -72,33 +71,55 @@ class DevPipeline:
             repo=ctx.repo,
             issue_number=ctx.issue_number,
             pipeline=self.name,
-            resume_session_id=ctx.session_id,
+            resume_session_id=resume_uuid,
             answer_length=len(answer),
             answer_hash=hash_text(answer),
         )
 
-        result = await self.dispatcher.spawn_session(
-            session_id=ctx.session_id,
-            prompt=prompt,
-            working_dir=ctx.worktree_path,
-            state_file=ctx.state_file,
-            resume_session_id=ctx.session_id,
-        )
-
+        result = await self._spawn(ctx, prompt, resume=True)
         return self._session_to_result(result)
 
     async def request_fix(
         self, ctx: PipelineContext, fix_instructions: str
     ) -> PipelineResult:
         """Resume the session with a fix request (failing CI or merge conflict)."""
+        result = await self._spawn(ctx, fix_instructions, resume=True)
+        return self._session_to_result(result)
+
+    async def _spawn(
+        self,
+        ctx: PipelineContext,
+        prompt: str,
+        *,
+        resume: bool,
+    ) -> SessionResult:
+        """Centralized dispatcher call: looks up the agent UUID on resume,
+        persists any newly-captured UUID to state_db."""
+        resume_uuid: str | None = None
+        if resume:
+            # If state_db has no stored UUID (session predates the capture, or
+            # first spawn didn't emit JSON) we fall back to a fresh session —
+            # better than hard-failing with `claude --resume <composite-id>`.
+            resume_uuid = self.state_db.get_agent_session_id(ctx.session_id)
+
         result = await self.dispatcher.spawn_session(
             session_id=ctx.session_id,
-            prompt=fix_instructions,
+            prompt=prompt,
             working_dir=ctx.worktree_path,
             state_file=ctx.state_file,
-            resume_session_id=ctx.session_id,
+            resume_session_id=resume_uuid,
         )
-        return self._session_to_result(result)
+
+        if result.agent_session_id:
+            try:
+                self.state_db.set_agent_session_id(
+                    ctx.session_id, result.agent_session_id
+                )
+            except Exception:
+                # state_db write failures must not mask the session result.
+                pass
+
+        return result
 
     def _build_prompt(
         self,

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -43,18 +43,17 @@ class SecopsPipeline:
             state_file=ctx.state_file,
         )
 
-        result = await self.dispatcher.spawn_session(
-            session_id=ctx.session_id,
-            prompt=prompt,
-            working_dir=ctx.worktree_path,
-            state_file=ctx.state_file,
-        )
-
+        result = await self._spawn(ctx, prompt, resume=False)
         return self._session_to_result(result)
 
     async def resume(self, ctx: PipelineContext, answer: str) -> PipelineResult:
         """Resume blocked secops with user answer."""
         prompt = f"User answered: {answer}\n\nContinue from where you left off."
+
+        # Resume uses Claude's own session UUID (captured on the first spawn
+        # and persisted to state_db). Our composite id is not a UUID and will
+        # be rejected by `claude --resume` on v2.0.x+.
+        resume_uuid = self.state_db.get_agent_session_id(ctx.session_id)
 
         log_event(
             _logger,
@@ -63,20 +62,44 @@ class SecopsPipeline:
             repo=ctx.repo,
             issue_number=ctx.issue_number,
             pipeline=self.name,
-            resume_session_id=ctx.session_id,
+            resume_session_id=resume_uuid,
             answer_length=len(answer),
             answer_hash=hash_text(answer),
         )
+
+        result = await self._spawn(ctx, prompt, resume=True)
+        return self._session_to_result(result)
+
+    async def _spawn(
+        self,
+        ctx: PipelineContext,
+        prompt: str,
+        *,
+        resume: bool,
+    ) -> SessionResult:
+        """Centralized dispatcher call: looks up the agent UUID on resume,
+        persists any newly-captured UUID to state_db."""
+        resume_uuid: str | None = None
+        if resume:
+            resume_uuid = self.state_db.get_agent_session_id(ctx.session_id)
 
         result = await self.dispatcher.spawn_session(
             session_id=ctx.session_id,
             prompt=prompt,
             working_dir=ctx.worktree_path,
             state_file=ctx.state_file,
-            resume_session_id=ctx.session_id,
+            resume_session_id=resume_uuid,
         )
 
-        return self._session_to_result(result)
+        if result.agent_session_id:
+            try:
+                self.state_db.set_agent_session_id(
+                    ctx.session_id, result.agent_session_id
+                )
+            except Exception:
+                pass
+
+        return result
 
     def _build_prompt(
         self,

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -140,11 +140,17 @@ class TestDevPipeline:
 
     @pytest.mark.asyncio
     async def test_request_fix_resumes_session_with_instructions(self, tmp_path: Path) -> None:
-        """request_fix should resume the session using the provided fix prompt."""
+        """request_fix should resume the session using the agent (Claude) UUID
+        looked up from state_db, not our composite session id."""
+        import time as _time
+
         from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
         from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.state import StateDB
         from ctrlrelay.pipelines.base import PipelineContext
         from ctrlrelay.pipelines.dev import DevPipeline
+
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
 
         mock_dispatcher = AsyncMock()
         mock_dispatcher.spawn_session.return_value = SessionResult(
@@ -152,6 +158,7 @@ class TestDevPipeline:
             exit_code=0,
             stdout="",
             stderr="",
+            agent_session_id=agent_uuid,
             state=CheckpointState(
                 version="1",
                 status=CheckpointStatus.DONE,
@@ -162,12 +169,21 @@ class TestDevPipeline:
             ),
         )
 
+        state_db = StateDB(tmp_path / "state.db")
+        state_db.execute(
+            """INSERT INTO sessions (id, pipeline, repo, status, started_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("dev-123", "dev", "owner/repo", "running", int(_time.time())),
+        )
+        state_db.set_agent_session_id("dev-123", agent_uuid)
+        state_db.commit()
+
         pipeline = DevPipeline(
             dispatcher=mock_dispatcher,
             github=MagicMock(),
             worktree=MagicMock(),
             dashboard=None,
-            state_db=MagicMock(),
+            state_db=state_db,
             transport=None,
         )
 
@@ -186,8 +202,139 @@ class TestDevPipeline:
 
         assert result.success
         call_kwargs = mock_dispatcher.spawn_session.call_args.kwargs
-        assert call_kwargs["resume_session_id"] == "dev-123"
+        assert call_kwargs["resume_session_id"] == agent_uuid
         assert call_kwargs["prompt"] == fix_prompt
+        state_db.close()
+
+    @pytest.mark.asyncio
+    async def test_request_fix_skips_resume_when_no_agent_uuid(
+        self, tmp_path: Path
+    ) -> None:
+        """If state_db has no agent UUID (e.g. session predates the fix),
+        request_fix should fall back to a fresh spawn (no --resume) rather
+        than hard-failing with `claude --resume <composite-id>`."""
+        import time as _time
+
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.base import PipelineContext
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            agent_session_id=None,
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="ok",
+                outputs={},
+            ),
+        )
+
+        state_db = StateDB(tmp_path / "state.db")
+        state_db.execute(
+            """INSERT INTO sessions (id, pipeline, repo, status, started_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("dev-123", "dev", "owner/repo", "running", int(_time.time())),
+        )
+        state_db.commit()
+
+        pipeline = DevPipeline(
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+        )
+
+        ctx = PipelineContext(
+            session_id="dev-123",
+            repo="owner/repo",
+            worktree_path=tmp_path,
+            context_path=tmp_path / "CLAUDE.md",
+            state_file=tmp_path / "state.json",
+            issue_number=123,
+            extra={},
+        )
+
+        await pipeline.request_fix(ctx, "fix it")
+
+        call_kwargs = mock_dispatcher.spawn_session.call_args.kwargs
+        assert call_kwargs["resume_session_id"] is None
+        state_db.close()
+
+    @pytest.mark.asyncio
+    async def test_run_persists_agent_session_id_to_state_db(
+        self, tmp_path: Path
+    ) -> None:
+        """After a spawn_session that returns an agent UUID, the pipeline
+        must persist it to state_db so future resumes can look it up."""
+        import time as _time
+
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.base import PipelineContext
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-123",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            agent_session_id=agent_uuid,
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-123",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="ok",
+                outputs={"pr_number": 42, "pr_url": "https://github.com/o/r/pull/42"},
+            ),
+        )
+
+        state_db = StateDB(tmp_path / "state.db")
+        state_db.execute(
+            """INSERT INTO sessions (id, pipeline, repo, status, started_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            ("dev-123", "dev", "owner/repo", "running", int(_time.time())),
+        )
+        state_db.commit()
+
+        pipeline = DevPipeline(
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+        )
+
+        ctx = PipelineContext(
+            session_id="dev-123",
+            repo="owner/repo",
+            worktree_path=tmp_path,
+            context_path=tmp_path / "CLAUDE.md",
+            state_file=tmp_path / "state.json",
+            issue_number=123,
+            extra={},
+        )
+
+        await pipeline.run(ctx)
+
+        assert state_db.get_agent_session_id("dev-123") == agent_uuid
+        state_db.close()
 
     @pytest.mark.asyncio
     async def test_run_dev_issue_posts_claim_comment(self, tmp_path: Path) -> None:
@@ -378,7 +525,11 @@ class TestRunDevIssueVerification:
     """Verifies run_dev_issue waits for CI and checks mergeability before DONE."""
 
     @staticmethod
-    def _make_done_state(session_id: str = "dev-123", pr_number: int = 42):
+    def _make_done_state(
+        session_id: str = "dev-123",
+        pr_number: int = 42,
+        agent_session_id: str | None = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10",
+    ):
         from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
         from ctrlrelay.core.dispatcher import SessionResult
 
@@ -387,6 +538,7 @@ class TestRunDevIssueVerification:
             exit_code=0,
             stdout="",
             stderr="",
+            agent_session_id=agent_session_id,
             state=CheckpointState(
                 version="1",
                 status=CheckpointStatus.DONE,
@@ -488,7 +640,10 @@ class TestRunDevIssueVerification:
         # Claude invoked twice: initial + fix request
         assert mock_dispatcher.spawn_session.call_count == 2
         fix_call = mock_dispatcher.spawn_session.call_args_list[1].kwargs
-        assert fix_call["resume_session_id"] == fix_call["session_id"]
+        # Resume must use Claude's UUID, not our composite id — newer claude
+        # CLI versions reject non-UUID strings passed to --resume.
+        assert fix_call["resume_session_id"] == "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+        assert fix_call["resume_session_id"] != fix_call["session_id"]
         assert "ci" in fix_call["prompt"].lower() or "check" in fix_call["prompt"].lower()
 
     @pytest.mark.asyncio
@@ -534,6 +689,8 @@ class TestRunDevIssueVerification:
         assert mock_dispatcher.spawn_session.call_count == 2
         fix_call = mock_dispatcher.spawn_session.call_args_list[1].kwargs
         assert "conflict" in fix_call["prompt"].lower()
+        assert fix_call["resume_session_id"] == "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+        assert fix_call["resume_session_id"] != fix_call["session_id"]
 
     @pytest.mark.asyncio
     async def test_run_dev_issue_blocked_asks_transport_and_resumes(
@@ -548,12 +705,14 @@ class TestRunDevIssueVerification:
         from ctrlrelay.core.state import StateDB
         from ctrlrelay.pipelines.dev import run_dev_issue
 
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
         # 1st spawn = BLOCKED with a question. 2nd spawn (resume) = DONE.
         blocked = SessionResult(
             session_id="dev-123",
             exit_code=0,
             stdout="",
             stderr="",
+            agent_session_id=agent_uuid,
             state=CheckpointState(
                 version="1",
                 status=CheckpointStatus.BLOCKED_NEEDS_INPUT,
@@ -567,6 +726,7 @@ class TestRunDevIssueVerification:
             exit_code=0,
             stdout="",
             stderr="",
+            agent_session_id=agent_uuid,
             state=CheckpointState(
                 version="1",
                 status=CheckpointStatus.DONE,
@@ -624,7 +784,10 @@ class TestRunDevIssueVerification:
         # Dispatcher was called twice: initial run + resume-with-answer.
         assert mock_dispatcher.spawn_session.call_count == 2
         resume_kwargs = mock_dispatcher.spawn_session.await_args_list[1].kwargs
-        assert resume_kwargs["resume_session_id"] == resume_kwargs["session_id"]
+        # Resume must use Claude's UUID captured on the first spawn, not our
+        # composite id (newer claude CLI rejects non-UUID --resume values).
+        assert resume_kwargs["resume_session_id"] == agent_uuid
+        assert resume_kwargs["resume_session_id"] != resume_kwargs["session_id"]
         assert "pin to 2.4.1" in resume_kwargs["prompt"]
 
         # Final result is the DONE state.

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -133,6 +133,130 @@ class TestClaudeDispatcher:
             assert result.state.outputs["merged_prs"] == [1, 2, 3]
 
     @pytest.mark.asyncio
+    async def test_spawn_session_captures_agent_session_id_from_json(
+        self, tmp_path: Path
+    ) -> None:
+        """Should parse Claude's session_id UUID out of JSON stdout and attach
+        it to the returned SessionResult as agent_session_id."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+        payload = json.dumps({
+            "type": "result",
+            "session_id": agent_uuid,
+            "result": "ok",
+        }).encode()
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (payload, b"")
+        mock_proc.returncode = 0
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({
+            "version": "1",
+            "status": "DONE",
+            "session_id": "dev-o-r-1-abc",
+            "timestamp": "2026-04-20T00:00:00Z",
+            "summary": "ok",
+        }))
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await dispatcher.spawn_session(
+                session_id="dev-o-r-1-abc",
+                prompt="x",
+                working_dir=tmp_path,
+                state_file=state_file,
+            )
+
+        assert result.agent_session_id == agent_uuid
+        # Composite id still lives on .session_id for orchestrator bookkeeping.
+        assert result.session_id == "dev-o-r-1-abc"
+
+    @pytest.mark.asyncio
+    async def test_spawn_session_agent_session_id_none_when_stdout_not_json(
+        self, tmp_path: Path
+    ) -> None:
+        """If Claude didn't emit JSON (e.g. error output), agent_session_id is None."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"not json at all", b"")
+        mock_proc.returncode = 0
+
+        with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+            result = await dispatcher.spawn_session(
+                session_id="sid",
+                prompt="x",
+                working_dir=tmp_path,
+                state_file=tmp_path / "state.json",
+            )
+
+        assert result.agent_session_id is None
+
+    @pytest.mark.asyncio
+    async def test_spawn_session_passes_resume_session_id_verbatim(
+        self, tmp_path: Path
+    ) -> None:
+        """--resume must receive whatever resume_session_id we pass — the
+        dispatcher does not substitute our composite id."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_exec:
+            await dispatcher.spawn_session(
+                session_id="dev-o-r-1-abc",
+                prompt="x",
+                working_dir=tmp_path,
+                state_file=tmp_path / "state.json",
+                resume_session_id=agent_uuid,
+            )
+
+        argv = mock_exec.call_args.args
+        assert "--resume" in argv
+        assert argv[argv.index("--resume") + 1] == agent_uuid
+        # Never our composite id.
+        assert "dev-o-r-1-abc" not in argv
+
+    @pytest.mark.asyncio
+    async def test_spawn_session_no_resume_flag_when_none(
+        self, tmp_path: Path
+    ) -> None:
+        """Fresh spawns (resume_session_id=None) must not include --resume."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec", return_value=mock_proc
+        ) as mock_exec:
+            await dispatcher.spawn_session(
+                session_id="dev-o-r-1-abc",
+                prompt="x",
+                working_dir=tmp_path,
+                state_file=tmp_path / "state.json",
+            )
+
+        argv = mock_exec.call_args.args
+        assert "--resume" not in argv
+
+    @pytest.mark.asyncio
     async def test_spawn_session_parses_blocked_state(self, tmp_path: Path) -> None:
         """Should parse BLOCKED_NEEDS_INPUT checkpoint state."""
         from ctrlrelay.core.dispatcher import ClaudeDispatcher

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -86,3 +86,88 @@ class TestRepoLocks:
         holder = db.get_lock_holder("owner/repo")
         assert holder is None
         db.close()
+
+
+class TestAgentSessionId:
+    """The sessions table persists the agent (Claude) session UUID separately
+    from our composite orchestrator id, so resumes can feed the real UUID to
+    `claude --resume`."""
+
+    def test_sessions_table_has_agent_session_id_column(self, tmp_path: Path) -> None:
+        db = StateDB(tmp_path / "state.db")
+        cols = {
+            row[1]
+            for row in db.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert "agent_session_id" in cols
+        db.close()
+
+    def test_set_and_get_agent_session_id_roundtrip(self, tmp_path: Path) -> None:
+        import time as _time
+
+        db = StateDB(tmp_path / "state.db")
+        session_id = "dev-owner-repo-1-deadbeef"
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+
+        db.execute(
+            """INSERT INTO sessions
+               (id, pipeline, repo, status, started_at)
+               VALUES (?, ?, ?, ?, ?)""",
+            (session_id, "dev", "owner/repo", "running", int(_time.time())),
+        )
+        db.commit()
+
+        assert db.get_agent_session_id(session_id) is None
+
+        db.set_agent_session_id(session_id, agent_uuid)
+        assert db.get_agent_session_id(session_id) == agent_uuid
+
+        db.close()
+
+    def test_get_agent_session_id_returns_none_for_missing_session(
+        self, tmp_path: Path
+    ) -> None:
+        db = StateDB(tmp_path / "state.db")
+        assert db.get_agent_session_id("nope") is None
+        db.close()
+
+    def test_agent_session_id_migrates_onto_existing_db(self, tmp_path: Path) -> None:
+        """Opening a pre-existing database written by an older version should
+        transparently add the `agent_session_id` column (backfilled to NULL)."""
+        import sqlite3
+
+        db_path = tmp_path / "state.db"
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                pipeline TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                issue_number INTEGER,
+                worktree_path TEXT,
+                status TEXT NOT NULL,
+                blocked_question TEXT,
+                started_at INTEGER NOT NULL,
+                ended_at INTEGER,
+                claude_exit_code INTEGER,
+                summary TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, pipeline, repo, status, started_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("old-session", "dev", "owner/repo", "done", 1),
+        )
+        conn.commit()
+        conn.close()
+
+        db = StateDB(db_path)
+        cols = {
+            row[1]
+            for row in db.execute("PRAGMA table_info(sessions)").fetchall()
+        }
+        assert "agent_session_id" in cols
+        assert db.get_agent_session_id("old-session") is None
+        db.close()


### PR DESCRIPTION
## Summary

Closes #83.

Newer `claude` CLI versions (v2.0.x+) validate `--resume <id>` and require
either a real UUID or a known session title. ctrlrelay was passing its own
composite id (`dev-<owner>-<repo>-<issue>-<hex>`), so every resume path —
post-DONE CI/conflict fix rounds and Telegram-bridge answer-to-BLOCKED
round-trips — was hard-failing. PRs shipped fine, but operators saw a
misleading \"❌ Failed\" notification.

### Changes

- **`ClaudeDispatcher`**: parses `session_id` out of `claude -p --output-format json` stdout into `SessionResult.agent_session_id`.
- **`state_db`**: new nullable `sessions.agent_session_id` column, plus `set_agent_session_id` / `get_agent_session_id` helpers. Guarded `ALTER TABLE` migration for databases written by older versions (pre-fix rows backfill to NULL).
- **`DevPipeline` / `SecopsPipeline`**: centralize spawn via a private `_spawn(ctx, prompt, *, resume)` that looks up Claude's UUID from state_db on resume and persists the newly-returned UUID after each call. If state_db has no UUID (predates fix / stdout wasn't JSON) the spawn falls back to a fresh session rather than hard-failing.
- **Docs**: `architecture.md` updated to document `agent_session_id` and the new `StateDB` helpers.

### Test plan

- [x] `pytest tests/` — 223 tests pass (baseline 213 + 10 new)
- [x] Dispatcher unit tests: captures UUID from JSON; tolerates non-JSON; `--resume` receives UUID verbatim; `--resume` omitted when no id passed.
- [x] StateDB tests: column present on fresh DB; set/get roundtrip; missing session returns None; pre-fix DB migrates in place.
- [x] DevPipeline tests: `run()` persists UUID to state_db; `request_fix` uses stored UUID; `request_fix` falls back to fresh spawn when UUID absent; blocked→answer→resume and CI/conflict fix loops all use the UUID, not the composite id.
- [ ] Out of scope per the issue: cleaning up zombie pre-fix sessions in state_db.