### PR TITLE
feat(poller): exclude issues by label (closes #91)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   assignments are logged as `poll.issue.foreign_assignment` and marked seen
   so they aren't re-checked. Repos can opt back into the old "any assignment
   counts" behaviour with `automation.accept_foreign_assignments: true`.
+- **Poller exclude-label filter** (`repos[].automation.exclude_labels`): issues
+  carrying any configured label are marked seen, logged as
+  `poll.issue.excluded_by_label`, and skipped by the dev pipeline — lets the
+  operator mark issues as "manual / operator / instruction" without the agent
+  opening off-topic PRs for them. Defaults to `["manual", "operator",
+  "instruction"]`; set to `[]` to disable. Closes #91.
 
 ## [0.1.5] - 2026-04-20
 

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -51,3 +51,10 @@ repos: []
   #     dependabot_patch: auto
   #     dependabot_minor: ask
   #     dependabot_major: never
+  #     # Issues carrying any of these labels are skipped by the poller:
+  #     # marked seen, logged as poll.issue.excluded_by_label, and never
+  #     # handed to the dev pipeline. Intended for operator tasks and
+  #     # pure instruction issues that should not trigger code changes.
+  #     # Matching is case-insensitive. Defaults to ["manual", "operator",
+  #     # "instruction"]; override with an empty list to disable.
+  #     exclude_labels: ["manual", "operator", "instruction"]

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -164,6 +164,7 @@ repos:
       secret_alerts: never
       deploy_after_merge: auto
       accept_foreign_assignments: false
+      exclude_labels: ["manual", "operator", "instruction"]
     code_review: { ... }      # optional
     deploy:      { ... }      # optional
 ```
@@ -191,9 +192,41 @@ and ask the operator), or `never` (skip).
 | `secret_alerts` | `never` | Secret-scan alerts. |
 | `deploy_after_merge` | `auto` | Whether to deploy after a merged PR. |
 | `accept_foreign_assignments` | `false` | When `true`, the poller also picks up issues assigned to you by someone else. Default (`false`) runs the dev pipeline only on issues you self-assigned. |
+| `exclude_labels` | `["manual", "operator", "instruction"]` | Issue labels that tell the poller "this isn't for the agent". See [exclude_labels](#reposautomationexclude_labels) below. |
 
 The current secops and dev pipelines read these settings to bias their prompts
 to Claude — they're not enforced by hard-coded checks.
+
+### repos[].automation.exclude_labels
+
+Some issues you assign to the operator user aren't code work — they're operator
+tasks (validate a build on your laptop) or pure instructions (document a
+workflow). The dev pipeline has no way to tell these apart from a feature
+request on its own, so it dutifully writes code and opens a PR anyway.
+
+`exclude_labels` gives the operator a short-circuit: any issue carrying one of
+the configured labels is **marked seen** in `poller_state.json` so it doesn't
+re-appear on the next poll, **not handed to the dev pipeline**, and **logged**
+under the `poll.issue.excluded_by_label` event.
+
+```yaml
+repos:
+  - name: "your-org/your-repo"
+    local_path: "~/Projects/your-repo"
+    automation:
+      exclude_labels: ["manual", "operator", "instruction"]
+```
+
+- Default: `["manual", "operator", "instruction"]`. Set to `[]` to disable.
+- Matching is **case-insensitive** (`Manual` matches `manual`).
+- The check runs in the poller, before any dev-pipeline work is scheduled.
+- Apply the label on GitHub; the next poll will pick it up automatically.
+
+If you mislabel and want the agent to take the issue after all, remove the
+label on GitHub **and** delete the issue number from
+`poller_state.json` (or bump the issue so it becomes visible again via some
+other mechanism — the poller treats "seen" as sticky per design, so operator
+input is the source of truth).
 
 ## Example: telegram-enabled config
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -912,12 +912,17 @@ def poller_start(
 
         first_run = not state_file.exists()
 
+        exclude_labels_by_repo = {
+            r.name: list(r.automation.exclude_labels) for r in config.repos
+        }
+
         poller = IssuePoller(
             github=github,
             username=username,
             repos=repo_names,
             state_file=state_file,
             accept_foreign_assignments=accept_foreign,
+            exclude_labels_by_repo=exclude_labels_by_repo,
         )
 
         # NOTE: first-run seeding moved into `_main()` so the APScheduler

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -148,6 +148,9 @@ class AutomationConfig(BaseModel):
     secret_alerts: AutomationPolicy = AutomationPolicy.NEVER
     deploy_after_merge: AutomationPolicy = AutomationPolicy.AUTO
     accept_foreign_assignments: bool = False
+    exclude_labels: list[str] = Field(
+        default_factory=lambda: ["manual", "operator", "instruction"]
+    )
 
 
 class RepoConfig(BaseModel):

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -42,6 +42,14 @@ class IssuePoller:
     ``assigned`` event naming ``username`` was performed by ``username``
     themselves — i.e. self-assignment only. Repos listed in
     ``accept_foreign_assignments`` bypass this check.
+
+    ``exclude_labels_by_repo`` gives the operator a way to mark issues as
+    "not for the agent" (operator tasks, pure instructions, manual work).
+    Matched issues are marked seen so they don't keep reappearing, logged
+    under ``poll.issue.excluded_by_label``, and never handed to the dev
+    pipeline. The exclusion check runs BEFORE the assignment-event lookup
+    so it short-circuits the extra ``gh`` call for excluded issues.
+    Matching is case-insensitive.
     """
 
     github: GitHubCLI
@@ -50,6 +58,7 @@ class IssuePoller:
     state_file: Path
     seen_issues: dict[str, set[int]] = field(default_factory=dict)
     accept_foreign_assignments: set[str] = field(default_factory=set)
+    exclude_labels_by_repo: dict[str, list[str]] = field(default_factory=dict)
     # Per-repo consecutive-skip counter; populated at runtime by poll() /
     # seed_current(). Not persisted — intentionally resets on daemon
     # restart so an operator fix is exercised before we re-escalate.
@@ -149,6 +158,11 @@ class IssuePoller:
         ``gh`` exit, OS error) is logged and skipped so the other repos still
         get polled. Only ``asyncio.CancelledError`` escapes, which allows a
         clean shutdown signal to propagate.
+
+        Issues carrying any label from ``exclude_labels_by_repo[repo]`` are
+        marked seen and dropped before the assignment-event check runs, so
+        operator-only / instruction-only issues never reach the dev pipeline
+        and we don't pay a second ``gh`` call for them.
         """
         new_issues: list[dict[str, Any]] = []
 
@@ -184,6 +198,10 @@ class IssuePoller:
             self._clear_repo_failure(repo)
 
             seen_for_repo = self.seen_issues.setdefault(repo, set())
+            exclude_lowered = {
+                label.lower()
+                for label in self.exclude_labels_by_repo.get(repo, [])
+            }
             for issue in issues:
                 # Per-issue guard so ONE malformed payload (missing 'number',
                 # wrong type, non-dict entry) doesn't poison the remaining
@@ -203,6 +221,22 @@ class IssuePoller:
                     continue
 
                 if number in seen_for_repo:
+                    continue
+
+                # Exclude-label filter runs before the assignment-event
+                # lookup so operator-only issues never trigger a second
+                # gh call, and are permanently marked seen so they stop
+                # re-appearing in future polls.
+                matched = self._matched_exclude_label(issue, exclude_lowered)
+                if matched is not None:
+                    seen_for_repo.add(number)
+                    log_event(
+                        _logger,
+                        "poll.issue.excluded_by_label",
+                        repo=repo,
+                        issue_number=number,
+                        matched_label=matched,
+                    )
                     continue
 
                 # Mark seen before deciding whether to surface the issue so a
@@ -278,6 +312,28 @@ class IssuePoller:
             assigner_login=assigner_login,
         )
         return False
+
+    @staticmethod
+    def _matched_exclude_label(
+        issue: dict[str, Any], exclude_lowered: set[str]
+    ) -> str | None:
+        """Return the first issue label that matches ``exclude_lowered``.
+
+        Labels come back from ``gh issue list`` as ``[{"name": "...", ...}]``;
+        we also accept a plain list of strings for flexibility in tests.
+        Matching is case-insensitive; the returned value is the label's
+        original casing so log output reflects what's actually on the issue.
+        """
+        if not exclude_lowered:
+            return None
+        for label in issue.get("labels") or []:
+            if isinstance(label, dict):
+                name = label.get("name", "")
+            else:
+                name = str(label)
+            if name and name.lower() in exclude_lowered:
+                return name
+        return None
 
     def mark_seen(self, repo: str, issue_number: int) -> None:
         """Mark an issue as seen without triggering a poll.

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -3,8 +3,9 @@
 from pathlib import Path
 
 import pytest
+import yaml
 
-from ctrlrelay.core.config import Config, ConfigError, load_config
+from ctrlrelay.core.config import AutomationConfig, Config, ConfigError, load_config
 
 
 class TestConfigLoading:
@@ -191,3 +192,57 @@ class TestTimezoneValidation:
         cfg_path.write_text(yaml.dump(sample_config_dict))
         config = load_config(cfg_path)
         assert config.timezone == "America/Santiago"
+
+
+class TestAutomationExcludeLabels:
+    """exclude_labels surfaces per-repo so the poller can skip operator-only issues."""
+
+    def test_default_exclude_labels(self) -> None:
+        """Default covers the common 'not for the agent' keywords from #91."""
+        auto = AutomationConfig()
+        assert auto.exclude_labels == ["manual", "operator", "instruction"]
+
+    def test_exclude_labels_empty_list_is_valid(self) -> None:
+        """Operators can opt out of any default exclusions."""
+        auto = AutomationConfig(exclude_labels=[])
+        assert auto.exclude_labels == []
+
+    def test_config_without_exclude_labels_key_gets_default(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """Legacy configs without exclude_labels load fine and get the default."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"dependabot_patch": "auto"},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.exclude_labels == [
+            "manual",
+            "operator",
+            "instruction",
+        ]
+
+    def test_exclude_labels_override_from_yaml(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """YAML override wins over the built-in default."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"exclude_labels": ["no-agent", "wontfix"]},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.exclude_labels == ["no-agent", "wontfix"]

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -11,13 +12,17 @@ import pytest
 from ctrlrelay.core.poller import IssuePoller
 
 
-def make_issue(number: int, title: str = "Test issue") -> dict:
+def make_issue(
+    number: int,
+    title: str = "Test issue",
+    labels: list[dict] | list[str] | None = None,
+) -> dict:
     return {
         "number": number,
         "title": title,
         "state": "open",
         "body": "",
-        "labels": [],
+        "labels": labels or [],
         "assignees": [],
         "createdAt": "2026-01-01T00:00:00Z",
         "updatedAt": "2026-01-01T00:00:00Z",
@@ -161,6 +166,168 @@ class TestIssuePoller:
 
         mock_github.list_assigned_issues.assert_not_called()
         assert 99 in poller.seen_issues.get("owner/repo-a", set())
+
+    @pytest.mark.asyncio
+    async def test_poll_excludes_issues_with_matching_label(
+        self,
+        mock_github: MagicMock,
+        state_file: Path,
+        caplog: pytest.LogCaptureFixture,
+    ) -> None:
+        """Issues carrying an exclude label are marked seen but NOT returned."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Operator task", labels=[{"name": "manual"}]),
+            make_issue(2, "Real code work", labels=[{"name": "bug"}]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            exclude_labels_by_repo={"owner/repo-a": ["manual", "operator"]},
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.poller"):
+            results = await poller.poll()
+
+        # Only issue #2 survives; #1 is filtered out by label.
+        assert [r["issue"]["number"] for r in results] == [2]
+
+        # Both issues are now marked seen — #1 will not re-appear.
+        assert poller.seen_issues["owner/repo-a"] == {1, 2}
+
+        # The excluded issue is logged under the agreed event name.
+        records = [
+            r for r in caplog.records if r.getMessage() == "poll.issue.excluded_by_label"
+        ]
+        assert len(records) == 1
+        rec = records[0]
+        assert rec.repo == "owner/repo-a"
+        assert rec.issue_number == 1
+        assert rec.matched_label == "manual"
+
+    @pytest.mark.asyncio
+    async def test_poll_without_exclude_labels_returns_everything(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """Labeled issues pass through when no exclude_labels are configured."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Looks operator-y but no exclude configured", labels=[{"name": "manual"}]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+        )
+
+        results = await poller.poll()
+
+        assert len(results) == 1
+        assert results[0]["issue"]["number"] == 1
+
+    @pytest.mark.asyncio
+    async def test_poll_exclude_match_is_case_insensitive(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """'Manual' label matches 'manual' in exclude config."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Case mismatch", labels=[{"name": "Manual"}]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            exclude_labels_by_repo={"owner/repo-a": ["manual"]},
+        )
+
+        results = await poller.poll()
+
+        assert results == []
+        assert 1 in poller.seen_issues["owner/repo-a"]
+
+    @pytest.mark.asyncio
+    async def test_poll_excluded_issue_not_rereported_across_polls(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """Once excluded and marked seen, the issue stays excluded on next poll.
+
+        Guards against the failure mode in #91: the issue keeps re-appearing
+        and the dev pipeline keeps getting spawned for operator-only work.
+        """
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Operator task", labels=[{"name": "manual"}]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            exclude_labels_by_repo={"owner/repo-a": ["manual"]},
+        )
+
+        # First poll: excluded, marked seen.
+        assert await poller.poll() == []
+
+        # Second poll with the same issue still present: still no handoff.
+        assert await poller.poll() == []
+
+    @pytest.mark.asyncio
+    async def test_poll_exclude_labels_persist_in_state_file(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """An excluded issue survives a poller restart (written to state.json)."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Op task", labels=[{"name": "manual"}]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            exclude_labels_by_repo={"owner/repo-a": ["manual"]},
+        )
+        await poller.poll()
+
+        saved = json.loads(state_file.read_text())
+        assert saved["seen_issues"]["owner/repo-a"] == [1]
+
+        # Restart: no exclude config this time. The issue still shouldn't
+        # re-appear because it was persisted as seen.
+        restarted = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+        )
+        assert await restarted.poll() == []
+
+    @pytest.mark.asyncio
+    async def test_poll_accepts_string_labels(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """Label matching tolerates labels given as plain strings (test robustness)."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Plain string labels", labels=["manual", "bug"]),
+        ]
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            exclude_labels_by_repo={"owner/repo-a": ["manual"]},
+        )
+
+        results = await poller.poll()
+
+        assert results == []
 
     @pytest.mark.asyncio
     async def test_run_poll_loop_processes_new_issues(self, tmp_path: Path) -> None:

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -213,7 +213,11 @@ class TestIssuePoller:
     ) -> None:
         """Labeled issues pass through when no exclude_labels are configured."""
         mock_github.list_assigned_issues.return_value = [
-            make_issue(1, "Looks operator-y but no exclude configured", labels=[{"name": "manual"}]),
+            make_issue(
+                1,
+                "Looks operator-y but no exclude configured",
+                labels=[{"name": "manual"}],
+            ),
         ]
 
         poller = IssuePoller(


### PR DESCRIPTION
## Summary

- Adds `repos[].automation.exclude_labels: list[str]` to config (default: `["manual", "operator", "instruction"]`).
- Poller short-circuits issues carrying any excluded label **before** the dev pipeline runs: marks them seen so they don't re-appear, skips handoff, and emits `poll.issue.excluded_by_label` for observability.
- Matching is case-insensitive.
- Covers the #87 → #89 failure mode (operator task → bot opened a PR that got closed without merging).
- Layer 2 (classifier pre-step) from the issue is intentionally left as a follow-up — explicitly optional and not cost-validated.

## Test plan

- [x] `tests/test_poller.py::TestIssuePoller` — exclude labels drop issues, mark them seen, log the event, and stay dropped across poll restarts.
- [x] Case-insensitive matching, string-form labels, and state persistence covered.
- [x] `tests/test_config.py::TestAutomationExcludeLabels` — default list, empty-list opt-out, legacy-config default, YAML override.
- [x] Full suite: `python3 -m pytest` → 223 passed.

Closes #91.