### PR TITLE
fix(ci-wait): cap sleep at deadline + retry on transient gh errors (closes #90)

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -788,9 +788,15 @@ def ci_wait(
         checks = asyncio.run(
             verifier.wait_for_checks(repo, pr, timeout=timeout)
         )
-    except GitHubError as e:
-        console.print(f"[red]gh error:[/red] {e}")
-        raise typer.Exit(1)
+    except (GitHubError, asyncio.TimeoutError) as e:
+        # wait_for_checks already retries transient errors internally;
+        # this except is defense-in-depth for any leak past the retry
+        # window (e.g. repeated timeouts that exhaust the deadline
+        # mid-call). Surface a clean message instead of a traceback.
+        console.print(
+            f"[red]gh error ({type(e).__name__}):[/red] {e}"
+        )
+        raise typer.Exit(1) from e
 
     pending = [c for c in checks if c.get("bucket") == "pending"]
     failing = [

--- a/src/ctrlrelay/core/pr_verifier.py
+++ b/src/ctrlrelay/core/pr_verifier.py
@@ -6,7 +6,10 @@ import asyncio
 from dataclasses import dataclass, field
 from typing import Any
 
-from ctrlrelay.core.github import GitHubCLI
+from ctrlrelay.core.github import GitHubCLI, GitHubError
+from ctrlrelay.core.obs import get_logger, log_event
+
+_logger = get_logger("core.pr_verifier")
 
 # `gh pr checks --json bucket` returns one of: pass, fail, pending, skipping, cancel.
 # Treat skipping as pass (skipped jobs don't block a merge) and everything except
@@ -68,25 +71,58 @@ class PRVerifier:
         `gh pr create` so a single empty read is ambiguous — the repo might
         have no CI, or CI just hasn't registered yet. We require
         `_EMPTY_CHECKS_CONFIRM_POLLS` consecutive empty reads separated by
-        `poll_interval` before concluding "no CI configured"."""
+        `poll_interval` before concluding "no CI configured".
+
+        Transient `gh` failures (subprocess timeout, GitHubError) are
+        treated as "still pending" and retried on the next iteration —
+        a flaky network or a GitHub rate-limit back-off shouldn't abort
+        the wait. The outer `limit` deadline is the safety net.
+
+        Sleep cap: when called with `timeout < poll_interval` the loop
+        used to block the full `poll_interval` before noticing the
+        deadline (issue #90). Now caps `sleep` at `max(0, limit -
+        elapsed)` so a 1-second timeout with a 15-second interval
+        returns within ~1 second.
+        """
         limit = self.check_timeout if timeout is None else timeout
         elapsed = 0
         empty_streak = 0
         checks: list[dict[str, Any]] = []
         while True:
-            checks = await self.github.get_pr_checks(repo, pr_number)
-            if not checks:
-                empty_streak += 1
-                if empty_streak >= _EMPTY_CHECKS_CONFIRM_POLLS:
-                    return checks
+            try:
+                checks = await self.github.get_pr_checks(repo, pr_number)
+            except (GitHubError, asyncio.TimeoutError) as e:
+                # Transient gh failure — treat as still-pending, retry
+                # on next iteration. Unconditional re-raise of
+                # asyncio.TimeoutError used to surface as an ugly
+                # traceback in `ctrlrelay ci wait` (issue #90).
+                log_event(
+                    _logger,
+                    "pr_verifier.transient_gh_error",
+                    repo=repo,
+                    pr_number=pr_number,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
             else:
-                empty_streak = 0
-                if all(c.get("bucket") not in _PENDING_BUCKETS for c in checks):
-                    return checks
+                if not checks:
+                    empty_streak += 1
+                    if empty_streak >= _EMPTY_CHECKS_CONFIRM_POLLS:
+                        return checks
+                else:
+                    empty_streak = 0
+                    if all(
+                        c.get("bucket") not in _PENDING_BUCKETS
+                        for c in checks
+                    ):
+                        return checks
             if elapsed >= limit:
                 return checks
-            await asyncio.sleep(self.poll_interval)
-            elapsed += self.poll_interval
+            sleep_for = min(
+                self.poll_interval, max(0, limit - elapsed)
+            )
+            await asyncio.sleep(sleep_for)
+            elapsed += sleep_for
 
     async def verify(
         self,

--- a/src/ctrlrelay/core/pr_verifier.py
+++ b/src/ctrlrelay/core/pr_verifier.py
@@ -85,9 +85,16 @@ class PRVerifier:
         returns within ~1 second.
         """
         limit = self.check_timeout if timeout is None else timeout
-        elapsed = 0
+        loop = asyncio.get_event_loop()
+        # Wall-clock deadline (monotonic) so the loop terminates even
+        # if `poll_interval` is 0 and every poll errors — accumulating
+        # sleep durations would loop forever in that case because
+        # max(0, 0) is still 0.
+        deadline = loop.time() + limit
         empty_streak = 0
         checks: list[dict[str, Any]] = []
+        had_successful_read = False
+        last_transient_error: Exception | None = None
         while True:
             try:
                 checks = await self.github.get_pr_checks(repo, pr_number)
@@ -96,6 +103,7 @@ class PRVerifier:
                 # on next iteration. Unconditional re-raise of
                 # asyncio.TimeoutError used to surface as an ugly
                 # traceback in `ctrlrelay ci wait` (issue #90).
+                last_transient_error = e
                 log_event(
                     _logger,
                     "pr_verifier.transient_gh_error",
@@ -105,6 +113,8 @@ class PRVerifier:
                     error=str(e)[:200],
                 )
             else:
+                had_successful_read = True
+                last_transient_error = None
                 if not checks:
                     empty_streak += 1
                     if empty_streak >= _EMPTY_CHECKS_CONFIRM_POLLS:
@@ -116,13 +126,20 @@ class PRVerifier:
                         for c in checks
                     ):
                         return checks
-            if elapsed >= limit:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                # Fail closed if every poll failed: an empty `checks`
+                # list would be misread as "no CI configured" and the
+                # caller would silently greenlight the PR while
+                # GitHub was actually unavailable. Surface the last
+                # transient error so the CLI / verify() can react —
+                # the widened except clause in `ci_wait` catches it
+                # cleanly. (Codex P1 caught on the first PR pass.)
+                if not had_successful_read and last_transient_error is not None:
+                    raise last_transient_error
                 return checks
-            sleep_for = min(
-                self.poll_interval, max(0, limit - elapsed)
-            )
+            sleep_for = min(self.poll_interval, remaining)
             await asyncio.sleep(sleep_for)
-            elapsed += sleep_for
 
     async def verify(
         self,

--- a/tests/test_pr_verifier.py
+++ b/tests/test_pr_verifier.py
@@ -1,5 +1,7 @@
 """Tests for PR verification (CI checks + mergeability)."""
 
+import asyncio
+import time
 from unittest.mock import AsyncMock
 
 import pytest
@@ -40,6 +42,83 @@ class TestPRVerifier:
         checks = await verifier.wait_for_checks("owner/repo", 42, timeout=5)
 
         assert mock_github.get_pr_checks.call_count == 3
+        assert checks[0]["bucket"] == "pass"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_checks_honors_timeout_shorter_than_poll_interval(
+        self,
+    ) -> None:
+        """Issue #90.1: timeout < poll_interval used to block the full
+        poll_interval before noticing it was over budget. Now the sleep
+        is capped at the remaining deadline so a 0.5s timeout with a
+        15s interval returns within ~0.5s."""
+        from ctrlrelay.core.pr_verifier import PRVerifier
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_checks.return_value = [
+            {"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"},
+        ]
+
+        verifier = PRVerifier(github=mock_github, poll_interval=15)
+        start = time.monotonic()
+        checks = await verifier.wait_for_checks(
+            "owner/repo", 42, timeout=1
+        )
+        elapsed = time.monotonic() - start
+
+        # Permissive upper bound — actual sleep should be ~1s, not 15s.
+        # 5s is well under the broken 15s and well over the expected 1s.
+        assert elapsed < 5, (
+            f"wait_for_checks blocked {elapsed:.1f}s on a 1s timeout — "
+            "sleep cap regression"
+        )
+        assert checks[0]["bucket"] == "pending"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_checks_treats_gh_timeout_as_pending(self) -> None:
+        """Issue #90.2: an asyncio.TimeoutError from the underlying gh
+        subprocess used to escape as an unhandled exception out of
+        wait_for_checks. Now it's logged and the loop retries — same
+        treatment as a transient GitHubError."""
+        from ctrlrelay.core.pr_verifier import PRVerifier
+
+        mock_github = AsyncMock()
+        # First call: gh subprocess hangs and times out. Second call:
+        # checks come back green. Without the fix, the first
+        # TimeoutError would propagate and never reach the second call.
+        mock_github.get_pr_checks.side_effect = [
+            asyncio.TimeoutError("gh subprocess hung"),
+            [{"name": "ci", "state": "SUCCESS", "bucket": "pass"}],
+        ]
+
+        verifier = PRVerifier(github=mock_github, poll_interval=0)
+        checks = await verifier.wait_for_checks(
+            "owner/repo", 42, timeout=10
+        )
+
+        assert mock_github.get_pr_checks.call_count == 2
+        assert checks[0]["bucket"] == "pass"
+
+    @pytest.mark.asyncio
+    async def test_wait_for_checks_treats_gh_error_as_pending(self) -> None:
+        """Same retry-on-transient behavior for GitHubError — covers the
+        case where `gh` exits non-zero (rate limit back-off, brief auth
+        glitch, network blip)."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_verifier import PRVerifier
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_checks.side_effect = [
+            GitHubError("gh failed: HTTP 502"),
+            [{"name": "ci", "state": "SUCCESS", "bucket": "pass"}],
+        ]
+
+        verifier = PRVerifier(github=mock_github, poll_interval=0)
+        checks = await verifier.wait_for_checks(
+            "owner/repo", 42, timeout=10
+        )
+
+        assert mock_github.get_pr_checks.call_count == 2
         assert checks[0]["bucket"] == "pass"
 
     @pytest.mark.asyncio

--- a/tests/test_pr_verifier.py
+++ b/tests/test_pr_verifier.py
@@ -100,6 +100,74 @@ class TestPRVerifier:
         assert checks[0]["bucket"] == "pass"
 
     @pytest.mark.asyncio
+    async def test_wait_for_checks_fails_closed_when_every_poll_errors(
+        self,
+    ) -> None:
+        """Codex P1 on PR #108: if every gh call fails up to the
+        deadline, returning empty `[]` would be misread by the caller
+        as "no CI configured" and silently greenlight the PR while
+        GitHub was actually down. wait_for_checks must raise the last
+        transient error instead of returning empty when no successful
+        read ever happened."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_verifier import PRVerifier
+
+        # Always-fail callable so the loop never exhausts the mock
+        # (a side_effect list would StopIteration once spent).
+        async def always_fail(*_args, **_kwargs):
+            raise GitHubError("gh failed: HTTP 503 Service Unavailable")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_checks = AsyncMock(side_effect=always_fail)
+
+        # Tiny poll_interval keeps the test fast while still bounded
+        # by the wall-clock deadline.
+        verifier = PRVerifier(github=mock_github, poll_interval=0.01)
+
+        with pytest.raises(GitHubError) as exc_info:
+            await verifier.wait_for_checks(
+                "owner/repo", 42, timeout=0.2
+            )
+        assert "503" in str(exc_info.value)
+
+    @pytest.mark.asyncio
+    async def test_wait_for_checks_succeeds_after_transient_then_recovery(
+        self,
+    ) -> None:
+        """The fail-closed guard only fires when no successful read
+        ever happened. Once a poll returns checks, even if subsequent
+        polls fail, the most recent successful state wins on deadline."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.pr_verifier import PRVerifier
+
+        call_count = 0
+
+        async def flaky(*_args, **_kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count == 1:
+                return [
+                    {"name": "ci", "state": "IN_PROGRESS",
+                     "bucket": "pending"},
+                ]
+            # Then errors forever until the deadline.
+            raise GitHubError("gh failed: HTTP 503")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_checks = AsyncMock(side_effect=flaky)
+
+        verifier = PRVerifier(github=mock_github, poll_interval=0.01)
+        checks = await verifier.wait_for_checks(
+            "owner/repo", 42, timeout=0.2
+        )
+
+        # Had a successful read — return what we last saw, no raise.
+        assert checks == [
+            {"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"}
+        ]
+        assert call_count >= 2  # at least the pending + one error
+
+    @pytest.mark.asyncio
     async def test_wait_for_checks_treats_gh_error_as_pending(self) -> None:
         """Same retry-on-transient behavior for GitHubError — covers the
         case where `gh` exits non-zero (rate limit back-off, brief auth


### PR DESCRIPTION
Two related polish items on `ctrlrelay ci wait`, both flagged by codex on the original PR #88. See commit message for full reproducers.

## What changed

- `wait_for_checks` caps per-iteration sleep at `min(poll_interval, max(0, limit - elapsed))` so a 1-second timeout with a 15-second interval returns within ~1 second.
- `wait_for_checks` catches `GitHubError` AND `asyncio.TimeoutError` inside the polling loop, logs them as transient, and retries on the next iteration. The outer deadline is the safety net.
- `ci_wait` CLI handler widens its top-level except clause as defense-in-depth.

## Test plan

- [x] 3 new tests in `tests/test_pr_verifier.py`
- [x] `uv run pytest -q` → 381 passed
- [x] `uv run ruff check src tests` → clean
- [ ] CI green
- [ ] codex review
- [ ] Merge