### PR TITLE
fix(worktree): explicit refspec in ensure_bare_repo fetch (stale bare clone bug)

### DIFF
--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -568,11 +568,32 @@ class WorktreeManager:
         await self._run_git("push", "-u", "origin", branch, cwd=worktree_path)
 
     async def ensure_bare_repo(self, repo: str) -> Path:
-        """Ensure bare repo exists, cloning if needed."""
+        """Ensure bare repo exists, cloning if needed.
+
+        Uses an explicit refspec on fetch instead of relying on
+        ``remote.origin.fetch`` config. Some bare clones in the wild
+        have the refspec missing or empty; ``git fetch --all`` is a
+        silent no-op in that case, so repeated calls never update
+        ``refs/heads/*``. Worktrees created from that stale bare
+        then check out commits days or weeks behind origin —
+        exactly what we saw today when a task-pipeline run reported
+        test counts from a commit that was two weeks old.
+
+        ``+refs/heads/*:refs/heads/*`` writes remote branch heads
+        directly to local branch refs (the standard bare-clone
+        convention). The leading ``+`` force-updates so a non-fast-
+        forward rewind on origin is reflected instead of silently
+        ignored. ``--prune`` drops refs that no longer exist on
+        origin so deleted branches don't linger forever.
+        """
         bare_path = self._get_bare_repo_path(repo)
 
         if bare_path.exists():
-            await self._run_git("fetch", "--all", cwd=bare_path)
+            await self._run_git(
+                "fetch", "--prune", "origin",
+                "+refs/heads/*:refs/heads/*",
+                cwd=bare_path,
+            )
         else:
             await self._run_git(
                 "clone", "--bare",

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -579,19 +579,30 @@ class WorktreeManager:
         exactly what we saw today when a task-pipeline run reported
         test counts from a commit that was two weeks old.
 
-        ``+refs/heads/*:refs/heads/*`` writes remote branch heads
-        directly to local branch refs (the standard bare-clone
-        convention). The leading ``+`` force-updates so a non-fast-
-        forward rewind on origin is reflected instead of silently
-        ignored. ``--prune`` drops refs that no longer exist on
-        origin so deleted branches don't linger forever.
+        Refspec: ``refs/heads/*:refs/heads/*`` (no leading ``+``).
+        Fast-forward-only on purpose — codex caught this on the
+        first pass: a force update would clobber the dev pipeline's
+        ``create_worktree_with_new_branch`` reuse path, which keeps
+        local-ahead-of-origin commits when a prior session pushed
+        partial work. Non-force semantics give us the right
+        behavior in all three cases:
+
+        - Local branch BEHIND origin (default-branch case, the bug
+          we're fixing): fast-forward applies, local catches up.
+        - Local branch AHEAD of origin (unpushed dev work): fetch
+          refuses to rewind, local stays as-is, dev's reuse logic
+          gets to inspect divergence and decide.
+        - Local and origin equal: no-op.
+
+        ``--prune`` drops refs that no longer exist on origin so
+        deleted branches don't linger forever.
         """
         bare_path = self._get_bare_repo_path(repo)
 
         if bare_path.exists():
             await self._run_git(
                 "fetch", "--prune", "origin",
-                "+refs/heads/*:refs/heads/*",
+                "refs/heads/*:refs/heads/*",
                 cwd=bare_path,
             )
         else:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -82,7 +82,13 @@ class TestWorktreeManager:
         # Must be a fetch, not --all, with the explicit refspec.
         assert args[0] == "fetch"
         assert "origin" in args
-        assert "+refs/heads/*:refs/heads/*" in args
+        # Non-force refspec on purpose: codex P1 — a force fetch
+        # would destroy unpushed local commits in the dev pipeline's
+        # branch-reuse flow. Fast-forward-only fixes the stale-
+        # default-branch case while leaving divergent dev branches
+        # for the reuse logic to handle.
+        assert "refs/heads/*:refs/heads/*" in args
+        assert "+refs/heads/*:refs/heads/*" not in args
         assert "--prune" in args
         # Explicit refspec must win over the bare `--all` that used to
         # silently no-op on refspec-less repos.

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -53,6 +53,42 @@ class TestWorktreeManager:
             assert any("clone" in str(c) and "--bare" in str(c) for c in calls)
 
     @pytest.mark.asyncio
+    async def test_ensure_bare_repo_fetches_with_explicit_refspec(
+        self, tmp_path: Path
+    ) -> None:
+        """When the bare already exists, fetch must use an explicit
+        refspec — some bare clones have no remote.origin.fetch config
+        so `git fetch --all` is a silent no-op. Without explicit
+        refspec we saw a task-pipeline run report test counts from a
+        commit two weeks behind origin. The fix writes
+        ``+refs/heads/*:refs/heads/*`` directly so ``refs/heads/main``
+        stays in sync regardless of config state."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        # Pre-create the bare so ensure_bare_repo takes the fetch branch.
+        bare = manager._get_bare_repo_path("owner/repo")
+        bare.mkdir(parents=True)
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.return_value = ""
+            await manager.ensure_bare_repo("owner/repo")
+
+        assert mock_git.await_count == 1
+        args = mock_git.await_args.args
+        # Must be a fetch, not --all, with the explicit refspec.
+        assert args[0] == "fetch"
+        assert "origin" in args
+        assert "+refs/heads/*:refs/heads/*" in args
+        assert "--prune" in args
+        # Explicit refspec must win over the bare `--all` that used to
+        # silently no-op on refspec-less repos.
+        assert "--all" not in args
+
+    @pytest.mark.asyncio
     async def test_remove_worktree(self, tmp_path: Path) -> None:
         """Should remove worktree and prune."""
         from ctrlrelay.core.worktree import WorktreeManager

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -61,8 +61,10 @@ class TestWorktreeManager:
         so `git fetch --all` is a silent no-op. Without explicit
         refspec we saw a task-pipeline run report test counts from a
         commit two weeks behind origin. The fix writes
-        ``+refs/heads/*:refs/heads/*`` directly so ``refs/heads/main``
-        stays in sync regardless of config state."""
+        ``refs/heads/*:refs/heads/*`` directly so ``refs/heads/main``
+        stays in sync regardless of config state. Non-force on
+        purpose so dev's branch-reuse path can still preserve
+        unpushed local commits — see assertion below."""
         from ctrlrelay.core.worktree import WorktreeManager
 
         manager = WorktreeManager(


### PR DESCRIPTION
Caught by yesterday's task-pipeline e2e (#104): the agent reported pytest ran 213 tests against commit \`97b05d1\` while current main was \`237da2d\` (two weeks ahead). Root cause: \`ensure_bare_repo\` ran \`git fetch --all\` on bare clones that had no \`remote.origin.fetch\` refspec — silent no-op. Local \`refs/heads/main\` never moved from the commit it was at when the bare was first cloned. Worktrees then checked out that stale ref.

## Fix

Explicit refspec \`+refs/heads/*:refs/heads/*\` on every fetch. Writes remote branch heads directly to local branch refs (standard bare-clone convention) regardless of what's in the config. Added \`--prune\` so deleted branches don't linger.

## Live impact

Before shipping the code fix I also manually refreshed all 12 existing bare clones in \`~/.ctrlrelay/repos\` so tomorrow's 6am secops sweep doesn't run against stale checkouts.

Affects: \`create_worktree\` (task + secops paths) and \`create_worktree_with_new_branch\` (dev path). Dev was less visibly broken because the branch-create logic does its own fetch for the PR branch, but the default-branch starting point was still stale when reading files from main.

## Test plan

- [x] \`uv run pytest -q\` → 378 passed (1 new: \`test_ensure_bare_repo_fetches_with_explicit_refspec\`)
- [x] \`uv run ruff check src tests\` → clean
- [x] Manual verification: ctrlrelay bare \`refs/heads/main\` went from \`97b05d1\` → \`237da2d\` after running the new fetch directly
- [ ] CI green
- [ ] Merge, ship as 0.1.11