### PR TITLE
chore(release): v0.1.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.7] - 2026-04-20
+
+Patch release. Fixes one drift bug in how the package reports its own
+version — the `__version__` string was pinned to a literal in
+`__init__.py` and never got bumped alongside releases, so `ctrlrelay
+version` on an installed 0.1.6 wheel still reported `0.1.4`. No API
+or behavior changes.
+
+### Fixed
+
+- **`__version__` now derives from installed metadata** (`closes
+  #94`). `ctrlrelay.__version__` resolves via
+  `importlib.metadata.version("ctrlrelay")` at import time so it
+  tracks the installed wheel's `pyproject.toml` automatically.
+  Source-checkout pytest runs (where no dist-info exists because
+  `pythonpath = ["src"]` is the only mechanism putting the package on
+  `sys.path`) fall back to parsing the sibling `pyproject.toml` with
+  `tomllib` — so the drift-catcher test
+  (`test_version_matches_pyproject`) still sees a real version
+  instead of a `0.0.0+unknown` placeholder.
+
+### Operator notes
+
+- No migration or restart guidance. Upgrade via `uv tool upgrade
+  ctrlrelay` (or `pip install -U ctrlrelay`) and the next `ctrlrelay
+  version` will report `0.1.7`.
+
 ## [0.1.6] - 2026-04-20
 
 The "pipeline reliability + operator control" release. Closes three

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.1.6"
+version = "0.1.7"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release. Picks up the #94 fix so `ctrlrelay.__version__` tracks the installed wheel instead of pinning to whatever literal was last hand-edited.

## Changes since v0.1.6

- **#95 (closes #94)** — `__version__` now resolves via `importlib.metadata.version("ctrlrelay")` at import time, with a `tomllib`-based pyproject fallback for source-checkout pytest runs.

## Release checklist

- [x] `pyproject.toml` → `0.1.7`
- [x] `CHANGELOG.md` — `[0.1.7] - 2026-04-20` section added
- [x] `src/ctrlrelay/__init__.py` — dynamic `__version__` (landed in #95, no literal to bump)
- [x] Full test suite: 359 passed
- [ ] CI green → squash-merge → tag `v0.1.7` → PyPI publish via OIDC