### PR TITLE
fix(dev): add `ctrlrelay ci wait` so agent stops improvising bash CI-wait loops (closes #85)

### DIFF
--- a/docs/cli.md
+++ b/docs/cli.md
@@ -29,6 +29,7 @@ ctrlrelay [--version] <command> ...
 | `ctrlrelay skills ...` | Skill discovery / audit. |
 | `ctrlrelay bridge ...` | Manage the Telegram bridge daemon. |
 | `ctrlrelay run ...` | Run a pipeline interactively. |
+| `ctrlrelay ci ...` | CI helpers used by the dev pipeline prompt. |
 | `ctrlrelay poller ...` | Manage the issue-poller daemon. |
 
 > **Note:** the `repos`, `export`, `import`, `team-export`, `team-import`,
@@ -160,6 +161,35 @@ Runs the secops pipeline across configured repos (or one repo with `--repo`).
 Each repo's run is serialised by the per-repo lock; the overall sweep runs in
 parallel across repos. Reports per-repo success/failure and exits non-zero if
 any repo failed.
+
+## `ctrlrelay ci`
+
+### `ci wait`
+
+```bash
+ctrlrelay ci wait --pr N --repo OWNER/REPO [--timeout 600] [--interval 15]
+```
+
+| Flag | Default | Description |
+|---|---|---|
+| `--pr` / `-p` | — (required) | PR number to wait on. |
+| `--repo` / `-r` | — (required) | Repository as `owner/name`. |
+| `--timeout` / `-t` | `600` | Hard timeout in seconds. |
+| `--interval` / `-i` | `15` | Seconds between polls. |
+
+Polls `gh pr checks` until every check has left the pending bucket (or the
+hard timeout is hit), then exits with:
+
+- **0** — all checks passed (or the repo has no CI configured)
+- **1** — at least one check failed / cancelled / timed_out
+- **2** — hard timeout while checks were still pending
+
+Exists specifically so the dev pipeline's prompt can point Claude at one
+correct command instead of asking it to improvise a bash `until` / `while`
+loop — every attempt at improvising those has been inverted-semantics or
+pipe-swallowed the exit code (see [issue #85][issue-85]).
+
+[issue-85]: https://github.com/AInvirion/ctrlrelay/issues/85
 
 ## `ctrlrelay poller`
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -8,6 +8,8 @@ from rich.table import Table
 
 from ctrlrelay import __version__
 from ctrlrelay.core.config import ConfigError, load_config
+from ctrlrelay.core.github import GitHubCLI, GitHubError
+from ctrlrelay.core.pr_verifier import PRVerifier
 
 app = typer.Typer(
     name="ctrlrelay",
@@ -724,6 +726,83 @@ def run_dev(
         if result.error:
             console.print(f"  Error: {result.error}")
         raise typer.Exit(1)
+
+
+# CI subcommand group
+# Exists so the dev pipeline has a correct, exit-code-driven helper to wait
+# on PR checks. Claude used to improvise bash `until gh pr checks` loops that
+# were inverted-semantics and swallowed exit codes (see issue #85), burning
+# the whole session timeout on PRs that had already gone green.
+ci_app = typer.Typer(help="CI helpers.")
+app.add_typer(ci_app, name="ci")
+
+
+@ci_app.command("wait")
+def ci_wait(
+    pr: int = typer.Option(..., "--pr", "-p", help="PR number to wait on"),
+    repo: str = typer.Option(..., "--repo", "-r", help="Repository as owner/name"),
+    timeout: int = typer.Option(
+        600,
+        "--timeout",
+        "-t",
+        help="Hard timeout in seconds before giving up (exit 2).",
+    ),
+    interval: int = typer.Option(
+        15,
+        "--interval",
+        "-i",
+        help="Poll interval in seconds.",
+    ),
+) -> None:
+    """Wait for a PR's CI checks to finish.
+
+    Exit codes:
+      0 — all checks passed (or no CI configured)
+      1 — at least one check failed / cancelled / timed_out
+      2 — hard timeout hit while checks were still pending
+    """
+    import asyncio
+
+    github = GitHubCLI()
+    verifier = PRVerifier(
+        github=github,
+        poll_interval=interval,
+        check_timeout=timeout,
+    )
+
+    try:
+        checks = asyncio.run(
+            verifier.wait_for_checks(repo, pr, timeout=timeout)
+        )
+    except GitHubError as e:
+        console.print(f"[red]gh error:[/red] {e}")
+        raise typer.Exit(1)
+
+    pending = [c for c in checks if c.get("bucket") == "pending"]
+    failing = [
+        c for c in checks
+        if c.get("bucket") not in ("pending", "pass", "skipping")
+    ]
+
+    if failing:
+        names = ", ".join(
+            f"{c.get('name', '?')}={c.get('state') or c.get('bucket')}"
+            for c in failing
+        )
+        console.print(f"[red]CI failing:[/red] {names}")
+        raise typer.Exit(1)
+
+    if pending:
+        names = ", ".join(c.get("name", "?") for c in pending)
+        console.print(
+            f"[yellow]CI still running after {timeout}s:[/yellow] {names}"
+        )
+        raise typer.Exit(2)
+
+    if checks:
+        console.print(f"[green]All {len(checks)} check(s) passed.[/green]")
+    else:
+        console.print("[green]No CI checks configured — treating as pass.[/green]")
 
 
 # Poller subcommand group

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -151,9 +151,15 @@ Execute the following workflow:
 3. Plan and implement the fix using TDD
 4. Push the branch and open a PR that references the issue
 5. Before signaling DONE, verify the PR is mergeable:
-   - Poll `gh pr checks <PR>` until every check is `completed`; if any
-     conclusion is `failure`/`cancelled`/`timed_out`, investigate, fix, push
-     again, and re-poll.
+   - Wait for CI by running EXACTLY this command (do NOT improvise bash):
+     `ctrlrelay ci wait --pr <PR> --repo {repo} --timeout 600`
+     Exit codes: 0 = all checks passed, 1 = a check failed (investigate,
+     fix, push, then re-run the wait), 2 = hard timeout while CI is still
+     pending (treat as acceptable — hand off and let the orchestrator
+     re-verify). Do NOT write your own `until` / `while` loops around
+     `gh pr checks`; those have been miswritten in the past (inverted
+     semantics, pipes swallowing exit codes) and burned the whole session
+     timeout on PRs that were already green.
    - Run `gh pr view <PR> --json mergeable,mergeStateStatus` — if `mergeable`
      is `CONFLICTING` or `mergeStateStatus` is `DIRTY`, rebase onto the base
      branch, resolve conflicts, and push again.

--- a/tests/test_cli_ci_wait.py
+++ b/tests/test_cli_ci_wait.py
@@ -6,11 +6,22 @@ codes — see issue #85). This command replaces that improvisation with a
 first-class helper that has sane exit codes and a hard timeout.
 """
 
+import re
 from unittest.mock import AsyncMock, patch
 
 from typer.testing import CliRunner
 
 runner = CliRunner()
+
+# Typer-with-Rich colorises `--help` on some hosts (CI runners in particular),
+# which splits literal substrings like `--pr` across escape codes. Strip codes
+# before substring assertions so the tests work identically on a plain-TTY
+# dev laptop and the GitHub Actions runner.
+_ANSI = re.compile(r"\x1b\[[0-9;]*m")
+
+
+def _plain(output: str) -> str:
+    return _ANSI.sub("", output)
 
 
 class TestCIWaitCommand:
@@ -21,9 +32,10 @@ class TestCIWaitCommand:
         result = runner.invoke(app, ["ci", "wait", "--help"])
 
         assert result.exit_code == 0
-        assert "--pr" in result.output
-        assert "--repo" in result.output
-        assert "--timeout" in result.output
+        out = _plain(result.output)
+        assert "--pr" in out
+        assert "--repo" in out
+        assert "--timeout" in out
 
     def test_ci_wait_requires_pr_and_repo(self) -> None:
         """Both --pr and --repo are required."""
@@ -86,7 +98,7 @@ class TestCIWaitCommand:
             )
 
         assert result.exit_code == 1, result.output
-        assert "lint" in result.output
+        assert "lint" in _plain(result.output)
 
     def test_ci_wait_exits_2_when_timeout_with_pending(self) -> None:
         """Hard timeout while checks are still pending → exit 2 (distinct from fail)."""

--- a/tests/test_cli_ci_wait.py
+++ b/tests/test_cli_ci_wait.py
@@ -1,0 +1,127 @@
+"""Tests for `ctrlrelay ci wait` — the approved CI-wait helper.
+
+The dev pipeline used to ask Claude to improvise a bash `until gh pr checks`
+loop, which it kept getting wrong (inverted semantics, pipe swallowing exit
+codes — see issue #85). This command replaces that improvisation with a
+first-class helper that has sane exit codes and a hard timeout.
+"""
+
+from unittest.mock import AsyncMock, patch
+
+from typer.testing import CliRunner
+
+runner = CliRunner()
+
+
+class TestCIWaitCommand:
+    def test_ci_wait_help(self) -> None:
+        """`ctrlrelay ci wait --help` should document --pr, --repo, --timeout."""
+        from ctrlrelay.cli import app
+
+        result = runner.invoke(app, ["ci", "wait", "--help"])
+
+        assert result.exit_code == 0
+        assert "--pr" in result.output
+        assert "--repo" in result.output
+        assert "--timeout" in result.output
+
+    def test_ci_wait_requires_pr_and_repo(self) -> None:
+        """Both --pr and --repo are required."""
+        from ctrlrelay.cli import app
+
+        result = runner.invoke(app, ["ci", "wait"])
+
+        assert result.exit_code != 0
+
+    def test_ci_wait_exits_0_when_all_checks_pass(self) -> None:
+        """Exit 0 when every check is in a passing bucket."""
+        from ctrlrelay.cli import app
+
+        fake_github = AsyncMock()
+        fake_github.get_pr_checks.return_value = [
+            {"name": "ci", "state": "SUCCESS", "bucket": "pass"},
+            {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
+        ]
+
+        with patch("ctrlrelay.cli.GitHubCLI", return_value=fake_github):
+            result = runner.invoke(
+                app,
+                ["ci", "wait", "--pr", "42", "--repo", "owner/repo",
+                 "--timeout", "1", "--interval", "0"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_ci_wait_exits_0_when_no_ci_configured(self) -> None:
+        """Repos with no CI (empty checks after confirmation) should pass."""
+        from ctrlrelay.cli import app
+
+        fake_github = AsyncMock()
+        fake_github.get_pr_checks.return_value = []
+
+        with patch("ctrlrelay.cli.GitHubCLI", return_value=fake_github):
+            result = runner.invoke(
+                app,
+                ["ci", "wait", "--pr", "42", "--repo", "owner/repo",
+                 "--timeout", "1", "--interval", "0"],
+            )
+
+        assert result.exit_code == 0, result.output
+
+    def test_ci_wait_exits_1_when_check_fails(self) -> None:
+        """Any failing check → exit 1."""
+        from ctrlrelay.cli import app
+
+        fake_github = AsyncMock()
+        fake_github.get_pr_checks.return_value = [
+            {"name": "ci", "state": "SUCCESS", "bucket": "pass"},
+            {"name": "lint", "state": "FAILURE", "bucket": "fail"},
+        ]
+
+        with patch("ctrlrelay.cli.GitHubCLI", return_value=fake_github):
+            result = runner.invoke(
+                app,
+                ["ci", "wait", "--pr", "42", "--repo", "owner/repo",
+                 "--timeout", "1", "--interval", "0"],
+            )
+
+        assert result.exit_code == 1, result.output
+        assert "lint" in result.output
+
+    def test_ci_wait_exits_2_when_timeout_with_pending(self) -> None:
+        """Hard timeout while checks are still pending → exit 2 (distinct from fail)."""
+        from ctrlrelay.cli import app
+
+        fake_github = AsyncMock()
+        fake_github.get_pr_checks.return_value = [
+            {"name": "long-ci", "state": "IN_PROGRESS", "bucket": "pending"},
+        ]
+
+        with patch("ctrlrelay.cli.GitHubCLI", return_value=fake_github):
+            result = runner.invoke(
+                app,
+                ["ci", "wait", "--pr", "42", "--repo", "owner/repo",
+                 "--timeout", "0", "--interval", "0"],
+            )
+
+        assert result.exit_code == 2, result.output
+
+    def test_ci_wait_polls_until_pending_resolves(self) -> None:
+        """Should keep polling while pending, return 0 when everything goes green."""
+        from ctrlrelay.cli import app
+
+        fake_github = AsyncMock()
+        fake_github.get_pr_checks.side_effect = [
+            [{"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"}],
+            [{"name": "ci", "state": "SUCCESS", "bucket": "pass"}],
+        ]
+
+        with patch("ctrlrelay.cli.GitHubCLI", return_value=fake_github):
+            result = runner.invoke(
+                app,
+                ["ci", "wait", "--pr", "42", "--repo", "owner/repo",
+                 "--timeout", "5", "--interval", "0"],
+            )
+
+        assert result.exit_code == 0, result.output
+        assert fake_github.get_pr_checks.call_count == 2

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -23,6 +23,43 @@ class TestDevPipeline:
 
         assert pipeline.name == "dev"
 
+    def test_prompt_directs_claude_to_ci_wait_helper(self) -> None:
+        """Prompt must tell Claude to call `ctrlrelay ci wait` (or equivalent
+        approved command) rather than improvising a bash `until`/`while` loop.
+        Issue #85: hand-written loops were inverted-semantics and ate exit
+        codes, burning 30-min timeouts on PRs that had already gone green.
+        """
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        pipeline = DevPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+
+        prompt = pipeline._build_prompt(
+            repo="owner/repo",
+            issue_number=42,
+            extra={
+                "issue_title": "t",
+                "issue_body": "b",
+                "branch_name": "fix/issue-42",
+            },
+            session_id="dev-42",
+            state_file=Path("/tmp/state.json"),
+        )
+
+        # Points Claude at the approved waiter.
+        assert "ctrlrelay ci wait" in prompt
+        # Explicitly forbids the pattern that broke in issue #85.
+        lower = prompt.lower()
+        assert "until" in lower and "while" in lower, (
+            "prompt should explicitly ban `until`/`while` bash CI-wait loops"
+        )
+
     @pytest.mark.asyncio
     async def test_run_dispatches_claude_session(self, tmp_path: Path) -> None:
         """Should dispatch Claude session with issue context."""


### PR DESCRIPTION
## Summary

- Adds a first-class `ctrlrelay ci wait --pr N --repo O/R [--timeout 600]` helper that wraps `PRVerifier.wait_for_checks` with proper exit codes (0 = all pass, 1 = any fail/cancelled/timed_out, 2 = hard timeout while still pending).
- Updates the dev pipeline prompt (`src/ctrlrelay/pipelines/dev.py`) to instruct the agent to run exactly that command and explicitly bans hand-rolled `until` / `while` loops around `gh pr checks`.
- Adds CLI docs for the new command in `docs/cli.md`.

## Why

Per issue #85, the dev pipeline's prompt previously asked the agent to "wait for CI to be green" without saying how. The agent improvised a `until gh pr checks ... | grep -q 'pending|queued|in_progress' | head -1 ...` loop that had inverted `until` semantics (exits on pending found, loops on green) AND had its exit code swallowed by the pipe to `head`. Net effect: the loop spun for the full 30-minute session timeout on PRs that had already gone green, the dispatcher SIGKILL'd the child, and the operator got a misleading "Failed" Telegram notification.

This fix replaces both halves of the problem:
- **Shell correctness** is moved out of the model (who was guessing under time pressure) and into a tested Python helper that reuses the existing verifier logic.
- **Prompt** now points at one approved command instead of "do it yourself."

## Test plan

- [x] `pytest tests/test_cli_ci_wait.py` — 7 new tests covering exits 0/1/2 and poll-until-resolve.
- [x] `pytest tests/test_dev_pipeline.py::TestDevPipeline::test_prompt_directs_claude_to_ci_wait_helper` — regression guard against reverting the prompt fix.
- [x] `pytest` — full suite (221 passed, 2 pre-existing warnings).
- [x] `ctrlrelay ci wait --help` renders cleanly.

Closes #85.