### PR TITLE
fix(dev): release repo lock during PR CI verification (closes #29)

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1265,17 +1265,25 @@ def poller_start(
                 # PR already exists AND verification decided it wasn't
                 # ready (_verify_and_fix_pr only returns this error from
                 # the "need to run request_fix but couldn't reacquire"
-                # path). Just spawning the merge watcher and leaving
-                # the issue seen would strand a known-broken PR forever,
-                # because nothing else would retry the fix round.
+                # path). Two sub-cases based on whether run_dev_issue's
+                # cleanup reacquire succeeded:
                 #
-                # Un-mark the issue so the next poll picks it up again.
-                # run_dev_issue's branch-reuse path handles "issue
-                # already has a branch / PR" (see issues #51, #52) —
-                # imperfect but functional. Still spawn the merge
-                # watcher below so the existing PR's auto-close works
-                # if it happens to get merged by a human before the
-                # retry round lands.
+                # (a) Cleanup clean (lock reclaimed, worktree torn down):
+                #     un-mark the issue so the next poll retries the fix.
+                #     run_dev_issue's branch-reuse path handles
+                #     "issue already has a branch / PR" (#51, #52).
+                #
+                # (b) Cleanup deferred (peer still holds lock; worktree
+                #     NOT removed): un-marking would make the next poll
+                #     call create_worktree_with_new_branch and fail
+                #     with "already checked out" because the abandoned
+                #     worktree metadata is still registered. Leave the
+                #     issue seen and log an operator-actionable warning;
+                #     a poller restart (or `git worktree prune`) will
+                #     clear the stale entry.
+                #
+                # Either way the merge watcher still spawns below so
+                # the existing PR's auto-close works if a human merges.
                 if (
                     not result.success
                     and not result.blocked
@@ -1284,13 +1292,29 @@ def poller_start(
                     in result.error.lower()
                 ):
                     pr_num_str = result.outputs.get("pr_number", "?")
-                    poller.unmark_seen(repo, issue_number)
-                    console.print(
-                        f"[yellow]#{issue_number} in {repo}: lock "
-                        f"contention during PR verification — un-marking "
-                        f"for retry (PR #{pr_num_str} needs another "
-                        "fix round). Merge watcher still spawns.[/yellow]"
+                    cleanup_deferred = bool(
+                        result.outputs.get("cleanup_deferred")
                     )
+                    if cleanup_deferred:
+                        console.print(
+                            f"[red]#{issue_number} in {repo}: lock "
+                            "contention during PR verification AND "
+                            "cleanup could not reclaim the lock. "
+                            f"Worktree for PR #{pr_num_str} is still "
+                            "registered; retry would fail at "
+                            "create_worktree. Operator action: "
+                            "`git worktree prune` in the bare repo "
+                            "or restart the poller.[/red]"
+                        )
+                    else:
+                        poller.unmark_seen(repo, issue_number)
+                        console.print(
+                            f"[yellow]#{issue_number} in {repo}: lock "
+                            "contention during PR verification — "
+                            f"un-marking for retry (PR #{pr_num_str} "
+                            "needs another fix round). Merge watcher "
+                            "still spawns.[/yellow]"
+                        )
 
                 # Spawn the PR watcher FIRST, before any best-effort
                 # notification. The poller has already marked this issue

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1660,27 +1660,26 @@ def poller_start(
                             pass
                         continue
 
-                    # Lock-contention is retryable: the 6am secops cron or
-                    # an in-flight dev session holds the repo lock. Leave
-                    # the pending_resumes row as-is so the next sweeper
-                    # tick tries again. Without this guard the operator's
-                    # queued answer is silently dropped.
+                    # Lock-contention at the INITIAL acquire step is
+                    # retryable: the 6am secops cron or an in-flight
+                    # dev session holds the repo lock, we never got
+                    # to pipeline.resume so the operator's answer is
+                    # still intact. Leave the pending_resumes row and
+                    # let the next sweeper tick try again.
                     #
-                    # Two distinct strings both mean "lock contended":
-                    # the initial-acquire message (secops / peer dev
-                    # holds it outright) AND the post-verify message
-                    # (resume_dev_from_pending went into _verify_and_fix_pr,
-                    # needed another fix round, and lost the reacquire
-                    # race). Without the second string, a resume hitting
-                    # contention mid-verify would be marked consumed and
-                    # the operator's answer silently dropped.
-                    lock_contended_strings = (
-                        "Repository locked by another session",
-                        "Repo lock reacquire contended during PR verification",
-                    )
-                    if (
-                        not result.success
-                        and result.error in lock_contended_strings
+                    # The OTHER lock-contended error
+                    # ("Repo lock reacquire contended during PR
+                    # verification") is NOT retryable here: it fires
+                    # only after pipeline.resume consumed the answer
+                    # and advanced the agent session. Replaying the
+                    # same answer on the next tick would double-apply
+                    # side effects on the PR (duplicate commit, dup
+                    # notification) or fail because the agent session
+                    # is already DONE. Fall through to mark the row
+                    # consumed; operator can provide a new answer if
+                    # the PR still needs work after the peer releases.
+                    if not result.success and result.error == (
+                        "Repository locked by another session"
                     ):
                         console.print(
                             "[dim]pending_resume_sweeper: "

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1235,10 +1235,10 @@ def poller_start(
                 # Lock-conflict retry hook. The poller marks issues seen
                 # BEFORE handle_issue runs, so a failed attempt would
                 # permanently drop the issue. If run_dev_issue couldn't
-                # acquire the per-repo lock (common when a scheduled
-                # secops sweep is mid-run on the same repo), un-mark the
-                # issue so the next poll picks it up. Any other failure
-                # still stays seen — those aren't transient.
+                # acquire the per-repo lock up front (common when a
+                # scheduled secops sweep is mid-run on the same repo),
+                # un-mark the issue so the next poll picks it up. Any
+                # other failure still stays seen — those aren't transient.
                 if (
                     not result.success
                     and not result.blocked
@@ -1260,6 +1260,28 @@ def poller_start(
                         except Exception:
                             pass
                     return
+
+                # Lock-contended DURING PR verification (issue #29): the
+                # PR already exists, so un-marking the issue would make
+                # the next poll launch a fresh dev pass against the open
+                # PR — duplicate work and merge-conflict territory.
+                # Leave the issue marked seen and fall through so the
+                # merge watcher still spawns for the existing PR and the
+                # operator still gets a notification.
+                if (
+                    not result.success
+                    and not result.blocked
+                    and result.error
+                    and "reacquire contended during pr verification"
+                    in result.error.lower()
+                ):
+                    pr_num_str = result.outputs.get("pr_number", "?")
+                    console.print(
+                        f"[yellow]#{issue_number} in {repo}: lock "
+                        f"contention during PR verification — leaving "
+                        f"seen (PR #{pr_num_str} already open). Merge "
+                        "watcher still spawns.[/yellow]"
+                    )
 
                 # Spawn the PR watcher FIRST, before any best-effort
                 # notification. The poller has already marked this issue

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1632,8 +1632,22 @@ def poller_start(
                     # the pending_resumes row as-is so the next sweeper
                     # tick tries again. Without this guard the operator's
                     # queued answer is silently dropped.
-                    if not result.success and result.error == (
-                        "Repository locked by another session"
+                    #
+                    # Two distinct strings both mean "lock contended":
+                    # the initial-acquire message (secops / peer dev
+                    # holds it outright) AND the post-verify message
+                    # (resume_dev_from_pending went into _verify_and_fix_pr,
+                    # needed another fix round, and lost the reacquire
+                    # race). Without the second string, a resume hitting
+                    # contention mid-verify would be marked consumed and
+                    # the operator's answer silently dropped.
+                    lock_contended_strings = (
+                        "Repository locked by another session",
+                        "Repo lock reacquire contended during PR verification",
+                    )
+                    if (
+                        not result.success
+                        and result.error in lock_contended_strings
                     ):
                         console.print(
                             "[dim]pending_resume_sweeper: "

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1299,12 +1299,19 @@ def poller_start(
                         console.print(
                             f"[red]#{issue_number} in {repo}: lock "
                             "contention during PR verification AND "
-                            "cleanup could not reclaim the lock. "
-                            f"Worktree for PR #{pr_num_str} is still "
-                            "registered; retry would fail at "
-                            "create_worktree. Operator action: "
-                            "`git worktree prune` in the bare repo "
-                            "or restart the poller.[/red]"
+                            "cleanup could not reclaim the lock after "
+                            "the full fix budget (~1 hour). A peer "
+                            "session is wedged. Operator action: "
+                            "identify the peer holding the lock on "
+                            f"repo_locks for {repo} (via `sqlite3 "
+                            "state.db 'SELECT * FROM repo_locks'`), "
+                            "investigate/kill it, then `git worktree "
+                            "remove --force` on the session's "
+                            "worktree directory before re-assigning "
+                            f"issue #{issue_number}. "
+                            f"PR #{pr_num_str} already exists on "
+                            "GitHub and is being watched for merge."
+                            "[/red]"
                         )
                     else:
                         poller.unmark_seen(repo, issue_number)
@@ -1666,18 +1673,6 @@ def poller_start(
                     # to pipeline.resume so the operator's answer is
                     # still intact. Leave the pending_resumes row and
                     # let the next sweeper tick try again.
-                    #
-                    # The OTHER lock-contended error
-                    # ("Repo lock reacquire contended during PR
-                    # verification") is NOT retryable here: it fires
-                    # only after pipeline.resume consumed the answer
-                    # and advanced the agent session. Replaying the
-                    # same answer on the next tick would double-apply
-                    # side effects on the PR (duplicate commit, dup
-                    # notification) or fail because the agent session
-                    # is already DONE. Fall through to mark the row
-                    # consumed; operator can provide a new answer if
-                    # the PR still needs work after the peer releases.
                     if not result.success and result.error == (
                         "Repository locked by another session"
                     ):
@@ -1685,6 +1680,48 @@ def poller_start(
                             "[dim]pending_resume_sweeper: "
                             f"lock contention on {repo}, will retry "
                             f"next tick (session={session_id})[/dim]"
+                        )
+                        continue
+
+                    # The OTHER lock-contended error fires only AFTER
+                    # pipeline.resume consumed the operator's answer
+                    # and advanced the agent session to DONE: replaying
+                    # the same answer would double-apply side effects
+                    # on the PR or fail because the agent session is
+                    # already finalized. BUT just marking the row
+                    # consumed strands the workflow — the PR needs
+                    # another fix round and nothing would trigger it.
+                    # Re-insert a fresh pending_resumes row with a
+                    # synthetic prompt so a new operator reply can
+                    # attach via the bridge and drive the next round.
+                    if not result.success and result.error == (
+                        "Repo lock reacquire contended during PR verification"
+                    ):
+                        pr_num = result.outputs.get("pr_number", "?")
+                        synthetic_question = (
+                            f"Post-verify lock contention on {repo} "
+                            f"while resuming session {session_id} "
+                            f"(PR #{pr_num}). The prior answer was "
+                            "consumed; reply with new guidance to "
+                            "retry the fix round once the peer "
+                            "session releases."
+                        )
+                        try:
+                            state_db.add_pending_resume(
+                                session_id=session_id,
+                                pipeline=pipeline_name,
+                                repo=repo,
+                                question=synthetic_question,
+                            )
+                        except Exception:
+                            pass
+                        console.print(
+                            f"[yellow]pending_resume_sweeper: "
+                            f"verify contention on {repo} (session="
+                            f"{session_id}); prior answer consumed, "
+                            "fresh pending_resumes row inserted so a "
+                            "new operator reply can drive the retry."
+                            "[/yellow]"
                         )
                         continue
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1262,12 +1262,20 @@ def poller_start(
                     return
 
                 # Lock-contended DURING PR verification (issue #29): the
-                # PR already exists, so un-marking the issue would make
-                # the next poll launch a fresh dev pass against the open
-                # PR — duplicate work and merge-conflict territory.
-                # Leave the issue marked seen and fall through so the
-                # merge watcher still spawns for the existing PR and the
-                # operator still gets a notification.
+                # PR already exists AND verification decided it wasn't
+                # ready (_verify_and_fix_pr only returns this error from
+                # the "need to run request_fix but couldn't reacquire"
+                # path). Just spawning the merge watcher and leaving
+                # the issue seen would strand a known-broken PR forever,
+                # because nothing else would retry the fix round.
+                #
+                # Un-mark the issue so the next poll picks it up again.
+                # run_dev_issue's branch-reuse path handles "issue
+                # already has a branch / PR" (see issues #51, #52) —
+                # imperfect but functional. Still spawn the merge
+                # watcher below so the existing PR's auto-close works
+                # if it happens to get merged by a human before the
+                # retry round lands.
                 if (
                     not result.success
                     and not result.blocked
@@ -1276,11 +1284,12 @@ def poller_start(
                     in result.error.lower()
                 ):
                     pr_num_str = result.outputs.get("pr_number", "?")
+                    poller.unmark_seen(repo, issue_number)
                     console.print(
                         f"[yellow]#{issue_number} in {repo}: lock "
-                        f"contention during PR verification — leaving "
-                        f"seen (PR #{pr_num_str} already open). Merge "
-                        "watcher still spawns.[/yellow]"
+                        f"contention during PR verification — un-marking "
+                        f"for retry (PR #{pr_num_str} needs another "
+                        "fix round). Merge watcher still spawns.[/yellow]"
                     )
 
                 # Spawn the PR watcher FIRST, before any best-effort

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -51,6 +51,15 @@ _REACQUIRE_PROGRESS_LOG_EVERY = 60
 _REACQUIRE_CLEANUP_ATTEMPTS = 3
 _REACQUIRE_CLEANUP_SLEEP_SECONDS = 1.0
 
+# Release-lock retry policy for transient SQLite errors. The final
+# release() call in run_dev_issue's outer finally is the last chance
+# to clean up; if that raises and we silently returned, the repo_locks
+# row would linger forever. Short retry loop handles the common
+# transient case; exhausted retries emit a loud wedged event so ops
+# can reclaim manually.
+_RELEASE_RETRY_ATTEMPTS = 3
+_RELEASE_RETRY_SLEEP_SECONDS = 0.5
+
 # Two distinct error messages so callers can tell which phase of the
 # pipeline hit contention:
 #   INITIAL  — nothing started, safe to retry from scratch (cli un-marks
@@ -91,33 +100,58 @@ class _RepoLockHandle:
         from a ``finally`` block that may run before acquire ever
         succeeded.
 
-        If the underlying DELETE raises (e.g. transient
-        ``database is locked`` from SQLite), we keep ``held=True`` so
-        subsequent release attempts retry. Flipping held=False after a
-        failed DELETE would wedge the repo: our stale row stays in
-        ``repo_locks`` rejecting peer acquires while our own code
-        believes the lock is free and tries to proceed.
+        Retries the DELETE a few times on transient failures (SQLite
+        ``database is locked``, etc.). The outer ``finally`` is the
+        last-chance call — if THAT raised and we silently returned,
+        the ``repo_locks`` row would linger forever, wedging every
+        future acquire on this repo until manual DB cleanup.
 
-        The exception is logged and swallowed (release must not leak
-        exceptions from a finally path, where it would mask the
-        original error the caller was unwinding)."""
+        After exhausting retries we emit a ``dev.lock.release_wedged``
+        critical-level event naming the repo + session so an operator
+        can reclaim the lock row. held is left True so an outer
+        retry (if any) still has a chance.
+
+        The inner retry's exception is swallowed only after the
+        wedged event fires — release must not leak exceptions from a
+        finally path where it would mask the caller's original error."""
         if not self.held:
             return
-        try:
-            self.state_db.release_lock(self.repo, self.session_id)
-        except Exception as e:
-            log_event(
-                _logger,
-                "dev.lock.release_failed",
-                session_id=self.session_id,
-                repo=self.repo,
-                reason=type(e).__name__,
-                error=str(e)[:200],
-            )
-            # Don't flip held — a later call (outer finally, etc.) will
-            # retry the DELETE once the transient condition clears.
+        last_exc: Exception | None = None
+        for attempt in range(1, _RELEASE_RETRY_ATTEMPTS + 1):
+            try:
+                self.state_db.release_lock(self.repo, self.session_id)
+            except Exception as e:
+                last_exc = e
+                log_event(
+                    _logger,
+                    "dev.lock.release_failed",
+                    session_id=self.session_id,
+                    repo=self.repo,
+                    attempt=attempt,
+                    max_attempts=_RELEASE_RETRY_ATTEMPTS,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
+                if attempt < _RELEASE_RETRY_ATTEMPTS:
+                    time.sleep(_RELEASE_RETRY_SLEEP_SECONDS)
+                continue
+            self.held = False
             return
-        self.held = False
+        # All retries exhausted. The row is presumed still present;
+        # alert loudly so it doesn't silently wedge the repo.
+        log_event(
+            _logger,
+            "dev.lock.release_wedged",
+            session_id=self.session_id,
+            repo=self.repo,
+            reason=type(last_exc).__name__ if last_exc else "unknown",
+            error=str(last_exc)[:200] if last_exc else "",
+            operator_action=(
+                "DELETE FROM repo_locks WHERE repo = ? AND session_id = ? "
+                "manually, or restart the poller after confirming the "
+                "session is not live."
+            ),
+        )
 
     async def reacquire(
         self,
@@ -737,18 +771,25 @@ async def run_dev_issue(
             )
 
         # Reacquire the lock for the post-verify cleanup phase (remove
-        # worktree / delete branch). Uses the SHORT cleanup budget, not
-        # the fix-path budget: cleanup is best-effort, and run_poll_loop
-        # awaits handlers serially — blocking here for an hour would
-        # stall the whole poll cycle AND delay the PR merge watcher
-        # spawn (which happens in cli.handle_issue after we return).
-        # If we can't get the lock back in a few seconds, log and skip
-        # cleanup; the session still returns its verified result.
+        # worktree / delete branch). Usually SHORT budget (cleanup is
+        # best-effort, run_poll_loop awaits handlers serially).
+        #
+        # EXCEPT for the verify-contention error: that path signals
+        # "PR needs another fix round that we couldn't enter," cli
+        # will un-mark the issue for retry, and a fresh run would
+        # fail at create_worktree if this one left the worktree
+        # registered. Retry success DEPENDS on cleanup here, so use
+        # the full fix budget — accepting a possible long wait in
+        # this rare double-contention case beats deterministically
+        # wedging the issue.
         if not lock.held:
-            reacquired = await lock.reacquire(
-                attempts=_REACQUIRE_CLEANUP_ATTEMPTS,
-                sleep_seconds=_REACQUIRE_CLEANUP_SLEEP_SECONDS,
-            )
+            if result.error == _LOCK_CONTENDED_DURING_VERIFY_ERROR:
+                reacquired = await lock.reacquire()  # full fix budget
+            else:
+                reacquired = await lock.reacquire(
+                    attempts=_REACQUIRE_CLEANUP_ATTEMPTS,
+                    sleep_seconds=_REACQUIRE_CLEANUP_SLEEP_SECONDS,
+                )
             if not reacquired:
                 log_event(
                     _logger,

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import time
 import uuid
 from dataclasses import dataclass
@@ -21,6 +22,92 @@ from ctrlrelay.transports.base import Transport
 
 DEFAULT_MAX_FIX_ATTEMPTS = 3
 DEFAULT_MAX_BLOCKED_ROUNDS = 5
+
+# Reacquire policy for the repo lock after the unlocked verification phase.
+# Verification only releases the lock because CI polling doesn't touch git;
+# when we need to run `request_fix` (which spawns claude + writes worktree)
+# we must get it back. Contention here is expected to be brief — another
+# session doing its own git-op phase — so a small retry budget with a
+# short sleep is enough to avoid a spurious failure. If we still can't
+# get it after the budget is exhausted, surface a clear typed error.
+_REACQUIRE_LOCK_ATTEMPTS = 6
+_REACQUIRE_LOCK_SLEEP_SECONDS = 5.0
+_LOCK_CONTENDED_ERROR = "Repository locked by another session"
+
+
+class _RepoLockHandle:
+    """Tracks whether this session currently holds the repo lock and
+    allows release/reacquire around phases that don't need exclusive git
+    access (PR CI verification is pure `gh` polling — see issue #29).
+    The ``finally`` block at the end of ``run_dev_issue`` calls
+    ``release`` regardless; calling it twice is a no-op because
+    ``StateDB.release_lock`` is idempotent (deletes rows, rowcount=0 the
+    second time). Tracking ``held`` locally lets the pipeline decide
+    whether worktree/branch cleanup is safe to attempt on error paths."""
+
+    __slots__ = ("state_db", "repo", "session_id", "held")
+
+    def __init__(self, state_db: StateDB, repo: str, session_id: str) -> None:
+        self.state_db = state_db
+        self.repo = repo
+        self.session_id = session_id
+        # Starts False; run_dev_issue wraps its initial acquire call and
+        # flips this to True on success.
+        self.held = False
+
+    def release(self) -> None:
+        """Release the lock if we hold it. Safe to call multiple times
+        and safe to call from a ``finally`` that ran before acquire
+        succeeded."""
+        if not self.held:
+            return
+        try:
+            self.state_db.release_lock(self.repo, self.session_id)
+        finally:
+            # Even if the DELETE raised, mark released so a later call
+            # doesn't try again. A retained `held=True` after a failed
+            # release would have the outer ``finally`` issue a second
+            # DELETE anyway — not useful.
+            self.held = False
+
+    async def reacquire(
+        self,
+        *,
+        attempts: int | None = None,
+        sleep_seconds: float | None = None,
+    ) -> bool:
+        """Try to re-grab the lock after a release. Returns True on
+        success, False if contention persists past the retry budget.
+
+        Retry budget: ``attempts`` INSERT tries separated by
+        ``sleep_seconds`` of sleep. Default 6×5s = up to 30s wait,
+        which is an order of magnitude longer than any pure-git phase
+        held by a peer session. If the peer is stuck in its own
+        verification phase we'd wait a very long time otherwise — but
+        that peer also releases before verify, so the remaining
+        git-held window is short by construction.
+
+        Defaults resolve at call time (``None`` sentinel) so tests can
+        monkey-patch the module constants to speed up contention
+        scenarios without threading kwargs through every caller.
+        """
+        if self.held:
+            return True
+        effective_attempts = (
+            _REACQUIRE_LOCK_ATTEMPTS if attempts is None else attempts
+        )
+        effective_sleep = (
+            _REACQUIRE_LOCK_SLEEP_SECONDS
+            if sleep_seconds is None
+            else sleep_seconds
+        )
+        for attempt in range(max(1, effective_attempts)):
+            if self.state_db.acquire_lock(self.repo, self.session_id):
+                self.held = True
+                return True
+            if attempt < effective_attempts - 1:
+                await asyncio.sleep(effective_sleep)
+        return False
 
 AGENT_CLAIM_MARKER = "<!-- ctrlrelay:claimed -->"
 AGENT_CLAIM_COMMENT = (
@@ -302,20 +389,78 @@ async def _verify_and_fix_pr(
     result: PipelineResult,
     verifier: PRVerifier,
     max_attempts: int,
+    lock_handle: _RepoLockHandle | None = None,
 ) -> PipelineResult:
-    """Loop: verify CI+mergeability, ask Claude to fix, re-verify."""
+    """Loop: verify CI+mergeability, ask Claude to fix, re-verify.
+
+    Lock discipline (issue #29): the verify phase is pure `gh` polling
+    and holds no git state, so callers pass a ``lock_handle`` whose
+    repo lock we release before each ``verifier.verify`` call and
+    reacquire before each ``request_fix`` call (which spawns claude
+    and writes to the worktree). This lets peer sessions targeting
+    the same repo run their own git-op phases while we wait on CI.
+
+    If reacquire fails after the retry budget, we surface a clear
+    failed result rather than silently running ``request_fix``
+    without the lock — another session may be mutating the shared
+    bare repo and our claude process could corrupt its state.
+    Cancellation during the unlocked phase is safe: the lock_handle
+    tracks ``held=False`` so the outer ``finally`` no-ops its release.
+    """
     pr_number_raw = result.outputs.get("pr_number")
     if pr_number_raw is None:
         return result
     pr_number = int(pr_number_raw)
 
-    verification = await verifier.verify(ctx.repo, pr_number)
+    async def _run_verify() -> VerificationResult:
+        """Release the lock around the pure-gh polling window, then
+        hand the lock back to the caller on return. Reacquire is
+        deferred to just before the fix path so peer sessions get the
+        widest possible window."""
+        if lock_handle is not None:
+            lock_handle.release()
+        try:
+            return await verifier.verify(ctx.repo, pr_number)
+        except asyncio.CancelledError:
+            # Intentionally leave held=False so the outer finally's
+            # release_lock is a no-op; the row is already gone. Re-raise
+            # to let the cancellation propagate.
+            raise
+
+    verification = await _run_verify()
     # If CI is simply slow (timed_out) we hand the PR off rather than asking
     # Claude to "fix" something that isn't broken.
     if verification.timed_out:
         return result
     attempts = 0
     while not verification.ready and attempts < max_attempts:
+        # Reacquire before request_fix — claude spawns inside the
+        # worktree and pushes to the shared bare repo. If we can't
+        # get the lock back in a reasonable window, bail cleanly
+        # rather than racing another session.
+        if lock_handle is not None and not lock_handle.held:
+            reacquired = await lock_handle.reacquire()
+            if not reacquired:
+                log_event(
+                    _logger,
+                    "dev.verify.lock_reacquire_contended",
+                    session_id=result.session_id,
+                    repo=ctx.repo,
+                    pr_number=pr_number,
+                    attempts=_REACQUIRE_LOCK_ATTEMPTS,
+                )
+                return PipelineResult(
+                    success=False,
+                    session_id=result.session_id,
+                    summary=(
+                        f"PR #{pr_number} verification found work to do "
+                        "but could not re-acquire repo lock after "
+                        f"{_REACQUIRE_LOCK_ATTEMPTS} attempts"
+                    ),
+                    error=_LOCK_CONTENDED_ERROR,
+                    outputs=result.outputs,
+                )
+
         fix_prompt = _build_fix_prompt(pr_number, verification)
         fix_result = await pipeline.request_fix(ctx, fix_prompt)
         attempts += 1
@@ -335,7 +480,7 @@ async def _verify_and_fix_pr(
             )
 
         result = fix_result
-        verification = await verifier.verify(ctx.repo, pr_number)
+        verification = await _run_verify()
         if verification.timed_out:
             # Same rule after a fix round: slow CI isn't a Claude task.
             return result
@@ -374,6 +519,7 @@ async def run_dev_issue(
     session_id = f"dev-{repo.replace('/', '-')}-{issue_number}-{uuid.uuid4().hex[:8]}"
     branch_name = branch_template.replace("{n}", str(issue_number))
 
+    lock = _RepoLockHandle(state_db, repo, session_id)
     if not state_db.acquire_lock(repo, session_id):
         return PipelineResult(
             success=False,
@@ -381,6 +527,7 @@ async def run_dev_issue(
             summary=f"Could not acquire lock for {repo}",
             error="Repository locked by another session",
         )
+    lock.held = True
 
     worktree_path: Path | None = None
     # Pessimistic default: if we never got far enough to check, assume the
@@ -513,6 +660,11 @@ async def run_dev_issue(
 
         # Verify PR is green & conflict-free before handing off. Resume the
         # session with a fix request if either is broken, up to max_fix_attempts.
+        #
+        # Issue #29: the lock handle is passed in so the verifier releases
+        # the repo lock during its CI-polling window (can be up to 30 min)
+        # and reacquires before any request_fix. Peer sessions targeting
+        # the same repo can now run their own git-op phases while we wait.
         if result.success and result.outputs.get("pr_number") is not None:
             verifier = pr_verifier or PRVerifier(github=github)
             result = await _verify_and_fix_pr(
@@ -521,7 +673,26 @@ async def run_dev_issue(
                 result=result,
                 verifier=verifier,
                 max_attempts=max_fix_attempts,
+                lock_handle=lock,
             )
+
+        # Reacquire the lock for the post-verify cleanup phase (remove
+        # worktree / delete branch). If verification passed with no fix
+        # needed, we'd have released the lock inside ``_verify_and_fix_pr``
+        # and never reacquired. If the lock is contended during cleanup
+        # we log and skip the worktree/branch removal — the session
+        # still returns the verified result so the caller sees success;
+        # a later retry / operator will reclaim the leftovers.
+        if not lock.held:
+            reacquired = await lock.reacquire()
+            if not reacquired:
+                log_event(
+                    _logger,
+                    "dev.cleanup.lock_reacquire_contended",
+                    session_id=session_id,
+                    repo=repo,
+                    issue_number=issue_number,
+                )
 
         # Update session status
         status = "done" if result.success else ("blocked" if result.blocked else "failed")
@@ -576,16 +747,25 @@ async def run_dev_issue(
         #              re-create `fix/issue-<n>` cleanly — BUT only if the
         #              branch did not pre-exist (we own it) and it was never
         #              pushed (no recoverable work on origin).
-        if result.success:
-            worktree.remove_context_symlink(worktree_path)
-            await worktree.remove_worktree(repo, session_id)
-        elif not result.blocked:
-            worktree.remove_context_symlink(worktree_path)
-            await worktree.remove_worktree(repo, session_id)
-            if not branch_preexisted and not await worktree.branch_exists_on_remote(
-                repo, branch_name
-            ):
-                await worktree.delete_branch(repo, branch_name)
+        #
+        # Cleanup mutates the shared bare repo (worktree metadata, branch
+        # refs) so it runs only when we hold the lock. If reacquire above
+        # failed, skip it and let the next retry / operator reclaim — the
+        # verified result is already final either way.
+        if lock.held:
+            if result.success:
+                worktree.remove_context_symlink(worktree_path)
+                await worktree.remove_worktree(repo, session_id)
+            elif not result.blocked:
+                worktree.remove_context_symlink(worktree_path)
+                await worktree.remove_worktree(repo, session_id)
+                if (
+                    not branch_preexisted
+                    and not await worktree.branch_exists_on_remote(
+                        repo, branch_name
+                    )
+                ):
+                    await worktree.delete_branch(repo, branch_name)
 
         return result
 
@@ -600,30 +780,40 @@ async def run_dev_issue(
         # touch the branch if it didn't pre-exist (we own it) AND origin has
         # no copy (no recoverable work to orphan). Covers partial failures of
         # `git worktree add -b` that create the ref before the directory setup
-        # crashes.
-        if worktree_path is not None:
+        # crashes. If we're mid-verify the lock may be released — try to get
+        # it back for the cleanup. If reacquire fails, skip (the next retry
+        # will reclaim).
+        if not lock.held:
             try:
-                worktree.remove_context_symlink(worktree_path)
+                await lock.reacquire()
             except Exception:
                 pass
-        # Always attempt remove_worktree + prune — handles the case where
-        # `git worktree add -b` registered worktree metadata before the dir
-        # step failed, leaving worktree_path unassigned but metadata in the
-        # bare repo that would prevent the branch from being deleted.
-        try:
-            await worktree.remove_worktree(repo, session_id)
-        except Exception:
-            pass
-        if not branch_preexisted:
-            try:
-                has_remote = await worktree.branch_exists_on_remote(repo, branch_name)
-            except Exception:
-                has_remote = True
-            if not has_remote:
+        if lock.held:
+            if worktree_path is not None:
                 try:
-                    await worktree.delete_branch(repo, branch_name)
+                    worktree.remove_context_symlink(worktree_path)
                 except Exception:
                     pass
+            # Always attempt remove_worktree + prune — handles the case where
+            # `git worktree add -b` registered worktree metadata before the dir
+            # step failed, leaving worktree_path unassigned but metadata in the
+            # bare repo that would prevent the branch from being deleted.
+            try:
+                await worktree.remove_worktree(repo, session_id)
+            except Exception:
+                pass
+            if not branch_preexisted:
+                try:
+                    has_remote = await worktree.branch_exists_on_remote(
+                        repo, branch_name
+                    )
+                except Exception:
+                    has_remote = True
+                if not has_remote:
+                    try:
+                        await worktree.delete_branch(repo, branch_name)
+                    except Exception:
+                        pass
 
         return PipelineResult(
             success=False,
@@ -633,7 +823,13 @@ async def run_dev_issue(
         )
 
     finally:
-        state_db.release_lock(repo, session_id)
+        # Safe even if we already released inside `_verify_and_fix_pr` —
+        # the handle's `release` is idempotent (no-op when held=False)
+        # and StateDB.release_lock is itself idempotent (DELETE with
+        # rowcount=0 is a valid outcome). This also covers
+        # CancelledError: if cancellation arrives during the unlocked
+        # verify window, held is already False, so no stray DELETE runs.
+        lock.release()
 
 
 async def resume_dev_from_pending(
@@ -692,6 +888,7 @@ async def resume_dev_from_pending(
 
     branch_name = branch_template.replace("{n}", str(issue_number))
 
+    lock = _RepoLockHandle(state_db, repo, session_id)
     if not state_db.acquire_lock(repo, session_id):
         return PipelineResult(
             success=False,
@@ -699,6 +896,7 @@ async def resume_dev_from_pending(
             summary=f"Could not acquire lock for {repo} to resume dev",
             error="Repository locked by another session",
         )
+    lock.held = True
 
     worktree_path: Path | None = None
 
@@ -810,6 +1008,8 @@ async def resume_dev_from_pending(
             result = await pipeline.resume(ctx, next_answer)
 
         # Verify PR once the agent says DONE, matching run_dev_issue.
+        # The lock handle is threaded through so the verifier releases
+        # the repo lock during its CI-polling window (issue #29).
         if result.success and result.outputs.get("pr_number") is not None:
             verifier = pr_verifier or PRVerifier(github=github)
             result = await _verify_and_fix_pr(
@@ -818,6 +1018,7 @@ async def resume_dev_from_pending(
                 result=result,
                 verifier=verifier,
                 max_attempts=max_fix_attempts,
+                lock_handle=lock,
             )
 
         status = "done" if result.success else (
@@ -872,8 +1073,13 @@ async def resume_dev_from_pending(
         # re-blocks. A follow-up can add teardown for the DONE/FAILED
         # outcomes (small disk leak, not a correctness issue; operator
         # can run `git worktree prune` in the bare repo to reclaim).
+        #
+        # ``lock.release`` is idempotent, so this is a no-op if the
+        # verify phase already released and never reacquired (CI-only
+        # path with no fix attempts + no cleanup work). Matches issue
+        # #29's release-during-verify semantics.
         try:
-            state_db.release_lock(repo, session_id)
+            lock.release()
         except Exception as lock_exc:
             log_event(
                 _logger,

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -24,15 +24,35 @@ DEFAULT_MAX_FIX_ATTEMPTS = 3
 DEFAULT_MAX_BLOCKED_ROUNDS = 5
 
 # Reacquire policy for the repo lock after the unlocked verification phase.
-# Verification only releases the lock because CI polling doesn't touch git;
-# when we need to run `request_fix` (which spawns claude + writes worktree)
-# we must get it back. Contention here is expected to be brief — another
-# session doing its own git-op phase — so a small retry budget with a
-# short sleep is enough to avoid a spurious failure. If we still can't
-# get it after the budget is exhausted, surface a clear typed error.
-_REACQUIRE_LOCK_ATTEMPTS = 6
+# Verification releases the lock because CI polling doesn't touch git; when
+# we need to run `request_fix` (which spawns claude + writes worktree) we
+# must get it back. Contention here is NOT necessarily brief — a peer
+# session may be running its own full claude pass on another issue in the
+# same repo, which can take tens of minutes. A short retry budget would
+# spuriously fail healthy same-repo parallelism; bound the wait at roughly
+# one hour, long enough to outlast a normal peer run and short enough to
+# escape a stuck/SIGKILL'd peer whose lock row is lingering.
+# Tests monkey-patch these to speed contention scenarios without changing
+# the call sites.
+_REACQUIRE_LOCK_ATTEMPTS = 720
 _REACQUIRE_LOCK_SLEEP_SECONDS = 5.0
+# Log progress periodically so an operator watching can see we're alive
+# and waiting, not hung. At 5s cadence this fires ~every 5 minutes.
+_REACQUIRE_PROGRESS_LOG_EVERY = 60
+
+# Two distinct error messages so callers can tell which phase of the
+# pipeline hit contention:
+#   INITIAL  — nothing started, safe to retry from scratch (cli un-marks
+#              the issue so the next poll picks it up).
+#   DURING_VERIFY — a PR already exists; re-running from scratch would
+#                   launch a duplicate dev pass against the open PR.
+#                   cli leaves the issue marked seen and only spawns the
+#                   PR merge watcher so the existing PR still auto-closes
+#                   on merge.
 _LOCK_CONTENDED_ERROR = "Repository locked by another session"
+_LOCK_CONTENDED_DURING_VERIFY_ERROR = (
+    "Repo lock reacquire contended during PR verification"
+)
 
 
 class _RepoLockHandle:
@@ -56,19 +76,37 @@ class _RepoLockHandle:
         self.held = False
 
     def release(self) -> None:
-        """Release the lock if we hold it. Safe to call multiple times
-        and safe to call from a ``finally`` that ran before acquire
-        succeeded."""
+        """Release the lock if we hold it. Idempotent and safe to call
+        from a ``finally`` block that may run before acquire ever
+        succeeded.
+
+        If the underlying DELETE raises (e.g. transient
+        ``database is locked`` from SQLite), we keep ``held=True`` so
+        subsequent release attempts retry. Flipping held=False after a
+        failed DELETE would wedge the repo: our stale row stays in
+        ``repo_locks`` rejecting peer acquires while our own code
+        believes the lock is free and tries to proceed.
+
+        The exception is logged and swallowed (release must not leak
+        exceptions from a finally path, where it would mask the
+        original error the caller was unwinding)."""
         if not self.held:
             return
         try:
             self.state_db.release_lock(self.repo, self.session_id)
-        finally:
-            # Even if the DELETE raised, mark released so a later call
-            # doesn't try again. A retained `held=True` after a failed
-            # release would have the outer ``finally`` issue a second
-            # DELETE anyway — not useful.
-            self.held = False
+        except Exception as e:
+            log_event(
+                _logger,
+                "dev.lock.release_failed",
+                session_id=self.session_id,
+                repo=self.repo,
+                reason=type(e).__name__,
+                error=str(e)[:200],
+            )
+            # Don't flip held — a later call (outer finally, etc.) will
+            # retry the DELETE once the transient condition clears.
+            return
+        self.held = False
 
     async def reacquire(
         self,
@@ -80,12 +118,11 @@ class _RepoLockHandle:
         success, False if contention persists past the retry budget.
 
         Retry budget: ``attempts`` INSERT tries separated by
-        ``sleep_seconds`` of sleep. Default 6×5s = up to 30s wait,
-        which is an order of magnitude longer than any pure-git phase
-        held by a peer session. If the peer is stuck in its own
-        verification phase we'd wait a very long time otherwise — but
-        that peer also releases before verify, so the remaining
-        git-held window is short by construction.
+        ``sleep_seconds`` of sleep. Default 720×5s ≈ 1 hour. That's
+        long enough to outlast a peer running its own full dev pass
+        on another issue in the same repo (claude + CI can take
+        tens of minutes), and short enough to escape a stuck or
+        SIGKILL'd peer whose lock row never got cleaned up.
 
         Defaults resolve at call time (``None`` sentinel) so tests can
         monkey-patch the module constants to speed up contention
@@ -105,6 +142,18 @@ class _RepoLockHandle:
             if self.state_db.acquire_lock(self.repo, self.session_id):
                 self.held = True
                 return True
+            # Surface a heartbeat every N attempts so an operator
+            # tailing logs during a long peer hold can tell the
+            # session is waiting, not wedged.
+            if attempt > 0 and attempt % _REACQUIRE_PROGRESS_LOG_EVERY == 0:
+                log_event(
+                    _logger,
+                    "dev.lock.reacquire_waiting",
+                    session_id=self.session_id,
+                    repo=self.repo,
+                    attempt=attempt,
+                    max_attempts=effective_attempts,
+                )
             if attempt < effective_attempts - 1:
                 await asyncio.sleep(effective_sleep)
         return False
@@ -457,7 +506,7 @@ async def _verify_and_fix_pr(
                         "but could not re-acquire repo lock after "
                         f"{_REACQUIRE_LOCK_ATTEMPTS} attempts"
                     ),
-                    error=_LOCK_CONTENDED_ERROR,
+                    error=_LOCK_CONTENDED_DURING_VERIFY_ERROR,
                     outputs=result.outputs,
                 )
 

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -40,6 +40,17 @@ _REACQUIRE_LOCK_SLEEP_SECONDS = 5.0
 # and waiting, not hung. At 5s cadence this fires ~every 5 minutes.
 _REACQUIRE_PROGRESS_LOG_EVERY = 60
 
+# Post-verify CLEANUP (worktree rm, branch delete) is best-effort — if
+# a peer grabs the lock while we're polling CI and we can't get it back
+# fast, skipping cleanup is fine (next run / operator reclaims). Don't
+# use the fix-path budget here: run_poll_loop awaits handlers serially,
+# so waiting an hour for cleanup would stall the whole poll cycle AND
+# delay the merge-watcher spawn that happens after run_dev_issue
+# returns. Three quick retries cover a fleeting hiccup; anything longer
+# belongs elsewhere.
+_REACQUIRE_CLEANUP_ATTEMPTS = 3
+_REACQUIRE_CLEANUP_SLEEP_SECONDS = 1.0
+
 # Two distinct error messages so callers can tell which phase of the
 # pipeline hit contention:
 #   INITIAL  — nothing started, safe to retry from scratch (cli un-marks
@@ -726,14 +737,18 @@ async def run_dev_issue(
             )
 
         # Reacquire the lock for the post-verify cleanup phase (remove
-        # worktree / delete branch). If verification passed with no fix
-        # needed, we'd have released the lock inside ``_verify_and_fix_pr``
-        # and never reacquired. If the lock is contended during cleanup
-        # we log and skip the worktree/branch removal — the session
-        # still returns the verified result so the caller sees success;
-        # a later retry / operator will reclaim the leftovers.
+        # worktree / delete branch). Uses the SHORT cleanup budget, not
+        # the fix-path budget: cleanup is best-effort, and run_poll_loop
+        # awaits handlers serially — blocking here for an hour would
+        # stall the whole poll cycle AND delay the PR merge watcher
+        # spawn (which happens in cli.handle_issue after we return).
+        # If we can't get the lock back in a few seconds, log and skip
+        # cleanup; the session still returns its verified result.
         if not lock.held:
-            reacquired = await lock.reacquire()
+            reacquired = await lock.reacquire(
+                attempts=_REACQUIRE_CLEANUP_ATTEMPTS,
+                sleep_seconds=_REACQUIRE_CLEANUP_SLEEP_SECONDS,
+            )
             if not reacquired:
                 log_event(
                     _logger,

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -845,11 +845,17 @@ async def run_dev_issue(
         # no copy (no recoverable work to orphan). Covers partial failures of
         # `git worktree add -b` that create the ref before the directory setup
         # crashes. If we're mid-verify the lock may be released — try to get
-        # it back for the cleanup. If reacquire fails, skip (the next retry
-        # will reclaim).
+        # it back for the cleanup. Uses the SHORT cleanup budget (not the
+        # fix-path one): a transient exception inside verifier.verify raising
+        # through while a peer holds the lock would otherwise stall the
+        # serial poll cycle for the full hour-long fix budget just to
+        # report the failure.
         if not lock.held:
             try:
-                await lock.reacquire()
+                await lock.reacquire(
+                    attempts=_REACQUIRE_CLEANUP_ATTEMPTS,
+                    sleep_seconds=_REACQUIRE_CLEANUP_SLEEP_SECONDS,
+                )
             except Exception:
                 pass
         if lock.held:

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -757,6 +757,24 @@ async def run_dev_issue(
                     repo=repo,
                     issue_number=issue_number,
                 )
+                # Signal to cli.handle_issue that the worktree was NOT
+                # torn down so the caller can skip any "unmark for
+                # retry" logic. A fresh dev run against this issue
+                # would fail at `create_worktree_with_new_branch`
+                # because the abandoned worktree is still registered
+                # on the bare repo. Requires operator cleanup (or the
+                # next poller restart, which prunes stale worktrees).
+                merged_outputs = dict(result.outputs)
+                merged_outputs["cleanup_deferred"] = True
+                result = PipelineResult(
+                    success=result.success,
+                    session_id=result.session_id,
+                    summary=result.summary,
+                    blocked=result.blocked,
+                    question=result.question,
+                    error=result.error,
+                    outputs=merged_outputs,
+                )
 
         # Update session status
         status = "done" if result.success else ("blocked" if result.blocked else "failed")

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1379,9 +1379,16 @@ class TestRunDevIssueLockReleaseDuringVerify:
             dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS = monkey_sleep
 
         assert not result.success
-        # Clear typed error so the caller / sweeper can distinguish
-        # "lock race lost, retry later" from "code actually broken".
-        assert result.error == dev_mod._LOCK_CONTENDED_ERROR
+        # Post-verify contention uses a DISTINCT error string from the
+        # initial acquire failure: the PR already exists, and if cli
+        # saw the same "Repository locked..." string it'd unmark the
+        # issue and a future poll would launch a duplicate dev pass.
+        assert result.error == dev_mod._LOCK_CONTENDED_DURING_VERIFY_ERROR
+        assert result.error != dev_mod._LOCK_CONTENDED_ERROR
+        # cli.handle_issue keys its "retry from scratch" branch on the
+        # substring below. This error must NOT match it — otherwise the
+        # whole point of the distinct string is lost.
+        assert "locked by another session" not in result.error.lower()
         # Dispatcher called exactly once — initial spawn only, never
         # got as far as request_fix because we couldn't reacquire.
         assert mock_dispatcher.spawn_session.call_count == 1
@@ -1460,3 +1467,95 @@ class TestRunDevIssueLockReleaseDuringVerify:
         # Lock table must be clean — no leaked row from this session.
         assert state_db.get_lock_holder("owner/repo") is None
         state_db.close()
+
+
+class TestRepoLockHandleReleaseSafety:
+    """_RepoLockHandle.release() must not flip held=False when the
+    underlying DELETE raised — otherwise our stale lock row stays in
+    repo_locks while our code thinks the lock is free, wedging every
+    peer session until someone cleans up manually (codex P2)."""
+
+    def test_release_keeps_held_true_when_db_raises(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.dev import _RepoLockHandle
+
+        real = StateDB(tmp_path / "state.db")
+
+        class FlakyDB:
+            """Proxy that raises once on release, then delegates."""
+            def __init__(self, inner: StateDB):
+                self.inner = inner
+                self.release_calls = 0
+
+            def acquire_lock(self, *a, **kw):
+                return self.inner.acquire_lock(*a, **kw)
+
+            def release_lock(self, *a, **kw):
+                self.release_calls += 1
+                if self.release_calls == 1:
+                    raise RuntimeError("transient sqlite hiccup")
+                return self.inner.release_lock(*a, **kw)
+
+            def get_lock_holder(self, *a, **kw):
+                return self.inner.get_lock_holder(*a, **kw)
+
+        flaky = FlakyDB(real)
+        handle = _RepoLockHandle(flaky, "owner/repo", "sess-A")
+        assert flaky.acquire_lock("owner/repo", "sess-A") is True
+        handle.held = True
+
+        # First release raises inside release_lock. held must stay True
+        # so the caller knows the row may still be present.
+        handle.release()
+        assert handle.held is True, (
+            "held must stay True after a failed release — otherwise the "
+            "stale repo_locks row wedges peer sessions"
+        )
+
+        # Second release succeeds and clears held.
+        handle.release()
+        assert handle.held is False
+        assert flaky.release_calls == 2
+        assert real.get_lock_holder("owner/repo") is None
+        real.close()
+
+    def test_release_is_idempotent_when_not_held(
+        self, tmp_path: Path
+    ) -> None:
+        """Safe to call from a finally that ran before acquire ever
+        succeeded — no DB round-trip, no exceptions."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.dev import _RepoLockHandle
+
+        db = StateDB(tmp_path / "state.db")
+        handle = _RepoLockHandle(db, "owner/repo", "sess-A")
+        # Never acquired.
+        handle.release()
+        handle.release()
+        assert handle.held is False
+        db.close()
+
+
+class TestRepoLockHandleReacquireBudget:
+    """The default reacquire budget must be generous enough that a
+    healthy peer session running a full claude pass doesn't cause a
+    spurious contention failure (codex P1)."""
+
+    def test_default_budget_outlasts_typical_peer_run(self) -> None:
+        """A peer claude run can take 10-30 minutes. The default budget
+        must comfortably exceed that — otherwise same-repo parallelism
+        deterministically fails whenever a peer is mid-run."""
+        from ctrlrelay.pipelines import dev as dev_mod
+
+        total_seconds = (
+            dev_mod._REACQUIRE_LOCK_ATTEMPTS
+            * dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS
+        )
+        # >= 30 minutes. Change-detector test: if someone knocks this
+        # back toward the old 30s cap, they need to justify why.
+        assert total_seconds >= 30 * 60, (
+            f"Reacquire budget of {total_seconds}s is too short to "
+            "outlast a normal peer claude run (10-30 min)"
+        )

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1480,16 +1480,19 @@ class TestRepoLockHandleReleaseSafety:
     repo_locks while our code thinks the lock is free, wedging every
     peer session until someone cleans up manually (codex P2)."""
 
-    def test_release_keeps_held_true_when_db_raises(
+    def test_release_retries_transient_db_errors(
         self, tmp_path: Path
     ) -> None:
+        """A single transient DB hiccup must not leak the lock.
+        release() retries internally; the second attempt succeeds
+        and held flips to False."""
         from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines import dev as dev_mod
         from ctrlrelay.pipelines.dev import _RepoLockHandle
 
         real = StateDB(tmp_path / "state.db")
 
         class FlakyDB:
-            """Proxy that raises once on release, then delegates."""
             def __init__(self, inner: StateDB):
                 self.inner = inner
                 self.release_calls = 0
@@ -1511,19 +1514,62 @@ class TestRepoLockHandleReleaseSafety:
         assert flaky.acquire_lock("owner/repo", "sess-A") is True
         handle.held = True
 
-        # First release raises inside release_lock. held must stay True
-        # so the caller knows the row may still be present.
-        handle.release()
-        assert handle.held is True, (
-            "held must stay True after a failed release — otherwise the "
-            "stale repo_locks row wedges peer sessions"
-        )
+        orig_sleep = dev_mod._RELEASE_RETRY_SLEEP_SECONDS
+        dev_mod._RELEASE_RETRY_SLEEP_SECONDS = 0.0
+        try:
+            handle.release()
+        finally:
+            dev_mod._RELEASE_RETRY_SLEEP_SECONDS = orig_sleep
 
-        # Second release succeeds and clears held.
-        handle.release()
         assert handle.held is False
         assert flaky.release_calls == 2
         assert real.get_lock_holder("owner/repo") is None
+        real.close()
+
+    def test_release_keeps_held_true_after_exhausted_retries(
+        self, tmp_path: Path
+    ) -> None:
+        """If every retry fails, held must stay True so any outer
+        retry still has a chance. The wedged event tells ops."""
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines import dev as dev_mod
+        from ctrlrelay.pipelines.dev import _RepoLockHandle
+
+        real = StateDB(tmp_path / "state.db")
+
+        class AlwaysFailingDB:
+            def __init__(self, inner: StateDB):
+                self.inner = inner
+                self.release_calls = 0
+
+            def acquire_lock(self, *a, **kw):
+                return self.inner.acquire_lock(*a, **kw)
+
+            def release_lock(self, *a, **kw):
+                self.release_calls += 1
+                raise RuntimeError("persistent sqlite wedge")
+
+            def get_lock_holder(self, *a, **kw):
+                return self.inner.get_lock_holder(*a, **kw)
+
+        flaky = AlwaysFailingDB(real)
+        handle = _RepoLockHandle(flaky, "owner/repo", "sess-A")
+        assert flaky.acquire_lock("owner/repo", "sess-A") is True
+        handle.held = True
+
+        orig_sleep = dev_mod._RELEASE_RETRY_SLEEP_SECONDS
+        dev_mod._RELEASE_RETRY_SLEEP_SECONDS = 0.0
+        try:
+            handle.release()
+        finally:
+            dev_mod._RELEASE_RETRY_SLEEP_SECONDS = orig_sleep
+
+        assert handle.held is True, (
+            "held must stay True after exhausted release retries — the "
+            "stale repo_locks row presumably still exists; clearing "
+            "held would hide that from any outer retry"
+        )
+        assert flaky.release_calls == dev_mod._RELEASE_RETRY_ATTEMPTS
         real.close()
 
     def test_release_is_idempotent_when_not_held(

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1389,6 +1389,11 @@ class TestRunDevIssueLockReleaseDuringVerify:
         # substring below. This error must NOT match it — otherwise the
         # whole point of the distinct string is lost.
         assert "locked by another session" not in result.error.lower()
+        # Peer still holds the lock, so cleanup reacquire also failed.
+        # The outputs flag tells cli the worktree is still registered
+        # and a fresh retry would fail at create_worktree — cli uses
+        # this to decide whether to unmark the issue.
+        assert result.outputs.get("cleanup_deferred") is True
         # Dispatcher called exactly once — initial spawn only, never
         # got as far as request_fix because we couldn't reacquire.
         assert mock_dispatcher.spawn_session.call_count == 1

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1,5 +1,6 @@
 """Tests for dev pipeline."""
 
+import asyncio
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
@@ -1075,3 +1076,387 @@ class TestRunDevIssueVerification:
         assert mock_dispatcher.spawn_session.call_count == 3
         assert result.error is not None
         assert result.outputs.get("pr_number") == 42
+
+
+class TestRunDevIssueLockReleaseDuringVerify:
+    """Issue #29: the repo lock is released while PR CI verification is
+    polling GitHub (pure `gh` traffic, no git access), then reacquired
+    before any ``request_fix`` call (which spawns claude and mutates the
+    worktree). These tests exercise the release/reacquire boundary and
+    verify peer sessions aren't blocked during the wait."""
+
+    @pytest.mark.asyncio
+    async def test_lock_released_during_verify_allows_concurrent_session(
+        self, tmp_path: Path
+    ) -> None:
+        """While session A is in _verify_and_fix_pr's polling window,
+        session B must be able to acquire the repo lock for its own
+        git work. After A finishes verification it returns without
+        needing the lock back (CI passed → no fix needed)."""
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.pr_verifier import VerificationResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.dev import run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-a",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-a",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42 opened",
+                outputs={
+                    "pr_url": "https://github.com/o/r/pull/42",
+                    "pr_number": 42,
+                },
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = (
+            tmp_path / "worktree"
+        )
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 1, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        peer_session_id = "dev-peer-session"
+        peer_acquired: list[bool] = []
+
+        mock_pr_verifier = AsyncMock()
+
+        async def verify_checks_peer_can_acquire(*_args, **_kwargs):
+            # During the verify call, simulate a peer session trying to
+            # acquire the repo lock. Before #29 this would fail because
+            # run_dev_issue held the lock for the entire run.
+            peer_acquired.append(
+                state_db.acquire_lock("owner/repo", peer_session_id)
+            )
+            if peer_acquired[-1]:
+                # Release so run_dev_issue can reacquire for cleanup.
+                state_db.release_lock("owner/repo", peer_session_id)
+            return VerificationResult(ready=True)
+
+        mock_pr_verifier.verify.side_effect = verify_checks_peer_can_acquire
+
+        result = await run_dev_issue(
+            repo="owner/repo",
+            issue_number=1,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+            pr_verifier=mock_pr_verifier,
+        )
+
+        assert result.success
+        # Peer was tried exactly once and SUCCEEDED — proving the lock
+        # was released during verify.
+        assert peer_acquired == [True]
+        # Session A's lock is gone after run completes.
+        assert state_db.get_lock_holder("owner/repo") is None
+        state_db.close()
+
+    @pytest.mark.asyncio
+    async def test_lock_reacquired_before_request_fix(
+        self, tmp_path: Path
+    ) -> None:
+        """When verification fails and request_fix is needed, the lock
+        must be held again for the claude-spawn phase."""
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.pr_verifier import VerificationResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.dev import run_dev_issue
+
+        session_id_a = "dev-a"
+        agent_uuid = "b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10"
+
+        done_state = SessionResult(
+            session_id=session_id_a,
+            exit_code=0,
+            stdout="",
+            stderr="",
+            agent_session_id=agent_uuid,
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id=session_id_a,
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42",
+                outputs={
+                    "pr_url": "https://github.com/o/r/pull/42",
+                    "pr_number": 42,
+                },
+            ),
+        )
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = done_state
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = (
+            tmp_path / "worktree"
+        )
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 1, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        holders_during_fix: list[str | None] = []
+
+        async def fix_spawn(*_args, **kwargs):
+            # Capture lock holder during the fix spawn to prove we hold
+            # it across the claude-invocation window.
+            holders_during_fix.append(
+                state_db.get_lock_holder("owner/repo")
+            )
+            return done_state
+
+        verify_calls = 0
+
+        async def verify(*_args, **_kwargs):
+            nonlocal verify_calls
+            verify_calls += 1
+            if verify_calls == 1:
+                return VerificationResult(
+                    ready=False,
+                    reason="ci failed",
+                    failing_checks=[
+                        {"name": "ci", "state": "FAILURE", "bucket": "fail"}
+                    ],
+                )
+            return VerificationResult(ready=True)
+
+        # First spawn = the initial run; second spawn = the fix round.
+        mock_dispatcher.spawn_session.side_effect = [done_state, None]
+
+        async def spawn_side_effect(*args, **kwargs):
+            if mock_dispatcher.spawn_session.call_count == 1:
+                return done_state
+            return await fix_spawn(*args, **kwargs)
+
+        mock_dispatcher.spawn_session.side_effect = spawn_side_effect
+
+        mock_pr_verifier = AsyncMock()
+        mock_pr_verifier.verify.side_effect = verify
+
+        result = await run_dev_issue(
+            repo="owner/repo",
+            issue_number=1,
+            branch_template="fix/issue-{n}",
+            dispatcher=mock_dispatcher,
+            github=mock_github,
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+            pr_verifier=mock_pr_verifier,
+        )
+
+        assert result.success
+        # fix_spawn ran once and the lock was held by THIS session at
+        # the moment request_fix invoked the dispatcher.
+        assert len(holders_during_fix) == 1
+        # session_id is generated internally as
+        # dev-owner-repo-1-<hex8>; just assert SOMEONE (i.e. this
+        # session) holds it rather than nothing.
+        assert holders_during_fix[0] is not None
+        assert holders_during_fix[0].startswith("dev-owner-repo-1-")
+        # Lock fully released when the run is done.
+        assert state_db.get_lock_holder("owner/repo") is None
+        state_db.close()
+
+    @pytest.mark.asyncio
+    async def test_lock_reacquire_fails_when_contended(
+        self, tmp_path: Path
+    ) -> None:
+        """If verification finds work to do but a peer holds the lock
+        forever, we must surface a typed error rather than run
+        request_fix without exclusive access."""
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.pr_verifier import VerificationResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines import dev as dev_mod
+        from ctrlrelay.pipelines.dev import run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-a",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-a",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42",
+                outputs={
+                    "pr_url": "https://github.com/o/r/pull/42",
+                    "pr_number": 42,
+                },
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = (
+            tmp_path / "worktree"
+        )
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 1, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        async def verify(*_args, **_kwargs):
+            # Returns not-ready so run_dev_issue has to reacquire the
+            # lock before request_fix. Simulates a peer grabbing the
+            # lock immediately after we release.
+            holder = state_db.get_lock_holder("owner/repo")
+            if holder is None:
+                state_db.acquire_lock("owner/repo", "peer-session-blocking")
+            return VerificationResult(
+                ready=False,
+                reason="ci failed",
+                failing_checks=[
+                    {"name": "ci", "state": "FAILURE", "bucket": "fail"}
+                ],
+            )
+
+        mock_pr_verifier = AsyncMock()
+        mock_pr_verifier.verify.side_effect = verify
+
+        # Zero sleep so the test runs instantly; small attempt budget
+        # so we fail fast after a handful of contention misses.
+        monkey_attempts = dev_mod._REACQUIRE_LOCK_ATTEMPTS
+        monkey_sleep = dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS
+        dev_mod._REACQUIRE_LOCK_ATTEMPTS = 2
+        dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS = 0.0
+
+        try:
+            result = await run_dev_issue(
+                repo="owner/repo",
+                issue_number=1,
+                branch_template="fix/issue-{n}",
+                dispatcher=mock_dispatcher,
+                github=mock_github,
+                worktree=mock_worktree,
+                dashboard=None,
+                state_db=state_db,
+                transport=None,
+                contexts_dir=tmp_path / "contexts",
+                pr_verifier=mock_pr_verifier,
+            )
+        finally:
+            dev_mod._REACQUIRE_LOCK_ATTEMPTS = monkey_attempts
+            dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS = monkey_sleep
+
+        assert not result.success
+        # Clear typed error so the caller / sweeper can distinguish
+        # "lock race lost, retry later" from "code actually broken".
+        assert result.error == dev_mod._LOCK_CONTENDED_ERROR
+        # Dispatcher called exactly once — initial spawn only, never
+        # got as far as request_fix because we couldn't reacquire.
+        assert mock_dispatcher.spawn_session.call_count == 1
+        # Peer lock is still there (we never touched it).
+        assert state_db.get_lock_holder("owner/repo") == "peer-session-blocking"
+        state_db.close()
+
+    @pytest.mark.asyncio
+    async def test_cancelled_during_verify_does_not_leak_lock(
+        self, tmp_path: Path
+    ) -> None:
+        """If asyncio.CancelledError arrives during the unlocked verify
+        phase, the finally block must not hold any lock AND must not
+        re-acquire one that was never released gracefully."""
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.core.state import StateDB
+        from ctrlrelay.pipelines.dev import run_dev_issue
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-a",
+            exit_code=0,
+            stdout="",
+            stderr="",
+            state=CheckpointState(
+                version="1",
+                status=CheckpointStatus.DONE,
+                session_id="dev-a",
+                timestamp="2026-04-17T12:00:00Z",
+                summary="PR #42",
+                outputs={
+                    "pr_url": "https://github.com/o/r/pull/42",
+                    "pr_number": 42,
+                },
+            ),
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree_with_new_branch.return_value = (
+            tmp_path / "worktree"
+        )
+        mock_worktree.symlink_context = MagicMock()
+        mock_worktree.remove_context_symlink = MagicMock()
+
+        mock_github = AsyncMock()
+        mock_github.get_issue.return_value = {
+            "number": 1, "title": "x", "body": "y", "comments": [],
+        }
+
+        state_db = StateDB(tmp_path / "state.db")
+
+        async def verify(*_args, **_kwargs):
+            # Confirm lock was released before raising cancellation.
+            assert state_db.get_lock_holder("owner/repo") is None
+            raise asyncio.CancelledError()
+
+        mock_pr_verifier = AsyncMock()
+        mock_pr_verifier.verify.side_effect = verify
+
+        with pytest.raises(asyncio.CancelledError):
+            await run_dev_issue(
+                repo="owner/repo",
+                issue_number=1,
+                branch_template="fix/issue-{n}",
+                dispatcher=mock_dispatcher,
+                github=mock_github,
+                worktree=mock_worktree,
+                dashboard=None,
+                state_db=state_db,
+                transport=None,
+                contexts_dir=tmp_path / "contexts",
+                pr_verifier=mock_pr_verifier,
+            )
+
+        # Lock table must be clean — no leaked row from this session.
+        assert state_db.get_lock_holder("owner/repo") is None
+        state_db.close()

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1541,7 +1541,9 @@ class TestRepoLockHandleReleaseSafety:
 class TestRepoLockHandleReacquireBudget:
     """The default reacquire budget must be generous enough that a
     healthy peer session running a full claude pass doesn't cause a
-    spurious contention failure (codex P1)."""
+    spurious contention failure (codex P1). Cleanup uses a SEPARATE
+    short budget so a contended cleanup doesn't stall the serial
+    poller for an hour (codex P1 round-2)."""
 
     def test_default_budget_outlasts_typical_peer_run(self) -> None:
         """A peer claude run can take 10-30 minutes. The default budget
@@ -1559,3 +1561,29 @@ class TestRepoLockHandleReacquireBudget:
             f"Reacquire budget of {total_seconds}s is too short to "
             "outlast a normal peer claude run (10-30 min)"
         )
+
+    def test_cleanup_budget_is_short_so_poller_does_not_stall(self) -> None:
+        """Cleanup reacquire budget must stay small. run_poll_loop
+        awaits handlers serially and spawns the PR watcher AFTER
+        run_dev_issue returns; if cleanup waited the full fix-path
+        budget, a single contended cleanup would delay every other
+        repo's polling by up to an hour and hold back the watcher
+        for a PR that already passed verification."""
+        from ctrlrelay.pipelines import dev as dev_mod
+
+        cleanup_seconds = (
+            dev_mod._REACQUIRE_CLEANUP_ATTEMPTS
+            * dev_mod._REACQUIRE_CLEANUP_SLEEP_SECONDS
+        )
+        # Cap at 30s: anything longer would meaningfully stall the poll.
+        assert cleanup_seconds <= 30, (
+            f"Cleanup reacquire budget of {cleanup_seconds}s is too "
+            "long; would stall the serial poll cycle"
+        )
+        # And it must be MUCH shorter than the fix-path budget — if
+        # someone lazily equated them in a refactor, this catches it.
+        fix_seconds = (
+            dev_mod._REACQUIRE_LOCK_ATTEMPTS
+            * dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS
+        )
+        assert cleanup_seconds < fix_seconds / 10


### PR DESCRIPTION
## Summary
- `run_dev_issue` used to hold the per-repo lock through `_verify_and_fix_pr`'s `wait_for_checks` polling (up to 30 min by default), which is pure `gh` traffic and touches no git state. Any peer session targeting the same repo hit "Repository locked by another session" for the entire wait. This releases the lock immediately before `verifier.verify` and reacquires before `request_fix` / cleanup.
- Adds `_RepoLockHandle` to track held/released state and expose an idempotent `release` plus a retrying `reacquire` (default 6x5s = ~30s budget). If reacquire fails after the budget, surfaces a typed `"Repository locked by another session"` error instead of running `request_fix` without the lock.
- CancelledError during the unlocked verification phase no longer leaks a lock row — the handle's `release` is a no-op when `held=False` and the outer `finally` just sees that state.
- `resume_dev_from_pending` gets the same treatment so resumed sessions don't wedge peers during their own verification windows.

Closes #29.

## Test Plan
- [x] `pytest tests/test_dev_pipeline.py::TestRunDevIssueLockReleaseDuringVerify` — 4 new regression tests:
  - peer session acquires the lock during session A's verify call
  - lock is held by this session at the moment `request_fix` spawns claude
  - reacquire contention surfaces typed `_LOCK_CONTENDED_ERROR` and never spawns the fix
  - CancelledError during verify leaves `repo_locks` empty (no leaked row)
- [x] Full `pytest` suite: 416 passed
- [x] `ruff check .` clean
- [ ] Manual smoke: two dev sessions on the same repo, first one stuck in CI wait, second acquires and runs its git ops to completion.