### PR TITLE
ci: fix spurious build failure on tag push (attach only on release:published)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,14 +38,16 @@ jobs:
           path: dist/*
           if-no-files-found: error
 
+      # Only attach on release: published. Tag-push alone (push.tags: v*)
+      # races `gh release create` — if the tag lands a second before the
+      # release is created, this step fails with "release not found".
+      # The release event fires AFTER the release exists, so the upload
+      # is always safe.
       - name: Attach artifacts to GitHub release
-        if: github.event_name == 'release' || startsWith(github.ref, 'refs/tags/v')
+        if: github.event_name == 'release'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          TAG="${GITHUB_REF#refs/tags/}"
-          if [ "$GITHUB_EVENT_NAME" = "release" ]; then
-            TAG="${{ github.event.release.tag_name }}"
-          fi
+          TAG="${{ github.event.release.tag_name }}"
           echo "Uploading dist/* to release ${TAG}"
           gh release upload "${TAG}" dist/* --repo "${GITHUB_REPOSITORY}" --clobber


### PR DESCRIPTION
Every release (v0.1.5 through v0.1.8) produced one red \"Build Python distribution\" check on the tag-push event. The attach step tried \`gh release upload \$TAG\` but the release was created a moment later by \`gh release create\`, so it got \"release not found\" and exited 1.

The release:published event fires AFTER the release exists, so that's the safe trigger. The tag-push build still runs (builds + uploads to the workflow artifact store for CI sanity), it just doesn't try to touch a GitHub Release that might not exist yet.

## Test plan

- [ ] CI green on this PR
- [ ] Merge
- [ ] Next release (or a manual tag-push) should no longer produce the red check