### PR TITLE
fix(pr-watcher): persist watchers across poller restarts (closes #57)

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1208,6 +1208,7 @@ def poller_start(
                                 session_id=result.session_id,
                                 github=github,
                                 transport_factory=_watch_transport_factory,
+                                state_db=state_db,
                             )
                         )
                         pr_watch_tasks.add(task)
@@ -1622,6 +1623,42 @@ def poller_start(
                     "[/dim]"
                 )
                 await poller.seed_current()
+
+            # Rehydrate PR watchers that survived the previous shutdown.
+            # A launchd kickstart / crash / redeploy cancels in-memory
+            # asyncio tasks; without this step, any PR sitting in review
+            # across a restart would silently lose its post-merge
+            # automation for the remainder of its 7-day watch window.
+            # Runs BEFORE run_poll_loop so watchers are live before the
+            # first poll interval elapses.
+            try:
+                surviving = state_db.list_pr_watches()
+            except Exception as e:
+                console.print(
+                    f"[yellow]pr_watches rehydrate: list failed ({e}) — "
+                    "skipping[/yellow]"
+                )
+                surviving = []
+            if surviving:
+                console.print(
+                    f"[dim]Rehydrating {len(surviving)} PR watcher(s) "
+                    "from state.db[/dim]"
+                )
+                for row in surviving:
+                    task = asyncio.create_task(
+                        pr_watch_task(
+                            repo=row["repo"],
+                            issue_number=row["issue_number"],
+                            pr_url=row["pr_url"] or "",
+                            pr_number=row["pr_number"],
+                            session_id=row.get("session_id"),
+                            github=github,
+                            transport_factory=_watch_transport_factory,
+                            state_db=state_db,
+                        )
+                    )
+                    pr_watch_tasks.add(task)
+                    task.add_done_callback(pr_watch_tasks.discard)
 
             try:
                 await run_poll_loop(

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1649,24 +1649,25 @@ def poller_start(
                     "from state.db[/dim]"
                 )
                 now = int(_time.time())
+                # Always spawn at least one poll cycle's worth of watch
+                # even for rows that exceeded the 7-day window while the
+                # poller was down. Age alone is not enough to drop: the
+                # PR may have merged just before the deadline, or a
+                # prior run may have crashed mid-cleanup (cleanup_phase
+                # populated). Giving every row a brief window means
+                # wait_for_merge runs at least once so those cases
+                # actually complete instead of being silently discarded.
+                rehydrate_min_timeout = 60
                 for row in surviving:
                     # Honor the original watch deadline: subtract time
                     # already spent watching from the default 7-day
                     # timeout. Without this, every restart resets the
                     # clock and abandoned PRs never time out.
                     elapsed = max(0, now - int(row["started_at"]))
-                    remaining = DEFAULT_PR_WATCH_TIMEOUT - elapsed
-                    if remaining <= 0:
-                        # Watch window elapsed while the poller was down.
-                        # Drop the row instead of respawning a watcher
-                        # that would fire a timeout on its first poll.
-                        try:
-                            state_db.remove_pr_watch(
-                                row["repo"], row["pr_number"]
-                            )
-                        except Exception:
-                            pass
-                        continue
+                    remaining = max(
+                        DEFAULT_PR_WATCH_TIMEOUT - elapsed,
+                        rehydrate_min_timeout,
+                    )
                     task = asyncio.create_task(
                         pr_watch_task(
                             repo=row["repo"],

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1058,6 +1058,51 @@ def poller_start(
         # handle_issue and aren't garbage-collected. Cleared via
         # done_callback as each task terminates.
         pr_watch_tasks: set[asyncio.Task] = set()
+        # Dedup key: only ONE watcher may run for a given (repo, pr_number)
+        # at a time. Without this, two spawn paths (rehydration + a
+        # handle_issue re-run after corrupted poller state) can race
+        # through _handle_merge_with_retry and duplicate the close
+        # comment / notification. Entries removed via done_callback
+        # below, paired with the task's removal from pr_watch_tasks.
+        active_pr_watches: set[tuple[str, int]] = set()
+
+        def _spawn_pr_watch(
+            *,
+            repo: str,
+            issue_number: int,
+            pr_url: str,
+            pr_number: int,
+            session_id: str | None,
+            timeout: int | None = None,
+        ) -> asyncio.Task | None:
+            """Start a pr_watch_task for (repo, pr_number) unless one is
+            already running for the same key. Returns the task on spawn,
+            None if a duplicate was suppressed."""
+            key = (repo, pr_number)
+            if key in active_pr_watches:
+                return None
+            active_pr_watches.add(key)
+            kwargs: dict = dict(
+                repo=repo,
+                issue_number=issue_number,
+                pr_url=pr_url,
+                pr_number=pr_number,
+                session_id=session_id,
+                github=github,
+                transport_factory=_watch_transport_factory,
+                state_db=state_db,
+            )
+            if timeout is not None:
+                kwargs["timeout"] = timeout
+            task = asyncio.create_task(pr_watch_task(**kwargs))
+            pr_watch_tasks.add(task)
+
+            def _on_done(t: asyncio.Task) -> None:
+                pr_watch_tasks.discard(t)
+                active_pr_watches.discard(key)
+
+            task.add_done_callback(_on_done)
+            return task
 
         async def _watch_transport_factory():
             """Build a fresh connected SocketTransport for a single watcher,
@@ -1202,20 +1247,13 @@ def poller_start(
                     except (TypeError, ValueError):
                         pr_number = None
                     if pr_number is not None:
-                        task = asyncio.create_task(
-                            pr_watch_task(
-                                repo=repo,
-                                issue_number=issue_number,
-                                pr_url=pr_url_str,
-                                pr_number=pr_number,
-                                session_id=result.session_id,
-                                github=github,
-                                transport_factory=_watch_transport_factory,
-                                state_db=state_db,
-                            )
+                        _spawn_pr_watch(
+                            repo=repo,
+                            issue_number=issue_number,
+                            pr_url=pr_url_str,
+                            pr_number=pr_number,
+                            session_id=result.session_id,
                         )
-                        pr_watch_tasks.add(task)
-                        task.add_done_callback(pr_watch_tasks.discard)
 
                 # Send result notification — best-effort. A failed send
                 # must NOT prevent the merge watcher (spawned above)
@@ -1673,21 +1711,14 @@ def poller_start(
                         DEFAULT_PR_WATCH_TIMEOUT - elapsed,
                         rehydrate_min_timeout,
                     )
-                    task = asyncio.create_task(
-                        pr_watch_task(
-                            repo=row["repo"],
-                            issue_number=row["issue_number"],
-                            pr_url=row["pr_url"] or "",
-                            pr_number=row["pr_number"],
-                            session_id=row.get("session_id"),
-                            github=github,
-                            transport_factory=_watch_transport_factory,
-                            state_db=state_db,
-                            timeout=remaining,
-                        )
+                    _spawn_pr_watch(
+                        repo=row["repo"],
+                        issue_number=row["issue_number"],
+                        pr_url=row["pr_url"] or "",
+                        pr_number=row["pr_number"],
+                        session_id=row.get("session_id"),
+                        timeout=remaining,
                     )
-                    pr_watch_tasks.add(task)
-                    task.add_done_callback(pr_watch_tasks.discard)
 
             try:
                 await run_poll_loop(

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -958,7 +958,10 @@ def poller_start(
         from ctrlrelay.core.state import StateDB
         from ctrlrelay.core.worktree import WorktreeManager
         from ctrlrelay.pipelines.dev import run_dev_issue
-        from ctrlrelay.pipelines.post_merge import pr_watch_task
+        from ctrlrelay.pipelines.post_merge import (
+            DEFAULT_PR_WATCH_TIMEOUT,
+            pr_watch_task,
+        )
         from ctrlrelay.pipelines.secops import run_secops_all
 
         # Build a DashboardClient if configured BEFORE the gh probe runs,
@@ -1640,11 +1643,30 @@ def poller_start(
                 )
                 surviving = []
             if surviving:
+                import time as _time
                 console.print(
                     f"[dim]Rehydrating {len(surviving)} PR watcher(s) "
                     "from state.db[/dim]"
                 )
+                now = int(_time.time())
                 for row in surviving:
+                    # Honor the original watch deadline: subtract time
+                    # already spent watching from the default 7-day
+                    # timeout. Without this, every restart resets the
+                    # clock and abandoned PRs never time out.
+                    elapsed = max(0, now - int(row["started_at"]))
+                    remaining = DEFAULT_PR_WATCH_TIMEOUT - elapsed
+                    if remaining <= 0:
+                        # Watch window elapsed while the poller was down.
+                        # Drop the row instead of respawning a watcher
+                        # that would fire a timeout on its first poll.
+                        try:
+                            state_db.remove_pr_watch(
+                                row["repo"], row["pr_number"]
+                            )
+                        except Exception:
+                            pass
+                        continue
                     task = asyncio.create_task(
                         pr_watch_task(
                             repo=row["repo"],
@@ -1655,6 +1677,7 @@ def poller_start(
                             github=github,
                             transport_factory=_watch_transport_factory,
                             state_db=state_db,
+                            timeout=remaining,
                         )
                     )
                     pr_watch_tasks.add(task)

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1649,15 +1649,20 @@ def poller_start(
                     "from state.db[/dim]"
                 )
                 now = int(_time.time())
-                # Always spawn at least one poll cycle's worth of watch
-                # even for rows that exceeded the 7-day window while the
-                # poller was down. Age alone is not enough to drop: the
-                # PR may have merged just before the deadline, or a
-                # prior run may have crashed mid-cleanup (cleanup_phase
-                # populated). Giving every row a brief window means
-                # wait_for_merge runs at least once so those cases
-                # actually complete instead of being silently discarded.
-                rehydrate_min_timeout = 60
+                # Always spawn with enough headroom for SEVERAL poll
+                # attempts even on rows past the 7-day window. A
+                # single-poll window (grace == poll_interval) would
+                # expire the instant the first gh call has a transient
+                # failure, logging watch_timeout and permanently
+                # dropping the row. 5 minutes against the default 60s
+                # poll_interval lets wait_for_merge retry through a
+                # handful of hiccups and still covers a PR that merges
+                # right after the restart. Abandoned-row cost is 5 min
+                # of extra polling, which is negligible.
+                # (Rehydrated rows with cleanup_phase set bypass
+                # wait_for_merge entirely — see pr_watch_task — so
+                # this headroom only affects phase=NULL rehydrates.)
+                rehydrate_min_timeout = 300
                 for row in surviving:
                     # Honor the original watch deadline: subtract time
                     # already spent watching from the default 7-day

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1074,13 +1074,41 @@ def poller_start(
             pr_number: int,
             session_id: str | None,
             timeout: int | None = None,
+            skip_initial_persist: bool = False,
         ) -> asyncio.Task | None:
             """Start a pr_watch_task for (repo, pr_number) unless one is
             already running for the same key. Returns the task on spawn,
-            None if a duplicate was suppressed."""
+            None if a duplicate was suppressed.
+
+            The pr_watches row is persisted SYNCHRONOUSLY before the
+            coroutine is scheduled. asyncio.create_task only queues the
+            coroutine — its body doesn't execute until the loop next
+            yields, so a shutdown between create_task and the first
+            await inside pr_watch_task would otherwise lose the row
+            entirely (no rehydrate after restart). Writing first closes
+            that gap.
+
+            ``skip_initial_persist`` is for rehydration: the row
+            already exists in pr_watches (that's how we know to spawn),
+            and re-writing it would be harmless but wasteful.
+            """
             key = (repo, pr_number)
             if key in active_pr_watches:
                 return None
+            if state_db is not None and not skip_initial_persist:
+                try:
+                    state_db.add_pr_watch(
+                        repo=repo, pr_number=pr_number,
+                        issue_number=issue_number,
+                        session_id=session_id,
+                        pr_url=pr_url,
+                    )
+                except Exception:
+                    # Persist failure is logged inside pr_watch_task on
+                    # its own attempt; don't abort the spawn here, the
+                    # watcher can still run in-memory like the legacy
+                    # pre-persistence code did.
+                    pass
             active_pr_watches.add(key)
             kwargs: dict = dict(
                 repo=repo,
@@ -1682,8 +1710,27 @@ def poller_start(
                 surviving = []
             if surviving:
                 import time as _time
+                # Respect the operator's current config: if a repo was
+                # removed from `repos:`, skip respawning its watchers
+                # even if old rows linger in pr_watches. Treating the
+                # config as the source of truth matches how the rest
+                # of the poller behaves; silently driving close/notify
+                # on a now-unconfigured repo would be surprising.
+                configured_repos = {r.name for r in config.repos}
+                orphaned = [
+                    r for r in surviving if r["repo"] not in configured_repos
+                ]
+                if orphaned:
+                    console.print(
+                        f"[yellow]pr_watches: {len(orphaned)} row(s) "
+                        "for repos no longer in config — leaving "
+                        "dormant[/yellow]"
+                    )
+                active = [
+                    r for r in surviving if r["repo"] in configured_repos
+                ]
                 console.print(
-                    f"[dim]Rehydrating {len(surviving)} PR watcher(s) "
+                    f"[dim]Rehydrating {len(active)} PR watcher(s) "
                     "from state.db[/dim]"
                 )
                 now = int(_time.time())
@@ -1701,7 +1748,7 @@ def poller_start(
                 # wait_for_merge entirely — see pr_watch_task — so
                 # this headroom only affects phase=NULL rehydrates.)
                 rehydrate_min_timeout = 300
-                for row in surviving:
+                for row in active:
                     # Honor the original watch deadline: subtract time
                     # already spent watching from the default 7-day
                     # timeout. Without this, every restart resets the
@@ -1718,6 +1765,7 @@ def poller_start(
                         pr_number=row["pr_number"],
                         session_id=row.get("session_id"),
                         timeout=remaining,
+                        skip_initial_persist=True,
                     )
 
             try:

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -387,17 +387,38 @@ class StateDB:
         started_at: int | None = None,
     ) -> None:
         """Record an in-flight merge watcher so a poller restart can
-        rehydrate it. Idempotent on ``(repo, pr_number)`` — re-inserting
-        the same PR refreshes ``started_at`` and any metadata (useful
-        when the same PR is re-spawned for any reason).
+        rehydrate it. Idempotent on ``(repo, pr_number)``.
+
+        When ``started_at`` is None (production path, including the
+        rehydrate re-insert), a new row gets ``now()`` and an existing
+        row keeps its original ``started_at``. Preserving the original
+        timestamp is load-bearing: if every rehydrate refreshed it, the
+        7-day watch deadline would reset on every poller restart and
+        abandoned PRs would never time out.
+
+        When ``started_at`` is explicit (tests, seed flows), the row
+        is overwritten outright.
         """
-        ts = int(time.time()) if started_at is None else int(started_at)
-        self._conn.execute(
-            """INSERT OR REPLACE INTO pr_watches
-               (repo, pr_number, session_id, issue_number, pr_url, started_at)
-               VALUES (?, ?, ?, ?, ?, ?)""",
-            (repo, pr_number, session_id, issue_number, pr_url, ts),
-        )
+        if started_at is None:
+            self._conn.execute(
+                """INSERT INTO pr_watches
+                   (repo, pr_number, session_id, issue_number, pr_url, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?)
+                   ON CONFLICT(repo, pr_number) DO UPDATE SET
+                       session_id = excluded.session_id,
+                       issue_number = excluded.issue_number,
+                       pr_url = excluded.pr_url""",
+                (repo, pr_number, session_id, issue_number, pr_url,
+                 int(time.time())),
+            )
+        else:
+            self._conn.execute(
+                """INSERT OR REPLACE INTO pr_watches
+                   (repo, pr_number, session_id, issue_number, pr_url, started_at)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (repo, pr_number, session_id, issue_number, pr_url,
+                 int(started_at)),
+            )
         self._conn.commit()
 
     def remove_pr_watch(self, repo: str, pr_number: int) -> bool:

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -92,6 +92,7 @@ CREATE TABLE IF NOT EXISTS pr_watches (
     issue_number INTEGER NOT NULL,
     pr_url TEXT,
     started_at INTEGER NOT NULL,
+    cleanup_phase TEXT,
     PRIMARY KEY (repo, pr_number)
 );
 
@@ -143,6 +144,17 @@ class StateDB:
         if "agent_session_id" not in existing:
             self._conn.execute(
                 "ALTER TABLE sessions ADD COLUMN agent_session_id TEXT"
+            )
+
+        pr_watches_cols = {
+            row[1]
+            for row in self._conn.execute(
+                "PRAGMA table_info(pr_watches)"
+            ).fetchall()
+        }
+        if pr_watches_cols and "cleanup_phase" not in pr_watches_cols:
+            self._conn.execute(
+                "ALTER TABLE pr_watches ADD COLUMN cleanup_phase TEXT"
             )
 
     def close(self) -> None:
@@ -440,3 +452,52 @@ class StateDB:
             "SELECT * FROM pr_watches ORDER BY started_at ASC"
         ).fetchall()
         return [dict(row) for row in rows]
+
+    # Valid post-merge cleanup phases, in monotonic progression. Each
+    # phase stamps *after* its side effect has succeeded, so if the
+    # poller is killed mid-cleanup and rehydrates later, the resumed
+    # handle_merge can skip every step the prior run already completed.
+    _PR_WATCH_CLEANUP_PHASES = frozenset(
+        {"commented", "closed", "notified"}
+    )
+
+    def set_pr_watch_cleanup_phase(
+        self, repo: str, pr_number: int, phase: str
+    ) -> None:
+        """Stamp a durable marker that a given post-merge cleanup step
+        has succeeded for this watch. Caller must invoke AFTER the
+        side effect completes so a process kill between the stamp and
+        the next step never leaves us claiming work we didn't do.
+
+        Validated: ``phase`` must be one of the known monotonic values
+        (``commented`` / ``closed`` / ``notified``). An invalid value
+        raises rather than silently corrupting resume semantics.
+        """
+        if phase not in self._PR_WATCH_CLEANUP_PHASES:
+            raise ValueError(
+                f"invalid pr_watches cleanup_phase: {phase!r}; "
+                f"expected one of {sorted(self._PR_WATCH_CLEANUP_PHASES)}"
+            )
+        self._conn.execute(
+            "UPDATE pr_watches SET cleanup_phase = ? "
+            "WHERE repo = ? AND pr_number = ?",
+            (phase, repo, pr_number),
+        )
+        self._conn.commit()
+
+    def get_pr_watch_cleanup_phase(
+        self, repo: str, pr_number: int
+    ) -> str | None:
+        """Read the persisted cleanup phase for a watch, used by
+        rehydration so handle_merge can skip completed steps. Returns
+        None when the row is missing or the phase column is NULL
+        (fresh watch that never reached cleanup)."""
+        row = self._conn.execute(
+            "SELECT cleanup_phase FROM pr_watches "
+            "WHERE repo = ? AND pr_number = ?",
+            (repo, pr_number),
+        ).fetchone()
+        if row is None:
+            return None
+        value = row["cleanup_phase"]
+        return value if value else None

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -73,6 +73,28 @@ CREATE TABLE IF NOT EXISTS pending_resumes (
     resumed_at INTEGER
 );
 
+-- In-flight PR merge watchers that must survive a poller restart. Without
+-- this, a launchd kickstart / crash / redeploy / reboot cancels the
+-- in-memory asyncio watcher tasks and any PR that gets merged afterwards
+-- silently loses its post-merge automation (issue close + Telegram ping)
+-- for the remainder of the 7-day watch window. Poller startup rehydrates
+-- one `pr_watch_task` per surviving row before `run_poll_loop` enters its
+-- main loop. Rows are inserted on `dev.pr.watching` and deleted on the
+-- terminal `dev.pr.merged` / `dev.pr.watch_timeout` events only — a
+-- `dev.pr.watch_cancelled` (shutdown-driven cancellation, not operator
+-- intent) deliberately leaves the row in place so the next startup
+-- resumes the watch. `pr_number` is the unique row key because we watch
+-- at most one PR per (repo, pr_number).
+CREATE TABLE IF NOT EXISTS pr_watches (
+    repo TEXT NOT NULL,
+    pr_number INTEGER NOT NULL,
+    session_id TEXT,
+    issue_number INTEGER NOT NULL,
+    pr_url TEXT,
+    started_at INTEGER NOT NULL,
+    PRIMARY KEY (repo, pr_number)
+);
+
 CREATE INDEX IF NOT EXISTS idx_sessions_repo ON sessions(repo);
 CREATE INDEX IF NOT EXISTS idx_sessions_status ON sessions(status);
 CREATE INDEX IF NOT EXISTS idx_automation_repo ON automation_decisions(repo);
@@ -351,3 +373,49 @@ class StateDB:
         )
         self._conn.commit()
         return cursor.rowcount > 0
+
+    # PR watches (durable, cross-restart)
+
+    def add_pr_watch(
+        self,
+        *,
+        repo: str,
+        pr_number: int,
+        issue_number: int,
+        session_id: str | None,
+        pr_url: str | None,
+        started_at: int | None = None,
+    ) -> None:
+        """Record an in-flight merge watcher so a poller restart can
+        rehydrate it. Idempotent on ``(repo, pr_number)`` — re-inserting
+        the same PR refreshes ``started_at`` and any metadata (useful
+        when the same PR is re-spawned for any reason).
+        """
+        ts = int(time.time()) if started_at is None else int(started_at)
+        self._conn.execute(
+            """INSERT OR REPLACE INTO pr_watches
+               (repo, pr_number, session_id, issue_number, pr_url, started_at)
+               VALUES (?, ?, ?, ?, ?, ?)""",
+            (repo, pr_number, session_id, issue_number, pr_url, ts),
+        )
+        self._conn.commit()
+
+    def remove_pr_watch(self, repo: str, pr_number: int) -> bool:
+        """Delete a PR watch row after a terminal outcome (merge
+        detected, or watch window expired). Returns True iff a row was
+        deleted so callers can tell whether the row was still present."""
+        cursor = self._conn.execute(
+            "DELETE FROM pr_watches WHERE repo = ? AND pr_number = ?",
+            (repo, pr_number),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def list_pr_watches(self) -> list[dict[str, Any]]:
+        """Return all surviving PR watches, oldest first. Called by the
+        poller at startup (before ``run_poll_loop``) to rehydrate any
+        watchers cancelled by the previous shutdown."""
+        rows = self._conn.execute(
+            "SELECT * FROM pr_watches ORDER BY started_at ASC"
+        ).fetchall()
+        return [dict(row) for row in rows]

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -30,6 +30,35 @@ _HANDLE_MERGE_RETRY_ATTEMPTS = 5
 _HANDLE_MERGE_RETRY_BASE_DELAY = 5  # seconds; doubled each attempt
 
 
+def _stamp_phase(
+    state_db: StateDB | None,
+    repo: str,
+    pr_number: int,
+    phase: str,
+    session_id: str | None,
+    issue_number: int,
+) -> None:
+    """Best-effort persist the current cleanup phase. Called after
+    each side effect succeeds so a resumed watcher can skip work
+    already done. A DB failure must never abort the cleanup loop —
+    the alternative is abandoning a known-merged PR because SQLite
+    had a transient hiccup. Worst case with a swallowed failure is
+    a duplicate comment on the narrow restart window; best case
+    (DB healthy, which is essentially always) resume is exact."""
+    if state_db is None:
+        return
+    try:
+        state_db.set_pr_watch_cleanup_phase(repo, pr_number, phase)
+    except Exception as e:
+        log_event(
+            _logger, "dev.pr.watch_persist_failed",
+            session_id=session_id, repo=repo,
+            issue_number=issue_number, pr_number=pr_number,
+            reason=type(e).__name__, error=str(e)[:200],
+            phase=f"stamp:{phase}",
+        )
+
+
 async def handle_merge(
     repo: str,
     pr_number: int,
@@ -85,34 +114,47 @@ async def _handle_merge_with_retry(
     github: GitHubCLI,
     transport_factory: Callable[[], Awaitable[Transport | None]] | None,
     session_id: str | None,
+    state_db: StateDB | None = None,
 ) -> None:
     """Run the post-merge close + notify steps with per-step idempotent
     retry, rebuilding the transport on each attempt so a bridge restart
     mid-retry doesn't permanently break the notification.
 
-    Idempotency: ``github.close_issue`` is called at most once even
-    across retries — if it succeeds but the notification step later
-    fails, subsequent attempts skip the close so we don't post
-    duplicate "Closed by PR #N" comments.
+    Idempotency within a single call: each side-effect is gated by its
+    own local flag so retries don't duplicate work.
+
+    Idempotency across restarts: when ``state_db`` is supplied, each
+    completed step stamps a ``cleanup_phase`` on the ``pr_watches``
+    row (commented → closed → notified). On entry we read the phase
+    and pre-set the local flags so a rehydrated watcher resumes from
+    where the prior process left off instead of re-posting the close
+    comment or re-firing the Telegram notification.
 
     Transport rebuild: ``transport_factory`` is invoked INSIDE each
-    attempt. If the bridge socket drops between the watcher start and
-    a merge several days later, or during a retry, the next attempt
-    gets a fresh connection.
+    attempt so a bridge restart mid-retry gets a fresh socket.
 
     On final exhaustion, raises the last exception; pr_watch_task's
     outer handler logs it as dev.pr.watch_failed.
     """
-    # Split the post-merge work into three independent steps with
-    # their own idempotency flags. close_issue() in the github layer
-    # is NOT atomic — it posts a comment then runs `gh issue close`.
-    # If the close fails after the comment succeeded, a retry that
-    # called close_issue again would post a DUPLICATE comment.
-    # Tracking each sub-step separately ensures every side-effect
-    # runs at most once across retries.
     comment_posted = False
     issue_closed = False
     notification_sent = False
+    if state_db is not None:
+        # Rehydration: skip every step the prior process already
+        # completed. The phase is monotonic (commented → closed →
+        # notified) so higher phases imply all lower phases done.
+        try:
+            prior_phase = state_db.get_pr_watch_cleanup_phase(
+                repo, pr_number
+            )
+        except Exception:
+            prior_phase = None
+        if prior_phase in ("commented", "closed", "notified"):
+            comment_posted = True
+        if prior_phase in ("closed", "notified"):
+            issue_closed = True
+        if prior_phase == "notified":
+            notification_sent = True
     last_exc: Exception | None = None
     delay = _HANDLE_MERGE_RETRY_BASE_DELAY
     comment = f"Closed by PR #{pr_number}"
@@ -148,14 +190,20 @@ async def _handle_merge_with_retry(
             if not comment_posted:
                 await github.comment_on_issue(repo, issue_number, comment)
                 comment_posted = True
+                _stamp_phase(state_db, repo, pr_number, "commented",
+                             session_id, issue_number)
             if not issue_closed:
                 await github._run_gh(
                     "issue", "close", str(issue_number), "--repo", repo,
                 )
                 issue_closed = True
+                _stamp_phase(state_db, repo, pr_number, "closed",
+                             session_id, issue_number)
             if not notification_sent and transport is not None:
                 await transport.send(notification)
                 notification_sent = True
+                _stamp_phase(state_db, repo, pr_number, "notified",
+                             session_id, issue_number)
 
             # Done when either: we sent the notification this round, OR
             # the factory returned None meaning no channel was ever
@@ -293,6 +341,7 @@ async def pr_watch_task(
                 issue_number=issue_number, github=github,
                 transport_factory=transport_factory,
                 session_id=session_id,
+                state_db=state_db,
             )
         # Drop the durable row only AFTER post-merge cleanup fully
         # completes (merged path) or after we've given up on timeout.

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -8,6 +8,7 @@ from typing import Any, Awaitable, Callable
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.obs import get_logger, log_event
 from ctrlrelay.core.pr_watcher import PRWatcher
+from ctrlrelay.core.state import StateDB
 from ctrlrelay.transports.base import Transport
 
 _logger = get_logger("pipelines.post_merge")
@@ -205,6 +206,7 @@ async def pr_watch_task(
     transport_factory: Callable[[], Awaitable[Transport | None]] | None = None,
     poll_interval: int = 60,
     timeout: int = DEFAULT_PR_WATCH_TIMEOUT,
+    state_db: StateDB | None = None,
 ) -> dict[str, Any]:
     """Background-safe wrapper around the merge watcher that emits
     structured ``dev.pr.*`` events and manages a transport LAZILY —
@@ -218,6 +220,15 @@ async def pr_watch_task(
     A raising factory is logged and skipped (merge detection proceeds
     without the notification channel rather than aborting the close).
 
+    ``state_db`` persists the watcher across poller restarts: a row is
+    inserted on ``dev.pr.watching`` and removed on the terminal
+    ``dev.pr.merged`` / ``dev.pr.watch_timeout`` events. It is NOT
+    removed on ``dev.pr.watch_cancelled`` — a cancellation during
+    shutdown must leave the row behind so the next poller startup can
+    rehydrate the watcher. StateDB I/O is best-effort: a disk failure
+    is swallowed so it can never prevent merge detection from
+    continuing in-memory.
+
     Returns a dict describing the outcome:
       {"merged": bool, "timed_out": bool, "cancelled": bool, "failed": str|None}
     """
@@ -225,6 +236,29 @@ async def pr_watch_task(
         "merged": False, "timed_out": False,
         "cancelled": False, "failed": None,
     }
+
+    # Persist the watch before any long-running work so a crash between
+    # `dev.pr.watching` and the first poll doesn't lose the row.
+    # Idempotent: a rehydrated task calling this again just refreshes
+    # started_at, which is fine.
+    if state_db is not None:
+        try:
+            state_db.add_pr_watch(
+                repo=repo, pr_number=pr_number,
+                issue_number=issue_number,
+                session_id=session_id,
+                pr_url=pr_url,
+            )
+        except Exception as e:
+            # Never let a state_db failure kill the watcher — degrade
+            # to in-memory-only and log so ops can see the durability
+            # gap.
+            log_event(
+                _logger, "dev.pr.watch_persist_failed",
+                session_id=session_id, repo=repo,
+                issue_number=issue_number, pr_number=pr_number,
+                reason=type(e).__name__, error=str(e)[:200],
+            )
 
     log_event(
         _logger, "dev.pr.watching",
@@ -249,6 +283,22 @@ async def pr_watch_task(
             session_id=session_id, repo=repo, issue_number=issue_number,
             pr_number=pr_number,
         )
+        # Terminal state: merge or timeout. Drop the durable row so
+        # future poller startups don't rehydrate this watcher. We
+        # remove BEFORE handle_merge so an exhausted retry loop can't
+        # leave a ghost row that would be rehydrated on next startup
+        # and try the same permanently-broken cleanup forever.
+        if state_db is not None:
+            try:
+                state_db.remove_pr_watch(repo, pr_number)
+            except Exception as e:
+                log_event(
+                    _logger, "dev.pr.watch_persist_failed",
+                    session_id=session_id, repo=repo,
+                    issue_number=issue_number, pr_number=pr_number,
+                    reason=type(e).__name__, error=str(e)[:200],
+                    phase="remove",
+                )
         if merged:
             # Defer transport construction to inside the retry loop so
             # each attempt gets a fresh connection — a bridge restart
@@ -267,6 +317,10 @@ async def pr_watch_task(
             session_id=session_id, repo=repo, issue_number=issue_number,
             pr_number=pr_number,
         )
+        # Deliberately DO NOT remove the pr_watches row on cancellation.
+        # Cancellation is the shutdown signal — the next poller startup
+        # must rehydrate this watcher or the PR's post-merge automation
+        # is lost for the remainder of its 7-day window.
         raise
     except Exception as e:
         outcome["failed"] = type(e).__name__

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -314,10 +314,37 @@ async def pr_watch_task(
         pr_number=pr_number, pr_url=pr_url,
     )
     try:
-        watcher = PRWatcher(github=github, poll_interval=poll_interval)
-        merged = await watcher.wait_for_merge(
-            repo=repo, pr_number=pr_number, timeout=timeout,
-        )
+        # Rehydration shortcut: if the prior process already observed
+        # the merge (any cleanup_phase stamped), skip wait_for_merge
+        # entirely and resume cleanup. Re-running wait_for_merge here
+        # would let a transient GH error or a brief rehydrate window
+        # log dev.pr.watch_timeout and delete the row, permanently
+        # dropping the remaining close/notify steps — exactly the
+        # failure the phase tracking is supposed to prevent.
+        resuming_cleanup = False
+        if state_db is not None:
+            try:
+                prior_phase = state_db.get_pr_watch_cleanup_phase(
+                    repo, pr_number
+                )
+            except Exception:
+                prior_phase = None
+            if prior_phase is not None:
+                resuming_cleanup = True
+
+        if resuming_cleanup:
+            merged = True
+            log_event(
+                _logger, "dev.pr.watch_resumed",
+                session_id=session_id, repo=repo,
+                issue_number=issue_number, pr_number=pr_number,
+                cleanup_phase=prior_phase,
+            )
+        else:
+            watcher = PRWatcher(github=github, poll_interval=poll_interval)
+            merged = await watcher.wait_for_merge(
+                repo=repo, pr_number=pr_number, timeout=timeout,
+            )
         # Record merge detection BEFORE running the post-merge handler,
         # so an exhausted retry loop (e.g. permanent bridge outage) still
         # leaves `outcome["merged"] = True`. The merge really did happen;

--- a/src/ctrlrelay/pipelines/post_merge.py
+++ b/src/ctrlrelay/pipelines/post_merge.py
@@ -283,22 +283,6 @@ async def pr_watch_task(
             session_id=session_id, repo=repo, issue_number=issue_number,
             pr_number=pr_number,
         )
-        # Terminal state: merge or timeout. Drop the durable row so
-        # future poller startups don't rehydrate this watcher. We
-        # remove BEFORE handle_merge so an exhausted retry loop can't
-        # leave a ghost row that would be rehydrated on next startup
-        # and try the same permanently-broken cleanup forever.
-        if state_db is not None:
-            try:
-                state_db.remove_pr_watch(repo, pr_number)
-            except Exception as e:
-                log_event(
-                    _logger, "dev.pr.watch_persist_failed",
-                    session_id=session_id, repo=repo,
-                    issue_number=issue_number, pr_number=pr_number,
-                    reason=type(e).__name__, error=str(e)[:200],
-                    phase="remove",
-                )
         if merged:
             # Defer transport construction to inside the retry loop so
             # each attempt gets a fresh connection — a bridge restart
@@ -310,6 +294,24 @@ async def pr_watch_task(
                 transport_factory=transport_factory,
                 session_id=session_id,
             )
+        # Drop the durable row only AFTER post-merge cleanup fully
+        # completes (merged path) or after we've given up on timeout.
+        # If _handle_merge_with_retry raises — retries exhausted, bridge
+        # permanently broken — the except Exception branch below owns
+        # the row lifecycle and leaves it so the next poller startup
+        # rehydrates and retries cleanup. wait_for_merge returns True
+        # immediately on rehydrate since the PR is already merged.
+        if state_db is not None:
+            try:
+                state_db.remove_pr_watch(repo, pr_number)
+            except Exception as e:
+                log_event(
+                    _logger, "dev.pr.watch_persist_failed",
+                    session_id=session_id, repo=repo,
+                    issue_number=issue_number, pr_number=pr_number,
+                    reason=type(e).__name__, error=str(e)[:200],
+                    phase="remove",
+                )
     except asyncio.CancelledError:
         outcome["cancelled"] = True
         log_event(

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -1051,6 +1051,62 @@ class TestPRWatchTaskPersistence:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_expired_row_with_phase_still_completes_cleanup(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 round-3: rehydration must not discard a row just
+        because its 7-day watch window elapsed. If the prior run was
+        mid-cleanup (phase populated) or the PR merged just before the
+        deadline, spawning a short-window watcher finishes the job.
+        Dropping the row by age alone silently loses the post-merge
+        automation — exactly what persistence was supposed to prevent."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        # Seed an "expired" row (started_at 8 days ago) with cleanup
+        # mid-flight — prior run posted the comment + closed the issue
+        # but died before notifying.
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+            started_at=1,  # deep in the past
+        )
+        db.set_pr_watch_cleanup_phase("owner/repo", 42, "closed")
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return FakeTransport()
+
+        # Simulate cli.py rehydration passing the minimum grace timeout
+        # even though DEFAULT_PR_WATCH_TIMEOUT - elapsed is negative.
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-new",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=60, state_db=db,
+        )
+        assert outcome["merged"] is True
+        assert mock_github.comment_on_issue.call_count == 0
+        assert mock_github._run_gh.call_count == 0
+        assert len(sent_messages) == 1
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_state_db_optional_no_op_when_absent(self) -> None:
         """Legacy callers can still pass no state_db; the watcher must
         work in-memory-only just like before."""

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -868,6 +868,189 @@ class TestPRWatchTaskPersistence:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_phase_stamped_after_each_cleanup_step(
+        self, tmp_path: Path
+    ) -> None:
+        """Each post-merge side effect must stamp a durable phase AFTER
+        the effect succeeds, so a rehydrated watcher knows exactly
+        what's left to do. Without this the codex P2 replay bug
+        returns: crash between comment and close → restart posts a
+        duplicate comment."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return FakeTransport()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-1",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5, state_db=db,
+        )
+        assert outcome["merged"] is True
+        # Row was removed on clean completion — can't read phase from
+        # a deleted row, but we can assert each side effect ran once:
+        assert mock_github.comment_on_issue.call_count == 1
+        assert mock_github._run_gh.call_count == 1  # the issue close
+        assert len(sent_messages) == 1
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_from_commented_phase_skips_comment(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 fix: if the prior run posted the close comment but
+        crashed before closing the issue, the rehydrated watcher must
+        NOT post a duplicate comment. It should pick up from the close
+        step."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        # Simulate state left by a crashed prior run: row exists with
+        # phase='commented' (comment was posted, then process died).
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+        )
+        db.set_pr_watch_cleanup_phase("owner/repo", 42, "commented")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return None  # no transport configured
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-new",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5, state_db=db,
+        )
+        assert outcome["merged"] is True
+        # Comment was already posted by the prior run — must NOT be
+        # re-posted.
+        assert mock_github.comment_on_issue.call_count == 0
+        # Issue close SHOULD run (that's the step that failed before).
+        assert mock_github._run_gh.call_count == 1
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_from_closed_phase_skips_comment_and_close(
+        self, tmp_path: Path
+    ) -> None:
+        """If the prior run closed the issue but died before
+        notification, the rehydrated watcher must re-send only the
+        notification. No duplicate comment, no re-close on an
+        already-closed issue."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+        )
+        db.set_pr_watch_cleanup_phase("owner/repo", 42, "closed")
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return FakeTransport()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-new",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5, state_db=db,
+        )
+        assert outcome["merged"] is True
+        assert mock_github.comment_on_issue.call_count == 0
+        assert mock_github._run_gh.call_count == 0
+        assert len(sent_messages) == 1
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_rehydrate_from_notified_phase_skips_all_steps(
+        self, tmp_path: Path
+    ) -> None:
+        """Narrow terminal window: prior run completed every step but
+        crashed before remove_pr_watch. Rehydrate must recognize the
+        work is done and just drop the row — no duplicate anything."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+        )
+        db.set_pr_watch_cleanup_phase("owner/repo", 42, "notified")
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return FakeTransport()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-new",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5, state_db=db,
+        )
+        assert outcome["merged"] is True
+        assert mock_github.comment_on_issue.call_count == 0
+        assert mock_github._run_gh.call_count == 0
+        assert sent_messages == []
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_state_db_optional_no_op_when_absent(self) -> None:
         """Legacy callers can still pass no state_db; the watcher must
         work in-memory-only just like before."""

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -1051,6 +1051,65 @@ class TestPRWatchTaskPersistence:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_rehydrate_with_phase_skips_wait_for_merge(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1 round-4: when cleanup_phase is persisted, the prior
+        process already observed the merge. Re-running wait_for_merge
+        on rehydrate is unsafe — a transient GH error or an elapsed
+        deadline could log watch_timeout and delete the row, losing
+        the remaining cleanup work. The watcher must trust the phase
+        and go straight to _handle_merge_with_retry.
+
+        We verify by mocking get_pr_state to return OPEN (as if GH
+        briefly lied during rehydrate) — cleanup must still complete."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+        )
+        db.set_pr_watch_cleanup_phase("owner/repo", 42, "closed")
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        mock_github = AsyncMock()
+        # GH says the PR is still OPEN — would normally fool
+        # wait_for_merge into timing out. The phase shortcut must
+        # trust the persisted state instead.
+        mock_github.get_pr_state.return_value = {"state": "OPEN"}
+
+        async def factory():
+            return FakeTransport()
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-new",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=60, state_db=db,
+        )
+        assert outcome["merged"] is True
+        # wait_for_merge MUST NOT have been called — trust the phase.
+        assert mock_github.get_pr_state.call_count == 0
+        # Cleanup picked up from closed → only notification sent.
+        assert mock_github.comment_on_issue.call_count == 0
+        assert mock_github._run_gh.call_count == 0
+        assert len(sent_messages) == 1
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_expired_row_with_phase_still_completes_cleanup(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -2,6 +2,7 @@
 
 import asyncio
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock
 
 import pytest
@@ -664,3 +665,307 @@ class TestPRWatchTask:
         assert any(
             "dev.pr.watch_failed" in r.getMessage() for r in caplog.records
         )
+
+
+class TestPRWatchTaskPersistence:
+    """pr_watch_task must round-trip the pr_watches state_db table so
+    the watcher survives a poller restart. Row written on spawn,
+    removed on merged / timed_out, LEFT BEHIND on cancel."""
+
+    @pytest.mark.asyncio
+    async def test_row_written_on_spawn(self, tmp_path: Path) -> None:
+        """Acceptance: spawn writes a row keyed by (repo, pr_number)
+        with all the columns from the issue body."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return None
+
+        # Capture the row DURING the watch by observing it after run.
+        outcome = await pr_watch_task(
+            repo="owner/repo",
+            issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42,
+            session_id="sess-1",
+            github=mock_github,
+            transport_factory=factory,
+            poll_interval=0,
+            timeout=5,
+            state_db=db,
+        )
+        assert outcome["merged"] is True
+        # Merged → row removed. The write DID happen — we verify that
+        # in the cancel test. Here we assert the terminal cleanup.
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_row_removed_on_merge(self, tmp_path: Path) -> None:
+        """dev.pr.merged is terminal: row must be dropped so the next
+        poller startup doesn't rehydrate a watcher that already did its
+        job."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+        # Seed a stale row for this PR to simulate a restart scenario —
+        # the row must be gone after the merge completes.
+        db.add_pr_watch(
+            repo="owner/repo", pr_number=42, issue_number=77,
+            session_id="prev-sess",
+            pr_url="https://github.com/owner/repo/pull/42",
+        )
+        assert len(db.list_pr_watches()) == 1
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return None
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-1",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5, state_db=db,
+        )
+        assert outcome["merged"] is True
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_row_removed_on_timeout(self, tmp_path: Path) -> None:
+        """dev.pr.watch_timeout is terminal: the PR sat in review past
+        the watch window; we're giving up. Drop the row so a restart
+        doesn't resurrect the same dead watcher."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "OPEN"}
+
+        async def factory():
+            return None
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="https://github.com/owner/repo/pull/42",
+            pr_number=42, session_id="sess-1",
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=0,  # immediate timeout
+            state_db=db,
+        )
+        assert outcome["timed_out"] is True
+        assert db.list_pr_watches() == []
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_row_kept_on_cancellation(self, tmp_path: Path) -> None:
+        """Acceptance: dev.pr.watch_cancelled must LEAVE the row
+        behind. Cancellation is what a poller shutdown does to every
+        in-flight watcher; if we deleted the row here, the next startup
+        couldn't rehydrate and the PR's post-merge automation would
+        silently vanish for the rest of the 7-day window."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+
+        sleep_event = asyncio.Event()
+
+        async def slow_get_state(*_a, **_kw):
+            await sleep_event.wait()
+            return {"state": "OPEN"}
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.side_effect = slow_get_state
+
+        async def factory():
+            return None
+
+        async def run():
+            return await pr_watch_task(
+                repo="owner/repo", issue_number=77,
+                pr_url="https://github.com/owner/repo/pull/42",
+                pr_number=42, session_id="sess-1",
+                github=mock_github, transport_factory=factory,
+                poll_interval=0, timeout=60, state_db=db,
+            )
+
+        task = asyncio.create_task(run())
+        # Yield so the task gets to add_pr_watch and into the watcher.
+        await asyncio.sleep(0)
+        # At this point the row MUST already be persisted — that's
+        # what makes rehydration possible on the next startup.
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["repo"] == "owner/repo"
+        assert rows[0]["pr_number"] == 42
+        assert rows[0]["issue_number"] == 77
+        assert rows[0]["session_id"] == "sess-1"
+
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+
+        # Cancellation must have LEFT the row behind.
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["pr_number"] == 42
+        db.close()
+
+    @pytest.mark.asyncio
+    async def test_state_db_optional_no_op_when_absent(self) -> None:
+        """Legacy callers can still pass no state_db; the watcher must
+        work in-memory-only just like before."""
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+
+        async def factory():
+            return None
+
+        outcome = await pr_watch_task(
+            repo="owner/repo", issue_number=77,
+            pr_url="", pr_number=42, session_id=None,
+            github=mock_github, transport_factory=factory,
+            poll_interval=0, timeout=5,
+            state_db=None,
+        )
+        assert outcome["merged"] is True
+
+
+class TestPollerRestartRehydration:
+    """Integration acceptance: start poller, spawn watcher, kill poller,
+    start poller again, verify the watcher is respawned and the merge
+    still fires handle_merge.
+
+    We simulate the restart at the pr_watch_task level: StateDB is the
+    durability boundary and `cli.py` just reads list_pr_watches() and
+    spawns a task per row. Exercising the full launchd-path would
+    require subprocessing the CLI; the list_pr_watches → pr_watch_task
+    loop is the actual rehydration surface that must hold."""
+
+    @pytest.mark.asyncio
+    async def test_kill_then_restart_still_fires_handle_merge(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db_path = tmp_path / "state.db"
+
+        # --- Poller "run 1": spawn the watcher, then "crash" mid-watch. ---
+        db1 = StateDB(db_path)
+
+        sleep_event = asyncio.Event()
+        # Run 1: PR is still OPEN when the crash happens.
+        async def run1_get_state(*_a, **_kw):
+            await sleep_event.wait()
+            return {"state": "OPEN"}
+
+        mock_github_run1 = AsyncMock()
+        mock_github_run1.get_pr_state.side_effect = run1_get_state
+
+        async def factory_run1():
+            return None
+
+        async def runner1():
+            return await pr_watch_task(
+                repo="owner/repo", issue_number=77,
+                pr_url="https://github.com/owner/repo/pull/42",
+                pr_number=42, session_id="sess-1",
+                github=mock_github_run1,
+                transport_factory=factory_run1,
+                poll_interval=0, timeout=60,
+                state_db=db1,
+            )
+
+        task1 = asyncio.create_task(runner1())
+        # Yield so the row is persisted and the watcher enters its loop.
+        await asyncio.sleep(0)
+        assert len(db1.list_pr_watches()) == 1
+
+        # Simulate a poller shutdown: cancel the asyncio task + close
+        # the connection (launchd kickstart / crash / redeploy).
+        task1.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task1
+        db1.close()
+
+        # Row SURVIVED the restart — this is the durability claim.
+        db2 = StateDB(db_path)
+        surviving = db2.list_pr_watches()
+        assert len(surviving) == 1
+        row = surviving[0]
+        assert row["repo"] == "owner/repo"
+        assert row["pr_number"] == 42
+        assert row["issue_number"] == 77
+        assert row["session_id"] == "sess-1"
+        assert row["pr_url"] == "https://github.com/owner/repo/pull/42"
+
+        # --- Poller "run 2": rehydrate watcher, PR is now merged, handle_merge fires. ---
+        mock_github_run2 = AsyncMock()
+        mock_github_run2.get_pr_state.return_value = {"state": "MERGED"}
+
+        sent_messages: list[str] = []
+
+        class FakeTransport:
+            async def send(self, msg):
+                sent_messages.append(msg)
+
+            async def close(self):
+                pass
+
+        async def factory_run2():
+            return FakeTransport()
+
+        with caplog.at_level(
+            logging.INFO, logger="ctrlrelay.pipelines.post_merge"
+        ):
+            # This mirrors what cli.py does on startup: one
+            # asyncio.create_task per row, same kwargs as the original
+            # spawn plus the preserved state_db.
+            outcome = await pr_watch_task(
+                repo=row["repo"],
+                issue_number=row["issue_number"],
+                pr_url=row["pr_url"] or "",
+                pr_number=row["pr_number"],
+                session_id=row.get("session_id"),
+                github=mock_github_run2,
+                transport_factory=factory_run2,
+                poll_interval=0,
+                timeout=5,
+                state_db=db2,
+            )
+
+        # The rehydrated watcher MUST detect the merge and close the issue.
+        assert outcome["merged"] is True
+        assert outcome["failed"] is None
+        mock_github_run2.comment_on_issue.assert_called_once_with(
+            "owner/repo", 77, "Closed by PR #42",
+        )
+        # `gh issue close` ran via _run_gh.
+        close_calls = [
+            c for c in mock_github_run2._run_gh.call_args_list
+            if c.args[:2] == ("issue", "close")
+        ]
+        assert len(close_calls) == 1
+        # Telegram notification fired.
+        assert any(
+            "closed after PR #42 merged" in m for m in sent_messages
+        )
+        # Terminal outcome → row was cleaned up on run 2.
+        assert db2.list_pr_watches() == []
+        db2.close()

--- a/tests/test_post_merge.py
+++ b/tests/test_post_merge.py
@@ -825,6 +825,49 @@ class TestPRWatchTaskPersistence:
         db.close()
 
     @pytest.mark.asyncio
+    async def test_row_kept_when_handle_merge_raises(
+        self, tmp_path: Path
+    ) -> None:
+        """P1 regression (codex review on PR #111): if post-merge cleanup
+        fails (retries exhausted, bridge permanently dead), the durable
+        row MUST stay so the next poller startup re-runs handle_merge.
+        If the row is deleted before cleanup finishes, a shutdown in the
+        window between merge detection and issue close silently loses
+        the close + notify — exactly the bug persistence was meant to
+        prevent."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines import post_merge as pm
+        from ctrlrelay.pipelines.post_merge import pr_watch_task
+
+        db = StateDB(tmp_path / "state.db")
+
+        mock_github = AsyncMock()
+        mock_github.get_pr_state.return_value = {"state": "MERGED"}
+        mock_github._run_gh.side_effect = RuntimeError("gh unreachable")
+
+        async def factory():
+            return None
+
+        orig = pm._HANDLE_MERGE_RETRY_BASE_DELAY
+        pm._HANDLE_MERGE_RETRY_BASE_DELAY = 0
+        try:
+            outcome = await pr_watch_task(
+                repo="owner/repo", issue_number=77,
+                pr_url="https://github.com/owner/repo/pull/42",
+                pr_number=42, session_id="sess-1",
+                github=mock_github, transport_factory=factory,
+                poll_interval=0, timeout=5, state_db=db,
+            )
+        finally:
+            pm._HANDLE_MERGE_RETRY_BASE_DELAY = orig
+        assert outcome["merged"] is True
+        assert outcome["failed"] is not None
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["pr_number"] == 42
+        db.close()
+
+    @pytest.mark.asyncio
     async def test_state_db_optional_no_op_when_absent(self) -> None:
         """Legacy callers can still pass no state_db; the watcher must
         work in-memory-only just like before."""

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -261,6 +261,52 @@ class TestPRWatches:
         assert rows[0]["started_at"] == 2000
         db.close()
 
+    def test_add_pr_watch_preserves_started_at_on_conflict_without_explicit_ts(
+        self, tmp_path: Path
+    ) -> None:
+        """Production rehydrate path: re-inserting the same PR without
+        supplying ``started_at`` must preserve the original row's
+        timestamp. Otherwise every poller restart resets the 7-day
+        deadline and abandoned PRs never time out (codex P2 on PR #111)."""
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-1", pr_url="u1", started_at=1000,
+        )
+        # Re-insert WITHOUT started_at, simulating the rehydrated
+        # pr_watch_task calling add_pr_watch again on spawn. Metadata
+        # updates, timestamp does not.
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-2", pr_url="u2",
+        )
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "sess-2"
+        assert rows[0]["pr_url"] == "u2"
+        assert rows[0]["started_at"] == 1000
+        db.close()
+
+    def test_add_pr_watch_without_started_at_new_row_uses_now(
+        self, tmp_path: Path
+    ) -> None:
+        """New inserts (no existing row) still get ``now()`` when the
+        caller omits ``started_at``. Regression guard for the conflict
+        path so it doesn't accidentally break initial inserts."""
+        import time
+
+        db = StateDB(tmp_path / "state.db")
+        before = int(time.time())
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-1", pr_url="u1",
+        )
+        after = int(time.time())
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert before <= rows[0]["started_at"] <= after
+        db.close()
+
     def test_list_pr_watches_oldest_first(self, tmp_path: Path) -> None:
         db = StateDB(tmp_path / "state.db")
         db.add_pr_watch(

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -321,6 +321,113 @@ class TestPRWatches:
         assert [r["started_at"] for r in rows] == [100, 200]
         db.close()
 
+    def test_set_pr_watch_cleanup_phase_persists_value(
+        self, tmp_path: Path
+    ) -> None:
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-1", pr_url="u",
+        )
+        db.set_pr_watch_cleanup_phase("owner/r1", 42, "commented")
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) == "commented"
+        db.set_pr_watch_cleanup_phase("owner/r1", 42, "closed")
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) == "closed"
+        db.set_pr_watch_cleanup_phase("owner/r1", 42, "notified")
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) == "notified"
+        db.close()
+
+    def test_get_pr_watch_cleanup_phase_returns_none_for_fresh_row(
+        self, tmp_path: Path
+    ) -> None:
+        """A freshly-added watch has no phase yet — get() must return
+        None so handle_merge_with_retry starts from the beginning."""
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id=None, pr_url=None,
+        )
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) is None
+        db.close()
+
+    def test_get_pr_watch_cleanup_phase_returns_none_for_missing_row(
+        self, tmp_path: Path
+    ) -> None:
+        db = StateDB(tmp_path / "state.db")
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) is None
+        db.close()
+
+    def test_set_pr_watch_cleanup_phase_rejects_unknown_value(
+        self, tmp_path: Path
+    ) -> None:
+        """Invalid phases would break resume semantics — fail loudly
+        rather than writing a value that rehydration will interpret
+        as 'nothing done yet'."""
+        import pytest
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id=None, pr_url=None,
+        )
+        with pytest.raises(ValueError):
+            db.set_pr_watch_cleanup_phase("owner/r1", 42, "bogus")
+        db.close()
+
+    def test_add_pr_watch_preserves_cleanup_phase_on_conflict(
+        self, tmp_path: Path
+    ) -> None:
+        """Rehydrate path: the re-insert in pr_watch_task must not
+        clobber the stored cleanup_phase. Otherwise a resumed watcher
+        would re-run every step the prior run already completed."""
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-1", pr_url="u1",
+        )
+        db.set_pr_watch_cleanup_phase("owner/r1", 42, "closed")
+        # Rehydrate simulates pr_watch_task re-adding its row. The
+        # phase must survive — that's the whole point of durable
+        # resume.
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-2", pr_url="u2",
+        )
+        assert db.get_pr_watch_cleanup_phase("owner/r1", 42) == "closed"
+        db.close()
+
+    def test_cleanup_phase_column_added_to_preexisting_pr_watches(
+        self, tmp_path: Path
+    ) -> None:
+        """Older DBs created by the first cut of PR #111 have a
+        pr_watches table without cleanup_phase. Migration must ALTER
+        it in, otherwise set_pr_watch_cleanup_phase raises on an
+        OperationalError and resume-after-restart breaks."""
+        import sqlite3
+        db_path = tmp_path / "state.db"
+        # Simulate the OLD schema: pr_watches without cleanup_phase.
+        conn = sqlite3.connect(str(db_path))
+        conn.execute(
+            """CREATE TABLE pr_watches (
+                repo TEXT NOT NULL,
+                pr_number INTEGER NOT NULL,
+                session_id TEXT,
+                issue_number INTEGER NOT NULL,
+                pr_url TEXT,
+                started_at INTEGER NOT NULL,
+                PRIMARY KEY (repo, pr_number)
+            )"""
+        )
+        conn.commit()
+        conn.close()
+        # Re-opening via StateDB should run _migrate and add the col.
+        db = StateDB(db_path)
+        cols = {
+            row[1]
+            for row in db.execute("PRAGMA table_info(pr_watches)").fetchall()
+        }
+        assert "cleanup_phase" in cols
+        db.close()
+
     def test_pr_watches_table_added_to_preexisting_db(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -173,6 +173,176 @@ class TestAgentSessionId:
         db.close()
 
 
+class TestPRWatches:
+    """pr_watches stores in-flight merge watchers so a poller restart
+    rehydrates them. Rows are written on `dev.pr.watching` and removed
+    on the terminal merged / timed-out events only — a cancellation
+    (shutdown) deliberately leaves the row behind."""
+
+    def test_pr_watches_table_is_created(self, tmp_path: Path) -> None:
+        db = StateDB(tmp_path / "state.db")
+        tables = db.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        ).fetchall()
+        table_names = {row[0] for row in tables}
+        assert "pr_watches" in table_names
+        db.close()
+
+    def test_pr_watches_schema_has_expected_columns(self, tmp_path: Path) -> None:
+        """Acceptance: (session_id, repo, issue_number, pr_number, pr_url,
+        started_at)."""
+        db = StateDB(tmp_path / "state.db")
+        cols = {
+            row[1]
+            for row in db.execute("PRAGMA table_info(pr_watches)").fetchall()
+        }
+        expected = {
+            "session_id", "repo", "issue_number", "pr_number",
+            "pr_url", "started_at",
+        }
+        assert expected.issubset(cols)
+        db.close()
+
+    def test_add_and_list_pr_watch(self, tmp_path: Path) -> None:
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42,
+            issue_number=77, session_id="sess-1",
+            pr_url="https://github.com/owner/r1/pull/42",
+        )
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["repo"] == "owner/r1"
+        assert rows[0]["pr_number"] == 42
+        assert rows[0]["issue_number"] == 77
+        assert rows[0]["session_id"] == "sess-1"
+        assert rows[0]["pr_url"] == "https://github.com/owner/r1/pull/42"
+        assert rows[0]["started_at"] > 0
+        db.close()
+
+    def test_remove_pr_watch_returns_true_when_present(
+        self, tmp_path: Path
+    ) -> None:
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42,
+            issue_number=77, session_id=None, pr_url=None,
+        )
+        assert db.remove_pr_watch("owner/r1", 42) is True
+        assert db.list_pr_watches() == []
+        db.close()
+
+    def test_remove_pr_watch_returns_false_when_missing(
+        self, tmp_path: Path
+    ) -> None:
+        db = StateDB(tmp_path / "state.db")
+        assert db.remove_pr_watch("owner/r1", 42) is False
+        db.close()
+
+    def test_add_pr_watch_is_idempotent_on_repo_pr_number(
+        self, tmp_path: Path
+    ) -> None:
+        """Re-inserting the same (repo, pr_number) refreshes the row
+        rather than raising — covers the rehydrate → re-spawn path
+        where the existing task re-inserts."""
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-1", pr_url="u1", started_at=1000,
+        )
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=42, issue_number=77,
+            session_id="sess-2", pr_url="u2", started_at=2000,
+        )
+        rows = db.list_pr_watches()
+        assert len(rows) == 1
+        assert rows[0]["session_id"] == "sess-2"
+        assert rows[0]["pr_url"] == "u2"
+        assert rows[0]["started_at"] == 2000
+        db.close()
+
+    def test_list_pr_watches_oldest_first(self, tmp_path: Path) -> None:
+        db = StateDB(tmp_path / "state.db")
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=1, issue_number=10,
+            session_id=None, pr_url=None, started_at=200,
+        )
+        db.add_pr_watch(
+            repo="owner/r2", pr_number=2, issue_number=20,
+            session_id=None, pr_url=None, started_at=100,
+        )
+        rows = db.list_pr_watches()
+        assert [r["started_at"] for r in rows] == [100, 200]
+        db.close()
+
+    def test_pr_watches_table_added_to_preexisting_db(
+        self, tmp_path: Path
+    ) -> None:
+        """Acceptance: an older state.db lacking the pr_watches table
+        must transparently gain it when opened by the new code. The
+        existing schema pattern is CREATE TABLE IF NOT EXISTS, so just
+        re-opening the DB should add the table without disturbing
+        existing rows."""
+        import sqlite3
+
+        db_path = tmp_path / "state.db"
+        # Simulate a pre-pr_watches DB: create the sessions table only,
+        # with an existing session row we want to see survive the open.
+        conn = sqlite3.connect(str(db_path))
+        conn.executescript(
+            """
+            CREATE TABLE sessions (
+                id TEXT PRIMARY KEY,
+                pipeline TEXT NOT NULL,
+                repo TEXT NOT NULL,
+                issue_number INTEGER,
+                worktree_path TEXT,
+                status TEXT NOT NULL,
+                blocked_question TEXT,
+                started_at INTEGER NOT NULL,
+                ended_at INTEGER,
+                claude_exit_code INTEGER,
+                summary TEXT
+            );
+            """
+        )
+        conn.execute(
+            "INSERT INTO sessions (id, pipeline, repo, status, started_at) "
+            "VALUES (?, ?, ?, ?, ?)",
+            ("old-session", "dev", "owner/repo", "done", 1),
+        )
+        conn.commit()
+        # Sanity check: the old DB has no pr_watches table.
+        assert conn.execute(
+            "SELECT name FROM sqlite_master "
+            "WHERE type='table' AND name='pr_watches'"
+        ).fetchone() is None
+        conn.close()
+
+        # Open with the new StateDB — migration/creation must add the
+        # table and not clobber the existing session row.
+        db = StateDB(db_path)
+        table_names = {
+            row[0]
+            for row in db.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+        assert "pr_watches" in table_names
+        # Existing sessions row intact.
+        row = db.execute(
+            "SELECT id FROM sessions WHERE id = ?", ("old-session",)
+        ).fetchone()
+        assert row is not None
+        # And the new table works.
+        db.add_pr_watch(
+            repo="owner/r1", pr_number=1, issue_number=1,
+            session_id=None, pr_url=None,
+        )
+        assert len(db.list_pr_watches()) == 1
+        db.close()
+
+
 class TestPendingResumes:
     """pending_resumes stores BLOCKED sessions + operator answers so a
     Telegram reply arriving after a session has torn down still drives a


### PR DESCRIPTION
## Summary
- Adds a `pr_watches` state_db table so in-flight merge watchers survive a poller restart (launchd kickstart, crash, redeploy, reboot). Without this, any PR sitting in review across a restart silently loses its post-merge automation (issue close + Telegram ping) for the remainder of its 7-day watch window.
- `pr_watch_task` now persists a row on `dev.pr.watching` and removes it on terminal `dev.pr.merged` / `dev.pr.watch_timeout`. It deliberately **does not** remove on `dev.pr.watch_cancelled` — cancellation is the shutdown signal, and the row must be left behind for the next startup to rehydrate.
- Poller startup (`_main` in `cli.py`) now reads `list_pr_watches()` and spawns one `pr_watch_task` per surviving row **before** `run_poll_loop` enters its main loop.

## Design notes
- Took Option 1 from the issue (dedicated `pr_watches` table). Keyed on `(repo, pr_number)` because we watch at most one PR per slot.
- Migration reuses the existing `CREATE TABLE IF NOT EXISTS` pattern in `state.py` — no new migrations machinery needed; older DBs transparently gain the table on open (covered by `test_pr_watches_table_added_to_preexisting_db`).
- StateDB I/O is best-effort inside `pr_watch_task`: a disk failure logs `dev.pr.watch_persist_failed` but never aborts merge detection. Preserves the watcher's prior in-memory-only semantics as a fallback.
- Row removal happens *before* `handle_merge` runs so an exhausted retry loop can't leave a ghost row that gets rehydrated on every subsequent startup into the same broken cleanup.

## Test plan
- [x] `uv run ruff check src/ tests/` — clean
- [x] `uv run pytest tests/` — 396 passed, 1 deselected (pre-existing unrelated docs-site test)
- [x] New schema migration test: opens a pre-`pr_watches` DB, asserts the table is added and existing sessions rows survive
- [x] New state_db CRUD tests: add / list / remove / idempotent upsert / ordering
- [x] `pr_watch_task` lifecycle tests: row written on spawn, removed on merge, removed on timeout, **kept** on cancel
- [x] Integration test `TestPollerRestartRehydration::test_kill_then_restart_still_fires_handle_merge` — spawns a watcher against one StateDB instance, cancels the task + closes the connection (simulating shutdown), opens a second StateDB against the same file, rehydrates the watcher with a now-MERGED PR, and asserts `handle_merge` fires (issue close + Telegram send)

Closes #57.