### PR TITLE
fix(worktree): return created_fresh + refuse reuse when PR is open (closes #51, closes #52)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Branch ownership signal survives delete+recreate** (closes #51).
+  `create_worktree_with_new_branch` now returns `(path, created_fresh)`
+  so the caller knows whether THIS session created the branch (fresh
+  from default, or via the stale-merged delete+recreate path). Before
+  #51, `run_dev_issue` snapshotted `branch_preexisted` BEFORE the
+  call; the snapshot went stale the moment the helper detected a
+  fully-merged local branch and deleted+recreated it. A FAILED
+  cleanup would then skip `delete_branch` and leak partial commits
+  into the next retry.
+- **Refuse reuse when branch still backs an open PR** (closes #52).
+  `create_worktree_with_new_branch` now probes GitHub (via
+  `GitHubCLI.list_prs(head=...)`) before reusing an existing local
+  branch. If an open PR still backs it (prior DONE session whose PR
+  is unmerged, or any external source), raises `WorktreeError` with
+  the PR number and a concrete operator action instead of silently
+  hijacking the reviewer's already-reviewed branch or tripping
+  "A pull request already exists" at `gh pr create`.
+
 ## [0.1.12] - 2026-04-22
 
 Patch release. Closes #90 — three related polish items on the

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -85,7 +85,7 @@ class GitHubCLI:
             "--limit", str(limit),
             "--json", (
                 "number,title,author,labels,headRefName,mergeable,"
-                "reviewDecision,headRepositoryOwner"
+                "reviewDecision,headRepositoryOwner,headRepository"
             ),
         ]
         if head is not None:

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -31,13 +31,23 @@ class GitHubCLI:
     gh_binary: str = field(default_factory=_find_gh)
     timeout: int = 60
 
-    async def _run_gh(self, *args: str) -> str:
+    async def _run_gh(
+        self, *args: str, timeout: int | None = None,
+    ) -> str:
         """Run gh command and return stdout; raise GitHubError on non-zero.
+
+        ``timeout`` overrides ``self.timeout`` for one call — useful
+        for probes (like the open-PR check in worktree reuse) that
+        shouldn't inherit the full 60s default when any delay holds
+        the repo lock.
 
         Kills the child and waits for it to reap on timeout so a
         long-running daemon (e.g. 7-day PR-watch loop that retries on
         TimeoutError) doesn't leak subprocesses while the network hangs.
         """
+        effective_timeout = (
+            self.timeout if timeout is None else timeout
+        )
         cmd = [self.gh_binary, *args]
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -46,7 +56,7 @@ class GitHubCLI:
         )
         try:
             stdout, stderr = await asyncio.wait_for(
-                proc.communicate(), timeout=self.timeout
+                proc.communicate(), timeout=effective_timeout
             )
         except asyncio.TimeoutError:
             # Reap the hung child so we don't accumulate zombies across
@@ -70,6 +80,7 @@ class GitHubCLI:
         state: str = "open",
         limit: int = 100,
         head: str | None = None,
+        timeout: int | None = None,
     ) -> list[dict[str, Any]]:
         """List pull requests for a repository.
 
@@ -77,6 +88,11 @@ class GitHubCLI:
         branch is ``head`` (passed to ``gh pr list --head``). Used by
         the dev pipeline's worktree reuse path to refuse a branch that
         still backs an open PR (issue #52).
+
+        ``timeout`` overrides the default per call so the reuse probe
+        can bound latency — the probe holds the repo lock, so a full
+        default-timeout hang would stall every other session on the
+        same repo.
         """
         args = [
             "pr", "list",
@@ -90,7 +106,7 @@ class GitHubCLI:
         ]
         if head is not None:
             args.extend(["--head", head])
-        output = await self._run_gh(*args)
+        output = await self._run_gh(*args, timeout=timeout)
         return json.loads(output) if output.strip() else []
 
     async def list_security_alerts(

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -69,15 +69,25 @@ class GitHubCLI:
         repo: str,
         state: str = "open",
         limit: int = 100,
+        head: str | None = None,
     ) -> list[dict[str, Any]]:
-        """List pull requests for a repository."""
-        output = await self._run_gh(
+        """List pull requests for a repository.
+
+        When ``head`` is given, restrict the result to PRs whose head
+        branch is ``head`` (passed to ``gh pr list --head``). Used by
+        the dev pipeline's worktree reuse path to refuse a branch that
+        still backs an open PR (issue #52).
+        """
+        args = [
             "pr", "list",
             "--repo", repo,
             "--state", state,
             "--limit", str(limit),
             "--json", "number,title,author,labels,headRefName,mergeable,reviewDecision",
-        )
+        ]
+        if head is not None:
+            args.extend(["--head", head])
+        output = await self._run_gh(*args)
         return json.loads(output) if output.strip() else []
 
     async def list_security_alerts(

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -83,7 +83,10 @@ class GitHubCLI:
             "--repo", repo,
             "--state", state,
             "--limit", str(limit),
-            "--json", "number,title,author,labels,headRefName,mergeable,reviewDecision",
+            "--json", (
+                "number,title,author,labels,headRefName,mergeable,"
+                "reviewDecision,headRepositoryOwner"
+            ),
         ]
         if head is not None:
             args.extend(["--head", head])

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -268,12 +268,13 @@ class WorktreeManager:
         GitHub API doesn't wedge every retry — the existing reuse path
         and later ``gh pr create`` call still provide defense in depth.
 
-        ``gh pr list --head`` filters by branch name only, so a PR from
-        a fork using the same branch name (e.g. another contributor's
-        ``fix/issue-13``) would appear in the result and wrongly block
-        our reuse. Filter client-side on headRepositoryOwner.login so
-        only PRs whose head lives in the same repo we're about to
-        push to can veto reuse.
+        ``gh pr list --head`` filters by branch name only, so PRs from
+        unrelated repos (external forks, same-owner forks like
+        ``acme/repo-fork`` targeting ``acme/repo``) with the same
+        branch name would appear in the result and wrongly block
+        our reuse. Filter client-side on the FULL head repo identity
+        (owner + name) so only PRs whose head actually lives in the
+        repo we're about to push to can veto reuse.
         """
         try:
             prs = await github.list_prs(repo, state="open", head=branch)
@@ -284,11 +285,12 @@ class WorktreeManager:
             # exists" — noisier than we'd like, but not a correctness
             # regression.
             return
-        target_owner = repo.split("/", 1)[0]
+        target_owner, _, target_name = repo.partition("/")
         same_repo_prs = [
             p for p in prs
             if (p.get("headRepositoryOwner") or {}).get("login")
             == target_owner
+            and (p.get("headRepository") or {}).get("name") == target_name
         ]
         if not same_repo_prs:
             return

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -18,6 +18,12 @@ if TYPE_CHECKING:
 # gh is genuinely down. Three quick attempts strike a balance.
 _PR_PROBE_RETRY_ATTEMPTS = 3
 _PR_PROBE_RETRY_SLEEP_SECONDS = 1.0
+# Per-call gh timeout for the open-PR probe. This probe holds the repo
+# lock, so inheriting GitHubCLI's 60s default would let a hung gh
+# process block other sessions on the same repo for up to ~3 minutes
+# (3 attempts × 60s) before failing closed. 10s is plenty for a
+# single pr-list call with --head filter against GitHub.
+_PR_PROBE_TIMEOUT_SECONDS = 10
 
 
 class WorktreeError(Exception):
@@ -210,18 +216,6 @@ class WorktreeManager:
                     "`git worktree remove` in the bare repo before retrying."
                 )
 
-            # Issue #52: if this branch still backs an open PR (prior DONE
-            # session whose PR is unmerged, or any external source),
-            # refuse reuse. Reusing would either hijack the reviewer's
-            # already-reviewed branch or trip "A pull request already
-            # exists" later at `gh pr create`. Refuse loudly with a
-            # concrete operator action. Probe is BEFORE any ref
-            # mutations so we never half-modify a PR-backed branch.
-            if github is not None:
-                await self._refuse_if_branch_backs_open_pr(
-                    github, repo, new_branch,
-                )
-
             # Remote presence has to be KNOWN to take either sync-to-origin
             # or stale-merged branches. branch_exists_on_remote is
             # fail-closed (returns True on timeout/auth error) which is
@@ -235,12 +229,26 @@ class WorktreeManager:
                     bare_path, new_branch,
                 )
             except Exception:
+                # Local-only (ref isn't on origin), so no open PR can be
+                # backing it — skip the open-PR probe entirely. This
+                # also means a flaky `gh` doesn't block otherwise-safe
+                # local recovery paths (issue #52 codex P2 round-6).
                 await self._worktree_add_with_stale_cleanup(
                     bare_path, worktree_path, new_branch,
                 )
                 return worktree_path, False
 
             if on_remote:
+                # Issue #52: branch is on origin, so a same-repo PR
+                # could be backing it. Probe MUST run before any ref
+                # mutation and before `gh pr create` later; otherwise
+                # the push below would hijack the reviewer's branch.
+                # Fail-closed on probe error — see
+                # _refuse_if_branch_backs_open_pr for the rationale.
+                if github is not None:
+                    await self._refuse_if_branch_backs_open_pr(
+                        github, repo, new_branch,
+                    )
                 # Remote exists → sync local to remote head (preserving
                 # unpushed ahead-of-origin commits) and reuse.
                 await self._sync_reused_branch_to_origin(bare_path, new_branch)
@@ -334,6 +342,7 @@ class WorktreeManager:
             try:
                 prs = await github.list_prs(
                     repo, state="open", head=branch,
+                    timeout=_PR_PROBE_TIMEOUT_SECONDS,
                 )
                 last_exc = None
                 break

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -29,6 +29,17 @@ class WorktreeManager:
         self.bare_repos_dir = Path(self.bare_repos_dir)
         self.worktrees_dir.mkdir(parents=True, exist_ok=True)
         self.bare_repos_dir.mkdir(parents=True, exist_ok=True)
+        # Signal for callers doing exception-path cleanup: when
+        # create_worktree_with_new_branch enters the stale-merged
+        # delete+recreate path, the old local ref is destroyed before
+        # the final `git worktree add -b` runs. If that add raises
+        # partway, the caller's pre-call branch_existed_before
+        # snapshot says "branch existed, not ours" — wrong. Flipping
+        # this flag to True the moment we commit to the recreate path
+        # lets run_dev_issue's exception cleanup recognize that any
+        # ref left behind belongs to this session regardless of how
+        # the caller classified the branch pre-call.
+        self._last_stale_recreate_attempted = False
 
     async def _run_git(
         self,
@@ -160,6 +171,10 @@ class WorktreeManager:
         number and a concrete operator action. The probe runs BEFORE
         any ref mutations so a concurrent PR is surfaced cleanly.
         """
+        # Reset the stale-recreate flag for every fresh call so a
+        # prior session's state doesn't leak into this one's cleanup.
+        self._last_stale_recreate_attempted = False
+
         bare_path = self._get_bare_repo_path(repo)
         worktree_path = self._get_worktree_path(repo, session_id)
 
@@ -231,6 +246,14 @@ class WorktreeManager:
             #       content not represented in the default branch — reuse
             #       so the operator's work isn't silently dropped.
             if await self._branch_is_fully_merged(repo, new_branch):
+                # Commit to the delete+recreate path. From here on,
+                # any ref left on disk — whether the old one we just
+                # deleted, a partial one `worktree add -b` wrote
+                # before crashing, or the successfully recreated one
+                # — belongs to THIS session. Flip the flag BEFORE
+                # the delete so even an exception in update-ref
+                # leaves the right signal for cleanup.
+                self._last_stale_recreate_attempted = True
                 try:
                     await self._run_git(
                         "update-ref", "-d", f"refs/heads/{new_branch}",

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -6,6 +6,10 @@ import asyncio
 import shutil
 from dataclasses import dataclass
 from pathlib import Path
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from ctrlrelay.core.github import GitHubCLI
 
 
 class WorktreeError(Exception):
@@ -121,7 +125,8 @@ class WorktreeManager:
         session_id: str,
         new_branch: str,
         base_branch: str | None = None,
-    ) -> Path:
+        github: GitHubCLI | None = None,
+    ) -> tuple[Path, bool]:
         """Create a worktree for ``new_branch``.
 
         If ``new_branch`` already exists in the bare repo — e.g. because a
@@ -135,6 +140,25 @@ class WorktreeManager:
 
         When we have to fall back to a brand-new branch, it's cut from
         ``base_branch`` (default: the repo's default branch).
+
+        Returns ``(worktree_path, created_fresh)`` where ``created_fresh``
+        is True when THIS call either created a brand-new branch from
+        ``base_branch`` or detected a stale fully-merged local branch,
+        deleted it, and recreated it. Callers use this flag to decide
+        whether cleanup on session failure should delete the branch
+        (issue #51): a pre-snapshotted ``branch_exists_locally`` check
+        goes stale the moment we delete+recreate, so the ownership
+        signal has to come from the function that performed the
+        mutation.
+
+        When ``github`` is provided and the branch already exists locally,
+        probe GitHub for an open PR with ``new_branch`` as head. If one
+        exists, refuse to reuse the branch — the reviewer's already-
+        reviewed work must not be hijacked by a fresh session, and
+        ``gh pr create`` would later fail with "A pull request already
+        exists" (issue #52). Raises :class:`WorktreeError` with the PR
+        number and a concrete operator action. The probe runs BEFORE
+        any ref mutations so a concurrent PR is surfaced cleanly.
         """
         bare_path = self._get_bare_repo_path(repo)
         worktree_path = self._get_worktree_path(repo, session_id)
@@ -157,6 +181,18 @@ class WorktreeManager:
                     "`git worktree remove` in the bare repo before retrying."
                 )
 
+            # Issue #52: if this branch still backs an open PR (prior DONE
+            # session whose PR is unmerged, or any external source),
+            # refuse reuse. Reusing would either hijack the reviewer's
+            # already-reviewed branch or trip "A pull request already
+            # exists" later at `gh pr create`. Refuse loudly with a
+            # concrete operator action. Probe is BEFORE any ref
+            # mutations so we never half-modify a PR-backed branch.
+            if github is not None:
+                await self._refuse_if_branch_backs_open_pr(
+                    github, repo, new_branch,
+                )
+
             # Remote presence has to be KNOWN to take either sync-to-origin
             # or stale-merged branches. branch_exists_on_remote is
             # fail-closed (returns True on timeout/auth error) which is
@@ -173,7 +209,7 @@ class WorktreeManager:
                 await self._worktree_add_with_stale_cleanup(
                     bare_path, worktree_path, new_branch,
                 )
-                return worktree_path
+                return worktree_path, False
 
             if on_remote:
                 # Remote exists → sync local to remote head (preserving
@@ -182,7 +218,7 @@ class WorktreeManager:
                 await self._worktree_add_with_stale_cleanup(
                     bare_path, worktree_path, new_branch,
                 )
-                return worktree_path
+                return worktree_path, False
 
             # Local-only (confirmed). Distinguish between:
             #   (a) stale-merged: the prior PR was merged (any strategy) and
@@ -202,12 +238,15 @@ class WorktreeManager:
                     )
                 except Exception:
                     pass
-                # Fall through to the fresh-branch creation below.
+                # Fall through to the fresh-branch creation below. The
+                # delete+recreate path is the exact scenario issue #51
+                # covers: the branch that now exists was created by THIS
+                # session, so cleanup on failure must treat it as ours.
             else:
                 await self._worktree_add_with_stale_cleanup(
                     bare_path, worktree_path, new_branch,
                 )
-                return worktree_path
+                return worktree_path, False
 
         if base_branch is None:
             base_branch = await self.get_default_branch(repo)
@@ -219,7 +258,32 @@ class WorktreeManager:
             base_branch,
             cwd=bare_path,
         )
-        return worktree_path
+        return worktree_path, True
+
+    async def _refuse_if_branch_backs_open_pr(
+        self, github: GitHubCLI, repo: str, branch: str,
+    ) -> None:
+        """Issue #52: raise WorktreeError if ``branch`` is the head of an
+        open PR on ``repo``. Skips silently on probe failure so a flaky
+        GitHub API doesn't wedge every retry — the existing reuse path
+        and later ``gh pr create`` call still provide defense in depth.
+        """
+        try:
+            prs = await github.list_prs(repo, state="open", head=branch)
+        except Exception:
+            # Probe failure: don't block reuse on a transient gh/network
+            # error. If a PR really does exist, the subsequent
+            # `gh pr create` would fail with "A pull request already
+            # exists" — noisier than we'd like, but not a correctness
+            # regression.
+            return
+        if not prs:
+            return
+        pr_number = prs[0].get("number")
+        raise WorktreeError(
+            f"Branch {branch!r} already has open PR #{pr_number} on "
+            f"{repo!r} — close or merge it before retrying this issue."
+        )
 
     async def _worktree_add_with_stale_cleanup(
         self, bare_path: Path, worktree_path: Path, branch: str,

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -267,6 +267,13 @@ class WorktreeManager:
         open PR on ``repo``. Skips silently on probe failure so a flaky
         GitHub API doesn't wedge every retry — the existing reuse path
         and later ``gh pr create`` call still provide defense in depth.
+
+        ``gh pr list --head`` filters by branch name only, so a PR from
+        a fork using the same branch name (e.g. another contributor's
+        ``fix/issue-13``) would appear in the result and wrongly block
+        our reuse. Filter client-side on headRepositoryOwner.login so
+        only PRs whose head lives in the same repo we're about to
+        push to can veto reuse.
         """
         try:
             prs = await github.list_prs(repo, state="open", head=branch)
@@ -277,9 +284,15 @@ class WorktreeManager:
             # exists" — noisier than we'd like, but not a correctness
             # regression.
             return
-        if not prs:
+        target_owner = repo.split("/", 1)[0]
+        same_repo_prs = [
+            p for p in prs
+            if (p.get("headRepositoryOwner") or {}).get("login")
+            == target_owner
+        ]
+        if not same_repo_prs:
             return
-        pr_number = prs[0].get("number")
+        pr_number = same_repo_prs[0].get("number")
         raise WorktreeError(
             f"Branch {branch!r} already has open PR #{pr_number} on "
             f"{repo!r} — close or merge it before retrying this issue."

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -216,6 +216,20 @@ class WorktreeManager:
                     "`git worktree remove` in the bare repo before retrying."
                 )
 
+            # Issue #52: probe for an open same-repo PR BEFORE any ref
+            # mutation. Must run for BOTH on-remote and local-only
+            # branches — GitHub can keep a PR open after its head
+            # branch is deleted, and our next push would recreate
+            # origin/<branch>, re-attaching this session's commits to
+            # the reviewer-owned PR (codex round-7). Fail-closed on
+            # probe error is the correct trade-off: a flaky gh can
+            # delay recovery, but a missed probe silently hijacks a
+            # PR. See _refuse_if_branch_backs_open_pr.
+            if github is not None:
+                await self._refuse_if_branch_backs_open_pr(
+                    github, repo, new_branch,
+                )
+
             # Remote presence has to be KNOWN to take either sync-to-origin
             # or stale-merged branches. branch_exists_on_remote is
             # fail-closed (returns True on timeout/auth error) which is
@@ -229,26 +243,12 @@ class WorktreeManager:
                     bare_path, new_branch,
                 )
             except Exception:
-                # Local-only (ref isn't on origin), so no open PR can be
-                # backing it — skip the open-PR probe entirely. This
-                # also means a flaky `gh` doesn't block otherwise-safe
-                # local recovery paths (issue #52 codex P2 round-6).
                 await self._worktree_add_with_stale_cleanup(
                     bare_path, worktree_path, new_branch,
                 )
                 return worktree_path, False
 
             if on_remote:
-                # Issue #52: branch is on origin, so a same-repo PR
-                # could be backing it. Probe MUST run before any ref
-                # mutation and before `gh pr create` later; otherwise
-                # the push below would hijack the reviewer's branch.
-                # Fail-closed on probe error — see
-                # _refuse_if_branch_backs_open_pr for the rationale.
-                if github is not None:
-                    await self._refuse_if_branch_backs_open_pr(
-                        github, repo, new_branch,
-                    )
                 # Remote exists → sync local to remote head (preserving
                 # unpushed ahead-of-origin commits) and reuse.
                 await self._sync_reused_branch_to_origin(bare_path, new_branch)

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -286,12 +286,22 @@ class WorktreeManager:
             # regression.
             return
         target_owner, _, target_name = repo.partition("/")
-        same_repo_prs = [
-            p for p in prs
-            if (p.get("headRepositoryOwner") or {}).get("login")
-            == target_owner
-            and (p.get("headRepository") or {}).get("name") == target_name
-        ]
+        # GitHub owner/repo names are case-insensitive: config may say
+        # "Owner/Repo" while the API returns "owner/repo". Normalize
+        # both sides before comparing so a case mismatch doesn't let
+        # a colliding PR slip past the veto.
+        target_owner_lc = target_owner.lower()
+        target_name_lc = target_name.lower()
+
+        def _same_repo(pr: dict) -> bool:
+            owner = (pr.get("headRepositoryOwner") or {}).get("login") or ""
+            name = (pr.get("headRepository") or {}).get("name") or ""
+            return (
+                owner.lower() == target_owner_lc
+                and name.lower() == target_name_lc
+            )
+
+        same_repo_prs = [p for p in prs if _same_repo(p)]
         if not same_repo_prs:
             return
         pr_number = same_repo_prs[0].get("number")

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -12,8 +12,30 @@ if TYPE_CHECKING:
     from ctrlrelay.core.github import GitHubCLI
 
 
+# Open-PR probe (issue #52) retries a handful of times before failing
+# closed. Transient gh/network errors are common enough that one-shot
+# failure would be noisy; but infinite retry would block retries when
+# gh is genuinely down. Three quick attempts strike a balance.
+_PR_PROBE_RETRY_ATTEMPTS = 3
+_PR_PROBE_RETRY_SLEEP_SECONDS = 1.0
+
+
 class WorktreeError(Exception):
     """Raised when worktree operations fail."""
+
+
+class StaleRecreatePartialFailureError(WorktreeError):
+    """Raised when `create_worktree_with_new_branch` had committed to the
+    stale-merged delete+recreate path (destroying the old local ref)
+    and then the subsequent `git worktree add -b` failed partway. The
+    exception signals to the caller that any leftover ref on disk was
+    introduced by THIS session, so run_dev_issue's FAILED-path cleanup
+    must delete it regardless of the pre-call branch_existed_before
+    snapshot — the old ref is gone and anything present now is ours.
+
+    Scoped to the exception path so concurrent sessions can't clobber
+    each other's ownership state (instance-level flags on the shared
+    WorktreeManager were racy under concurrent run_dev_issue calls)."""
 
 
 @dataclass
@@ -29,17 +51,6 @@ class WorktreeManager:
         self.bare_repos_dir = Path(self.bare_repos_dir)
         self.worktrees_dir.mkdir(parents=True, exist_ok=True)
         self.bare_repos_dir.mkdir(parents=True, exist_ok=True)
-        # Signal for callers doing exception-path cleanup: when
-        # create_worktree_with_new_branch enters the stale-merged
-        # delete+recreate path, the old local ref is destroyed before
-        # the final `git worktree add -b` runs. If that add raises
-        # partway, the caller's pre-call branch_existed_before
-        # snapshot says "branch existed, not ours" — wrong. Flipping
-        # this flag to True the moment we commit to the recreate path
-        # lets run_dev_issue's exception cleanup recognize that any
-        # ref left behind belongs to this session regardless of how
-        # the caller classified the branch pre-call.
-        self._last_stale_recreate_attempted = False
 
     async def _run_git(
         self,
@@ -171,9 +182,12 @@ class WorktreeManager:
         number and a concrete operator action. The probe runs BEFORE
         any ref mutations so a concurrent PR is surfaced cleanly.
         """
-        # Reset the stale-recreate flag for every fresh call so a
-        # prior session's state doesn't leak into this one's cleanup.
-        self._last_stale_recreate_attempted = False
+        # Per-call flag: tracks whether we committed to the stale-merged
+        # delete+recreate path. Must stay local to this coroutine call —
+        # placing it on self would race under concurrent sessions sharing
+        # the WorktreeManager instance (one session's start-of-call reset
+        # would clobber another's in-progress signal).
+        entered_stale_recreate = False
 
         bare_path = self._get_bare_repo_path(repo)
         worktree_path = self._get_worktree_path(repo, session_id)
@@ -250,10 +264,11 @@ class WorktreeManager:
                 # any ref left on disk — whether the old one we just
                 # deleted, a partial one `worktree add -b` wrote
                 # before crashing, or the successfully recreated one
-                # — belongs to THIS session. Flip the flag BEFORE
-                # the delete so even an exception in update-ref
-                # leaves the right signal for cleanup.
-                self._last_stale_recreate_attempted = True
+                # — belongs to THIS session. Flip the local flag
+                # BEFORE the delete so even an exception in
+                # update-ref still surfaces StaleRecreatePartialFailureError
+                # to the caller.
+                entered_stale_recreate = True
                 try:
                     await self._run_git(
                         "update-ref", "-d", f"refs/heads/{new_branch}",
@@ -274,22 +289,36 @@ class WorktreeManager:
         if base_branch is None:
             base_branch = await self.get_default_branch(repo)
 
-        await self._run_git(
-            "worktree", "add",
-            "-b", new_branch,
-            str(worktree_path),
-            base_branch,
-            cwd=bare_path,
-        )
+        try:
+            await self._run_git(
+                "worktree", "add",
+                "-b", new_branch,
+                str(worktree_path),
+                base_branch,
+                cwd=bare_path,
+            )
+        except Exception as e:
+            # If we destroyed the old stale-merged ref on the way here,
+            # re-raise as StaleRecreatePartialFailureError so the caller
+            # knows any leftover ref belongs to this session. Without
+            # this signal, a pre-call branch_existed_before=True
+            # snapshot would misclassify the leftover as "not ours"
+            # and leak it into the next retry (issue #51).
+            if entered_stale_recreate:
+                raise StaleRecreatePartialFailureError(str(e)) from e
+            raise
         return worktree_path, True
 
     async def _refuse_if_branch_backs_open_pr(
         self, github: GitHubCLI, repo: str, branch: str,
     ) -> None:
         """Issue #52: raise WorktreeError if ``branch`` is the head of an
-        open PR on ``repo``. Skips silently on probe failure so a flaky
-        GitHub API doesn't wedge every retry — the existing reuse path
-        and later ``gh pr create`` call still provide defense in depth.
+        open PR on ``repo``. Probe is fail-closed (on repeated probe
+        error, we refuse reuse): the dev workflow pushes to the shared
+        branch BEFORE calling ``gh pr create``, so relying on the
+        later create to catch a PR-backed branch is unsafe — a
+        transient ``gh`` error would let the push hijack the existing
+        PR before any failure surfaces.
 
         ``gh pr list --head`` filters by branch name only, so PRs from
         unrelated repos (external forks, same-owner forks like
@@ -299,15 +328,29 @@ class WorktreeManager:
         (owner + name) so only PRs whose head actually lives in the
         repo we're about to push to can veto reuse.
         """
-        try:
-            prs = await github.list_prs(repo, state="open", head=branch)
-        except Exception:
-            # Probe failure: don't block reuse on a transient gh/network
-            # error. If a PR really does exist, the subsequent
-            # `gh pr create` would fail with "A pull request already
-            # exists" — noisier than we'd like, but not a correctness
-            # regression.
-            return
+        last_exc: Exception | None = None
+        prs: list | None = None
+        for attempt in range(_PR_PROBE_RETRY_ATTEMPTS):
+            try:
+                prs = await github.list_prs(
+                    repo, state="open", head=branch,
+                )
+                last_exc = None
+                break
+            except Exception as e:
+                last_exc = e
+                if attempt < _PR_PROBE_RETRY_ATTEMPTS - 1:
+                    await asyncio.sleep(_PR_PROBE_RETRY_SLEEP_SECONDS)
+        if prs is None:
+            raise WorktreeError(
+                f"Could not determine whether branch {branch!r} on "
+                f"{repo!r} backs an open PR (gh probe failed after "
+                f"{_PR_PROBE_RETRY_ATTEMPTS} attempts: "
+                f"{type(last_exc).__name__ if last_exc else 'unknown'}). "
+                "Refusing reuse to avoid hijacking an open PR. Retry "
+                "once gh is reachable, or delete the branch manually "
+                "if you're certain no PR is open."
+            ) from last_exc
         target_owner, _, target_name = repo.partition("/")
         # GitHub owner/repo names are case-insensitive: config may say
         # "Owner/Repo" while the API returns "owner/repo". Normalize

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -969,15 +969,28 @@ async def run_dev_issue(
                 await worktree.remove_worktree(repo, session_id)
             except Exception:
                 pass
-            # Exception path ownership: created_fresh covers the normal
-            # return-and-fail case (issue #51). For partial failures of
-            # ``git worktree add -b`` that crash AFTER the branch ref was
-            # registered but BEFORE create_worktree_with_new_branch
-            # returns, created_fresh is still False (the default), so we
-            # fall back to the pre-call snapshot: if the branch did not
-            # exist before this run, the leftover ref must have been
-            # created by us.
-            we_own_branch = created_fresh or not branch_existed_before
+            # Exception path ownership: three signals, ordered by
+            # reliability.
+            # 1. created_fresh covers the normal return-and-fail case
+            #    (issue #51).
+            # 2. worktree._last_stale_recreate_attempted covers the
+            #    stale-merged delete+recreate path (issue #51 codex
+            #    round-4): the helper destroyed the old ref before
+            #    `git worktree add -b`, so anything on disk with this
+            #    branch name is ours regardless of what the pre-call
+            #    snapshot said.
+            # 3. Pre-call snapshot (`not branch_existed_before`) is
+            #    the fallback for partial failures of the plain
+            #    fresh-branch path where the helper raises before
+            #    setting created_fresh.
+            stale_recreate_attempted = getattr(
+                worktree, "_last_stale_recreate_attempted", False,
+            )
+            we_own_branch = (
+                created_fresh
+                or stale_recreate_attempted
+                or not branch_existed_before
+            )
             if we_own_branch:
                 try:
                     has_remote = await worktree.branch_exists_on_remote(

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -624,9 +624,29 @@ async def run_dev_issue(
     lock.held = True
 
     worktree_path: Path | None = None
-    # Pessimistic default: if we never got far enough to check, assume the
-    # branch was pre-existing so cleanup never clobbers unrelated state.
-    branch_preexisted = True
+    # Ownership signal: True when THIS session created the branch (either
+    # from default or via the stale-merged delete+recreate path). False
+    # when we reused an existing branch. Stays False until
+    # create_worktree_with_new_branch returns so the exception-path
+    # cleanup can't accidentally delete a pre-existing branch belonging
+    # to another session. Issue #51: a pre-call snapshot of
+    # branch_exists_locally goes stale the moment the worktree helper
+    # detects a stale fully-merged local branch, deletes it, and
+    # recreates it — so the flag has to come out of the helper itself.
+    created_fresh = False
+    # Pre-call snapshot of branch_exists_locally, used ONLY by the
+    # exception-cleanup path to handle partial failures of
+    # ``git worktree add -b`` that register the branch ref before the
+    # directory setup crashes — in that case the helper raises before
+    # returning created_fresh=True, so the snapshot is our only
+    # signal that the leftover ref belongs to this session. Pessimistic
+    # default (True) so we never delete a branch on a path that
+    # didn't even get far enough to probe. The #51 fix (stale snapshot
+    # after delete+recreate) doesn't apply here because the
+    # delete+recreate path runs entirely INSIDE the helper and only
+    # takes effect on successful return, where ``created_fresh``
+    # wins over this snapshot.
+    branch_existed_before = True
 
     try:
         # Get issue details
@@ -647,18 +667,32 @@ async def run_dev_issue(
                 body=AGENT_CLAIM_COMMENT,
             )
 
-        # Snapshot branch ownership BEFORE we try to create it. If the ref
-        # already exists in the bare repo, it came from another run (possibly
-        # a prior DONE session whose PR is still open) and we must not touch
-        # it. If it does not exist here, any ref we see later belongs to us —
-        # even if `git worktree add -b` fails partway through and leaves the
-        # ref behind without a usable worktree.
+        # Issue #51: ownership is signaled by ``created_fresh`` returned
+        # from create_worktree_with_new_branch. True when this call
+        # created the branch from default OR went through the
+        # stale-merged delete+recreate path — either way THIS session
+        # owns the resulting ref and cleanup on failure should delete it.
+        #
+        # Issue #52: pass the GitHubCLI so the reuse path can refuse a
+        # branch that still backs an open PR (prior DONE session whose
+        # PR is unmerged, or any external source). Without this, we'd
+        # silently check out the reviewer's already-reviewed branch and
+        # either hijack the PR or hit "A pull request already exists"
+        # on `gh pr create` at the end.
         await worktree.ensure_bare_repo(repo)
-        branch_preexisted = await worktree.branch_exists_locally(repo, branch_name)
-        worktree_path = await worktree.create_worktree_with_new_branch(
+        # Snapshot for the exception-path cleanup only (see
+        # ``branch_existed_before`` comment at the top of this function).
+        # We still need this because ``git worktree add -b`` can register
+        # the branch ref before the directory step crashes, and the
+        # helper raises before it can return ``created_fresh=True``.
+        branch_existed_before = await worktree.branch_exists_locally(
+            repo, branch_name,
+        )
+        worktree_path, created_fresh = await worktree.create_worktree_with_new_branch(
             repo=repo,
             session_id=session_id,
             new_branch=branch_name,
+            github=github,
         )
 
         # Symlink context
@@ -867,9 +901,10 @@ async def run_dev_issue(
         #   DONE    -> remove worktree, keep branch (the open PR references it)
         #   BLOCKED -> keep both (user may resume the session)
         #   FAILED  -> remove worktree AND delete branch so the next retry can
-        #              re-create `fix/issue-<n>` cleanly — BUT only if the
-        #              branch did not pre-exist (we own it) and it was never
-        #              pushed (no recoverable work on origin).
+        #              re-create `fix/issue-<n>` cleanly — BUT only if this
+        #              session created the branch (``created_fresh`` — see
+        #              issue #51) and it was never pushed (no recoverable
+        #              work on origin).
         #
         # Cleanup mutates the shared bare repo (worktree metadata, branch
         # refs) so it runs only when we hold the lock. If reacquire above
@@ -883,7 +918,7 @@ async def run_dev_issue(
                 worktree.remove_context_symlink(worktree_path)
                 await worktree.remove_worktree(repo, session_id)
                 if (
-                    not branch_preexisted
+                    created_fresh
                     and not await worktree.branch_exists_on_remote(
                         repo, branch_name
                     )
@@ -899,16 +934,19 @@ async def run_dev_issue(
         )
         state_db.commit()
 
-        # Best-effort cleanup so a retry isn't blocked by leftover state. Only
-        # touch the branch if it didn't pre-exist (we own it) AND origin has
-        # no copy (no recoverable work to orphan). Covers partial failures of
-        # `git worktree add -b` that create the ref before the directory setup
-        # crashes. If we're mid-verify the lock may be released — try to get
-        # it back for the cleanup. Uses the SHORT cleanup budget (not the
-        # fix-path one): a transient exception inside verifier.verify raising
-        # through while a peer holds the lock would otherwise stall the
-        # serial poll cycle for the full hour-long fix budget just to
-        # report the failure.
+        # Best-effort cleanup so a retry isn't blocked by leftover state.
+        # Only touch the branch if THIS session created it (issue #51 —
+        # ``created_fresh``) AND origin has no copy (no recoverable work
+        # to orphan). Covers partial failures of `git worktree add -b`
+        # that create the ref before the directory setup crashes, and
+        # the stale-merged delete+recreate path where the branch now on
+        # disk was put there by this very call. If we're mid-verify the
+        # lock may be released — try to get it back for the cleanup.
+        # Uses the SHORT cleanup budget (not the fix-path one): a
+        # transient exception inside verifier.verify raising through
+        # while a peer holds the lock would otherwise stall the serial
+        # poll cycle for the full hour-long fix budget just to report
+        # the failure.
         if not lock.held:
             try:
                 await lock.reacquire(
@@ -931,7 +969,16 @@ async def run_dev_issue(
                 await worktree.remove_worktree(repo, session_id)
             except Exception:
                 pass
-            if not branch_preexisted:
+            # Exception path ownership: created_fresh covers the normal
+            # return-and-fail case (issue #51). For partial failures of
+            # ``git worktree add -b`` that crash AFTER the branch ref was
+            # registered but BEFORE create_worktree_with_new_branch
+            # returns, created_fresh is still False (the default), so we
+            # fall back to the pre-call snapshot: if the branch did not
+            # exist before this run, the leftover ref must have been
+            # created by us.
+            we_own_branch = created_fresh or not branch_existed_before
+            if we_own_branch:
                 try:
                     has_remote = await worktree.branch_exists_on_remote(
                         repo, branch_name
@@ -1043,7 +1090,16 @@ async def resume_dev_from_pending(
                 worktree_path = candidate
 
         if worktree_path is None:
-            worktree_path = await worktree.create_worktree_with_new_branch(
+            # Resume path: the branch should already exist (BLOCKED
+            # sessions preserve both worktree and branch). We discard
+            # ``created_fresh`` here — cleanup semantics don't apply to
+            # resume, which never deletes the branch on exit; the
+            # original run_dev_issue is the single owner of that
+            # decision. Don't pass ``github`` either: an open PR for a
+            # mid-BLOCKED session is possible (claude opened the PR and
+            # blocked on a review question) and refusing reuse would
+            # wedge the resume path.
+            worktree_path, _ = await worktree.create_worktree_with_new_branch(
                 repo=repo,
                 session_id=session_id,
                 new_branch=branch_name,

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -973,18 +973,20 @@ async def run_dev_issue(
             # reliability.
             # 1. created_fresh covers the normal return-and-fail case
             #    (issue #51).
-            # 2. worktree._last_stale_recreate_attempted covers the
-            #    stale-merged delete+recreate path (issue #51 codex
-            #    round-4): the helper destroyed the old ref before
-            #    `git worktree add -b`, so anything on disk with this
-            #    branch name is ours regardless of what the pre-call
-            #    snapshot said.
+            # 2. StaleRecreatePartialFailureError signals the helper
+            #    destroyed the old ref before `git worktree add -b`,
+            #    so anything on disk with this branch name is ours
+            #    regardless of what the pre-call snapshot said. The
+            #    signal is per-call (exception attribute) so
+            #    concurrent sessions on the shared WorktreeManager
+            #    can't clobber each other's ownership state.
             # 3. Pre-call snapshot (`not branch_existed_before`) is
             #    the fallback for partial failures of the plain
             #    fresh-branch path where the helper raises before
             #    setting created_fresh.
-            stale_recreate_attempted = getattr(
-                worktree, "_last_stale_recreate_attempted", False,
+            from ctrlrelay.core.worktree import StaleRecreatePartialFailureError
+            stale_recreate_attempted = isinstance(
+                e, StaleRecreatePartialFailureError,
             )
             we_own_branch = (
                 created_fresh

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -93,7 +93,7 @@ class TestDevIntegration:
 
             worktree_path = tmp_path / "worktrees" / "test-worktree"
             worktree_path.mkdir(parents=True)
-            mock_create.return_value = worktree_path
+            mock_create.return_value = (worktree_path, True)
 
             result = await run_dev_issue(
                 repo="owner/repo",
@@ -137,7 +137,8 @@ class TestDevPipelineCleanup:
         *,
         branch_on_remote: bool = False,
         create_side_effect=None,
-        branch_preexists_locally: bool = False,
+        created_fresh: bool = True,
+        branch_existed_before: bool | None = None,
     ):
         """Run the dev pipeline with a stub dispatcher behavior, returning
         (result, mocks) so tests can assert on cleanup calls.
@@ -147,6 +148,18 @@ class TestDevPipelineCleanup:
           has it (must preserve).
         - `create_side_effect`: if set, overrides create_worktree_with_new_branch
           to simulate setup failure before the branch is created.
+        - `created_fresh`: the ownership flag returned from
+          create_worktree_with_new_branch (issue #51). True when this
+          session created the branch (fresh from default or via
+          delete+recreate of a stale merged local branch); False when
+          we reused an existing branch.
+        - `branch_existed_before`: value returned by the pre-call
+          ``branch_exists_locally`` snapshot. When None (default),
+          derives from ``not created_fresh`` to match the typical
+          pairing: fresh creations imply "didn't exist before", reuses
+          imply "did". Override explicitly when exercising
+          partial-create cleanup (branch_existed_before=False while
+          create_worktree raises).
         """
         from ctrlrelay.core.dispatcher import ClaudeDispatcher
         from ctrlrelay.core.github import GitHubCLI
@@ -193,14 +206,24 @@ class TestDevPipelineCleanup:
         ):
 
             mock_remote.return_value = branch_on_remote
-            mock_local.return_value = branch_preexists_locally
+            # branch_exists_locally is used by run_dev_issue only for the
+            # pre-call snapshot that backs the exception-path cleanup
+            # fallback (see run_dev_issue.branch_existed_before). The
+            # normal FAILED path keys off the returned ``created_fresh``
+            # from create_worktree_with_new_branch (issue #51).
+            effective_existed_before = (
+                (not created_fresh)
+                if branch_existed_before is None
+                else branch_existed_before
+            )
+            mock_local.return_value = effective_existed_before
 
             if create_side_effect is not None:
                 mock_create.side_effect = create_side_effect
             else:
                 worktree_path = tmp_path / "worktrees" / "wt-13"
                 worktree_path.mkdir(parents=True)
-                mock_create.return_value = worktree_path
+                mock_create.return_value = (worktree_path, created_fresh)
 
             from ctrlrelay.core.pr_verifier import VerificationResult
             mock_pr_verifier = AsyncMock()
@@ -374,7 +397,7 @@ class TestDevPipelineCleanup:
             mock_local.return_value = False
             worktree_path = tmp_path / "worktrees" / "wt-42"
             worktree_path.mkdir(parents=True)
-            mock_create.return_value = worktree_path
+            mock_create.return_value = (worktree_path, True)
 
             result = await run_dev_issue(
                 repo="owner/repo",
@@ -470,7 +493,11 @@ class TestDevPipelineCleanup:
             tmp_path,
             spawn,
             create_side_effect=create_boom,
-            branch_preexists_locally=True,
+            # Branch existed before the call; create_worktree raised
+            # before returning, so no ``created_fresh`` signal is
+            # available. The helper's default (False) combined with
+            # branch_existed_before=True means cleanup must NOT delete.
+            created_fresh=False,
         )
 
         assert not result.success
@@ -503,7 +530,12 @@ class TestDevPipelineCleanup:
             tmp_path,
             spawn,
             create_side_effect=create_partial_fail,
-            branch_preexists_locally=False,  # this run introduced the ref
+            # This run introduced the ref, but create_worktree raised
+            # before returning ``created_fresh=True``. Force
+            # branch_existed_before=False so the exception-path
+            # fallback correctly treats the leftover ref as ours.
+            created_fresh=False,
+            branch_existed_before=False,
         )
 
         assert not result.success
@@ -546,3 +578,66 @@ class TestDevPipelineCleanup:
         assert result.success
         mock_remove_wt.assert_awaited_once()
         mock_delete_branch.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_failed_with_created_fresh_deletes_branch_even_if_preexisting_locally(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #51 regression: the branch ref may have existed locally
+        before the call (leftover from a prior merged PR whose remote
+        was auto-deleted), but create_worktree_with_new_branch detected
+        it as stale-merged, deleted it, and recreated from default. The
+        ref now on disk was created by THIS session, so a FAILED
+        cleanup MUST delete it — even though a pre-call
+        ``branch_exists_locally`` snapshot would have said "True".
+
+        Before #51 fix: run_dev_issue snapshotted
+        ``branch_preexisted = branch_exists_locally()`` BEFORE the call
+        and keyed cleanup on ``not branch_preexisted``. Cleanup skipped
+        delete_branch, partial commits from this session leaked into
+        the next retry's reuse path and got classified as
+        "local-only with unique commits"."""
+        from ctrlrelay.core.checkpoint import read_checkpoint
+        from ctrlrelay.core.dispatcher import SessionResult
+
+        async def spawn(**kwargs):
+            state_file = kwargs["state_file"]
+            state_file.parent.mkdir(parents=True, exist_ok=True)
+            state_file.write_text(json.dumps({
+                "version": "1",
+                "status": "FAILED",
+                "session_id": kwargs["session_id"],
+                "timestamp": "2026-04-17T12:00:00Z",
+                "error": "claude gave up mid-retry",
+            }))
+            return SessionResult(
+                session_id=kwargs["session_id"],
+                exit_code=1,
+                stdout="",
+                stderr="",
+                state=read_checkpoint(state_file),
+            )
+
+        # The scenario: branch_exists_locally says True (stale merged
+        # ref from the previous session), but the helper detected it as
+        # fully-merged, deleted the ref, and recreated fresh → returns
+        # created_fresh=True. Cleanup must key on created_fresh, not
+        # on the stale pre-call snapshot. Force both flags so the OR
+        # combining them exercises the #51 semantic: with the old
+        # ``not branch_preexisted`` cleanup gate, this scenario would
+        # incorrectly skip delete_branch.
+        result, mock_remove_wt, mock_delete_branch = await self._run(
+            tmp_path,
+            spawn,
+            branch_on_remote=False,
+            created_fresh=True,
+            branch_existed_before=True,
+        )
+
+        assert not result.success
+        assert not result.blocked
+        mock_remove_wt.assert_awaited_once()
+        # The key assertion: delete_branch ran even though the branch
+        # "existed before" the call. created_fresh wins.
+        mock_delete_branch.assert_awaited_once()
+        assert mock_delete_branch.await_args.args[1] == "fix/issue-13"

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -139,7 +139,6 @@ class TestDevPipelineCleanup:
         create_side_effect=None,
         created_fresh: bool = True,
         branch_existed_before: bool | None = None,
-        stale_recreate_flag_set: bool = False,
     ):
         """Run the dev pipeline with a stub dispatcher behavior, returning
         (result, mocks) so tests can assert on cleanup calls.
@@ -174,12 +173,6 @@ class TestDevPipelineCleanup:
             worktrees_dir=tmp_path / "worktrees",
             bare_repos_dir=tmp_path / "repos",
         )
-        # Simulate "helper entered stale-merged recreate path" so the
-        # exception cleanup can recognize the leftover ref as ours
-        # even though create_worktree_with_new_branch was mocked to
-        # raise and never set created_fresh=True.
-        if stale_recreate_flag_set:
-            worktree._last_stale_recreate_attempted = True
 
         mock_github = AsyncMock(spec=GitHubCLI)
         mock_github.get_issue.return_value = {
@@ -558,22 +551,23 @@ class TestDevPipelineCleanup:
     async def test_stale_recreate_partial_failure_cleans_up_branch(
         self, tmp_path: Path
     ) -> None:
-        """Codex P2 round-4 on #113. The branch existed before the
-        call (stale-merged leftover), so ``branch_existed_before``
-        snapshots True. create_worktree_with_new_branch commits to
-        the delete+recreate path, flips the worktree-level stale
-        flag, deletes the old ref, and then `git worktree add -b`
-        raises partway. No ``created_fresh`` signal because the
-        helper never returned.
+        """Codex P2 round-4 on #113, refined in round-5: The branch
+        existed before the call (stale-merged leftover), so
+        ``branch_existed_before`` snapshots True.
+        create_worktree_with_new_branch commits to the delete+recreate
+        path, deletes the old ref, and then `git worktree add -b`
+        raises partway. The helper re-raises as
+        ``StaleRecreatePartialFailureError`` so the exception carries
+        ownership intent per-call (shared instance flags would race
+        under concurrent sessions).
 
-        Without the stale-recreate flag, cleanup would read
-        ``we_own_branch = False or False or not True = False`` and
-        skip delete_branch, leaking a partial ref into the next
-        retry. With the flag, ownership is correctly attributed to
-        this session and the branch gets deleted."""
+        Without the signal, cleanup would read ``we_own_branch =
+        False or False or not True = False`` and skip delete_branch,
+        leaking a partial ref into the next retry."""
+        from ctrlrelay.core.worktree import StaleRecreatePartialFailureError
 
         async def create_partial_fail(**kwargs):
-            raise RuntimeError(
+            raise StaleRecreatePartialFailureError(
                 "worktree add -b failed after stale-merged recreate "
                 "deleted the old ref"
             )
@@ -590,15 +584,12 @@ class TestDevPipelineCleanup:
             # was auto-deleted.
             branch_existed_before=True,
             created_fresh=False,
-            # Helper committed to the stale-recreate path before
-            # raising, so this session owns whatever ref is on disk.
-            stale_recreate_flag_set=True,
         )
 
         assert not result.success
         mock_remove_wt.assert_awaited_once()
-        # Despite branch_existed_before=True, the stale-recreate
-        # flag marks ownership as ours → delete must run.
+        # Despite branch_existed_before=True, the typed exception
+        # marks ownership as ours → delete must run.
         mock_delete_branch.assert_awaited_once()
         assert mock_delete_branch.await_args.args[1] == "fix/issue-13"
 

--- a/tests/test_dev_integration.py
+++ b/tests/test_dev_integration.py
@@ -139,6 +139,7 @@ class TestDevPipelineCleanup:
         create_side_effect=None,
         created_fresh: bool = True,
         branch_existed_before: bool | None = None,
+        stale_recreate_flag_set: bool = False,
     ):
         """Run the dev pipeline with a stub dispatcher behavior, returning
         (result, mocks) so tests can assert on cleanup calls.
@@ -173,6 +174,12 @@ class TestDevPipelineCleanup:
             worktrees_dir=tmp_path / "worktrees",
             bare_repos_dir=tmp_path / "repos",
         )
+        # Simulate "helper entered stale-merged recreate path" so the
+        # exception cleanup can recognize the leftover ref as ours
+        # even though create_worktree_with_new_branch was mocked to
+        # raise and never set created_fresh=True.
+        if stale_recreate_flag_set:
+            worktree._last_stale_recreate_attempted = True
 
         mock_github = AsyncMock(spec=GitHubCLI)
         mock_github.get_issue.return_value = {
@@ -544,6 +551,54 @@ class TestDevPipelineCleanup:
         # git would refuse to delete the branch that's still "checked out".
         mock_remove_wt.assert_awaited_once()
         # we owned the branch, so it must be deleted
+        mock_delete_branch.assert_awaited_once()
+        assert mock_delete_branch.await_args.args[1] == "fix/issue-13"
+
+    @pytest.mark.asyncio
+    async def test_stale_recreate_partial_failure_cleans_up_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 round-4 on #113. The branch existed before the
+        call (stale-merged leftover), so ``branch_existed_before``
+        snapshots True. create_worktree_with_new_branch commits to
+        the delete+recreate path, flips the worktree-level stale
+        flag, deletes the old ref, and then `git worktree add -b`
+        raises partway. No ``created_fresh`` signal because the
+        helper never returned.
+
+        Without the stale-recreate flag, cleanup would read
+        ``we_own_branch = False or False or not True = False`` and
+        skip delete_branch, leaking a partial ref into the next
+        retry. With the flag, ownership is correctly attributed to
+        this session and the branch gets deleted."""
+
+        async def create_partial_fail(**kwargs):
+            raise RuntimeError(
+                "worktree add -b failed after stale-merged recreate "
+                "deleted the old ref"
+            )
+
+        async def spawn(**kwargs):
+            raise AssertionError("spawn should not be reached")
+
+        result, mock_remove_wt, mock_delete_branch = await self._run(
+            tmp_path,
+            spawn,
+            create_side_effect=create_partial_fail,
+            # Branch existed before the call — classic stale-merged
+            # leftover from a prior merged PR whose remote branch
+            # was auto-deleted.
+            branch_existed_before=True,
+            created_fresh=False,
+            # Helper committed to the stale-recreate path before
+            # raising, so this session owns whatever ref is on disk.
+            stale_recreate_flag_set=True,
+        )
+
+        assert not result.success
+        mock_remove_wt.assert_awaited_once()
+        # Despite branch_existed_before=True, the stale-recreate
+        # flag marks ownership as ours → delete must run.
         mock_delete_branch.assert_awaited_once()
         assert mock_delete_branch.await_args.args[1] == "fix/issue-13"
 

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -139,7 +139,7 @@ class TestDevPipeline:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -400,7 +400,7 @@ class TestDevPipeline:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -470,7 +470,7 @@ class TestDevPipeline:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -600,7 +600,7 @@ class TestRunDevIssueVerification:
         mock_dispatcher.spawn_session.return_value = self._make_done_state(pr_number=42)
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -643,7 +643,7 @@ class TestRunDevIssueVerification:
         mock_dispatcher.spawn_session.return_value = self._make_done_state(pr_number=42)
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -694,7 +694,7 @@ class TestRunDevIssueVerification:
         mock_dispatcher.spawn_session.return_value = self._make_done_state(pr_number=42)
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -781,7 +781,7 @@ class TestRunDevIssueVerification:
         mock_dispatcher.spawn_session.side_effect = [blocked, done]
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "wt", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -859,7 +859,7 @@ class TestRunDevIssueVerification:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "wt", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -915,7 +915,7 @@ class TestRunDevIssueVerification:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "wt"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "wt", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -986,7 +986,7 @@ class TestRunDevIssueVerification:
         )
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -1040,7 +1040,7 @@ class TestRunDevIssueVerification:
         mock_dispatcher.spawn_session.return_value = self._make_done_state(pr_number=42)
 
         mock_worktree = AsyncMock()
-        mock_worktree.create_worktree_with_new_branch.return_value = tmp_path / "worktree"
+        mock_worktree.create_worktree_with_new_branch.return_value = (tmp_path / "worktree", True)
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
 
@@ -1120,7 +1120,7 @@ class TestRunDevIssueLockReleaseDuringVerify:
 
         mock_worktree = AsyncMock()
         mock_worktree.create_worktree_with_new_branch.return_value = (
-            tmp_path / "worktree"
+            tmp_path / "worktree", True,
         )
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
@@ -1211,7 +1211,7 @@ class TestRunDevIssueLockReleaseDuringVerify:
 
         mock_worktree = AsyncMock()
         mock_worktree.create_worktree_with_new_branch.return_value = (
-            tmp_path / "worktree"
+            tmp_path / "worktree", True,
         )
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
@@ -1323,7 +1323,7 @@ class TestRunDevIssueLockReleaseDuringVerify:
 
         mock_worktree = AsyncMock()
         mock_worktree.create_worktree_with_new_branch.return_value = (
-            tmp_path / "worktree"
+            tmp_path / "worktree", True,
         )
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()
@@ -1434,7 +1434,7 @@ class TestRunDevIssueLockReleaseDuringVerify:
 
         mock_worktree = AsyncMock()
         mock_worktree.create_worktree_with_new_branch.return_value = (
-            tmp_path / "worktree"
+            tmp_path / "worktree", True,
         )
         mock_worktree.symlink_context = MagicMock()
         mock_worktree.remove_context_symlink = MagicMock()

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -27,6 +27,45 @@ class TestGitHubCLI:
             mock_run.assert_called_once()
 
     @pytest.mark.asyncio
+    async def test_list_prs_passes_head_filter(self) -> None:
+        """Issue #52: the worktree reuse path uses ``list_prs(head=...)``
+        to probe whether a branch still backs an open PR. ``head`` must
+        be forwarded to ``gh pr list --head`` so the filter narrows
+        server-side to that one branch."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = json.dumps([
+                {"number": 42, "headRefName": "fix/issue-13"},
+            ])
+            gh = GitHubCLI()
+            prs = await gh.list_prs(
+                "owner/repo", state="open", head="fix/issue-13",
+            )
+
+            assert len(prs) == 1
+            assert prs[0]["number"] == 42
+            args = mock_run.call_args.args
+            assert "--head" in args
+            assert "fix/issue-13" in args
+            assert "--state" in args
+            assert "open" in args
+
+    @pytest.mark.asyncio
+    async def test_list_prs_without_head_omits_flag(self) -> None:
+        """Unfiltered ``list_prs`` must not pass ``--head`` at all — an
+        empty head would make gh return no PRs, silently breaking
+        existing callers (poller, dashboard) that enumerate all PRs."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = "[]"
+            gh = GitHubCLI()
+            await gh.list_prs("owner/repo", state="open")
+            args = mock_run.call_args.args
+            assert "--head" not in args
+
+    @pytest.mark.asyncio
     async def test_list_security_alerts(self) -> None:
         """Should fetch Dependabot alerts."""
         from ctrlrelay.core.github import GitHubCLI

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -868,14 +868,12 @@ class TestWorktreeManager:
         ]
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Probe is now deferred until AFTER ls-remote confirms the
-            # branch is on origin (no open same-repo PR can exist for a
-            # local-only branch). Sequence: show-ref → worktree list →
-            # ls-remote (on_remote=True) → probe raises.
+            # Probe runs BEFORE ls-remote (branch-deleted-PR-still-open
+            # is a real failure mode). Sequence: show-ref → worktree
+            # list → probe raises.
             mock_git.side_effect = [
                 "",        # show-ref (branch exists)
                 "",        # worktree list --porcelain (no live checkout)
-                "abc\trefs/heads/fix/issue-13\n",  # ls-remote (on origin)
             ]
             with pytest.raises(WorktreeError, match="#42") as exc_info:
                 await manager.create_worktree_with_new_branch(
@@ -964,17 +962,16 @@ class TestWorktreeManager:
         assert created_fresh is False
 
     @pytest.mark.asyncio
-    async def test_reuse_skips_pr_probe_for_local_only_branch(
+    async def test_reuse_probes_open_pr_even_for_local_only_branch(
         self, tmp_path: Path
     ) -> None:
-        """Codex P2 round-6 on #113: a branch that exists only in the
-        bare (not on origin) cannot back an open same-repo PR. Running
-        the probe unconditionally would let a flaky gh block safe
-        local-only retries (e.g. prior session died before push, or
-        merged PR auto-deleted the remote). Probe must be gated on
-        on-remote."""
-        from ctrlrelay.core.github import GitHubError
-        from ctrlrelay.core.worktree import WorktreeManager
+        """Codex P1 round-7 on #113: GitHub can keep a same-repo PR
+        open after its head branch is deleted on origin. If we skip
+        the probe for local-only branches, a retry would push the
+        branch back to origin and re-attach this session's commits
+        to the reviewer-owned PR. The probe therefore runs BEFORE
+        the on-remote gate, not after."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
 
         manager = WorktreeManager(
             worktrees_dir=tmp_path / "worktrees",
@@ -983,41 +980,45 @@ class TestWorktreeManager:
         bare = tmp_path / "repos" / "owner-repo.git"
         bare.mkdir(parents=True)
 
+        # An open PR for this branch exists even though the head
+        # branch was deleted on origin (stale-merged-but-PR-still-
+        # open scenario).
         mock_github = AsyncMock()
-        # Probe would fail if called — but it MUST NOT be called.
-        mock_github.list_prs.side_effect = GitHubError(
-            "gh should not have been invoked for local-only branch"
-        )
+        mock_github.list_prs.return_value = [
+            {
+                "number": 88,
+                "headRefName": "fix/issue-42",
+                "headRepositoryOwner": {"login": "owner"},
+                "headRepository": {"name": "repo"},
+            },
+        ]
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # ls-remote returns empty → local-only. _branch_is_fully_merged
-            # returns False (unpushed work) so we take the reuse path.
+            # Only the first two calls are reached — probe raises
+            # before ls-remote runs.
             mock_git.side_effect = [
-                "",     # show-ref (branch exists)
-                "",     # worktree list (no live checkout)
-                "",     # ls-remote (NOT on origin)
-                "",     # _branch_is_fully_merged's cherry call → "" = has commits
-                "+a",   # cherry output has a line not starting with "-" → unpushed
-                "",     # worktree add (without -b)
+                "",  # show-ref (branch exists)
+                "",  # worktree list (no live checkout)
             ]
-            # Short-circuit _branch_is_fully_merged rather than mock-
-            # chaining every git call: patch it directly to False.
-            with patch.object(
-                manager, "_branch_is_fully_merged",
-                new_callable=AsyncMock,
-            ) as mock_merged:
-                mock_merged.return_value = False
-                wt, created_fresh = await manager.create_worktree_with_new_branch(
+            with pytest.raises(WorktreeError, match="#88"):
+                await manager.create_worktree_with_new_branch(
                     repo="owner/repo",
-                    session_id="retry-local-only",
+                    session_id="retry-hijack-risk",
                     new_branch="fix/issue-42",
                     github=mock_github,
                 )
 
-        assert "retry-local-only" in str(wt)
-        assert created_fresh is False
-        # Probe was gated by on-remote=False — never called.
-        mock_github.list_prs.assert_not_awaited()
+        # Probe MUST be called for local-only branches too.
+        mock_github.list_prs.assert_awaited_once()
+        # No ls-remote / fetch / add — probe aborted before any
+        # ref-touching operation.
+        mutating_calls = [
+            c for c in mock_git.call_args_list
+            if "ls-remote" in c[0]
+            or "fetch" in c[0]
+            or ("worktree" in c[0] and "add" in c[0])
+        ]
+        assert mutating_calls == []
 
     @pytest.mark.asyncio
     async def test_reuse_refuses_open_pr_with_casing_mismatch(
@@ -1051,7 +1052,6 @@ class TestWorktreeManager:
             mock_git.side_effect = [
                 "",  # show-ref
                 "",  # worktree list
-                "abc\trefs/heads/fix/issue-13\n",  # ls-remote (on origin)
             ]
             with pytest.raises(WorktreeError, match="#17"):
                 await manager.create_worktree_with_new_branch(
@@ -1195,13 +1195,9 @@ class TestWorktreeManager:
         worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = 0.0
         try:
             with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-                # Probe runs only when branch is on origin (that's when
-                # a same-repo PR could be backing it). Seed ls-remote
-                # to return the branch so we reach the probe path.
                 mock_git.side_effect = [
                     "",  # show-ref
                     "",  # worktree list
-                    "abc\trefs/heads/fix/issue-1\n",  # ls-remote
                 ]
                 with pytest.raises(
                     WorktreeError, match="backs an open PR"

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -868,11 +868,14 @@ class TestWorktreeManager:
         ]
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # show-ref (branch exists) + worktree list (no live checkout).
-            # Probe happens BEFORE ls-remote / cherry — nothing else runs.
+            # Probe is now deferred until AFTER ls-remote confirms the
+            # branch is on origin (no open same-repo PR can exist for a
+            # local-only branch). Sequence: show-ref → worktree list →
+            # ls-remote (on_remote=True) → probe raises.
             mock_git.side_effect = [
                 "",        # show-ref (branch exists)
                 "",        # worktree list --porcelain (no live checkout)
+                "abc\trefs/heads/fix/issue-13\n",  # ls-remote (on origin)
             ]
             with pytest.raises(WorktreeError, match="#42") as exc_info:
                 await manager.create_worktree_with_new_branch(
@@ -895,7 +898,7 @@ class TestWorktreeManager:
         assert kwargs.get("head") == "fix/issue-13"
 
         # No ref mutation or worktree add happened — the refusal is
-        # BEFORE any branch touches.
+        # before any mutating call. ls-remote is a pure read probe.
         mutating_calls = [
             c for c in mock_git.call_args_list
             if "update-ref" in c[0]
@@ -961,6 +964,62 @@ class TestWorktreeManager:
         assert created_fresh is False
 
     @pytest.mark.asyncio
+    async def test_reuse_skips_pr_probe_for_local_only_branch(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 round-6 on #113: a branch that exists only in the
+        bare (not on origin) cannot back an open same-repo PR. Running
+        the probe unconditionally would let a flaky gh block safe
+        local-only retries (e.g. prior session died before push, or
+        merged PR auto-deleted the remote). Probe must be gated on
+        on-remote."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        # Probe would fail if called — but it MUST NOT be called.
+        mock_github.list_prs.side_effect = GitHubError(
+            "gh should not have been invoked for local-only branch"
+        )
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # ls-remote returns empty → local-only. _branch_is_fully_merged
+            # returns False (unpushed work) so we take the reuse path.
+            mock_git.side_effect = [
+                "",     # show-ref (branch exists)
+                "",     # worktree list (no live checkout)
+                "",     # ls-remote (NOT on origin)
+                "",     # _branch_is_fully_merged's cherry call → "" = has commits
+                "+a",   # cherry output has a line not starting with "-" → unpushed
+                "",     # worktree add (without -b)
+            ]
+            # Short-circuit _branch_is_fully_merged rather than mock-
+            # chaining every git call: patch it directly to False.
+            with patch.object(
+                manager, "_branch_is_fully_merged",
+                new_callable=AsyncMock,
+            ) as mock_merged:
+                mock_merged.return_value = False
+                wt, created_fresh = await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-local-only",
+                    new_branch="fix/issue-42",
+                    github=mock_github,
+                )
+
+        assert "retry-local-only" in str(wt)
+        assert created_fresh is False
+        # Probe was gated by on-remote=False — never called.
+        mock_github.list_prs.assert_not_awaited()
+
+    @pytest.mark.asyncio
     async def test_reuse_refuses_open_pr_with_casing_mismatch(
         self, tmp_path: Path
     ) -> None:
@@ -992,6 +1051,7 @@ class TestWorktreeManager:
             mock_git.side_effect = [
                 "",  # show-ref
                 "",  # worktree list
+                "abc\trefs/heads/fix/issue-13\n",  # ls-remote (on origin)
             ]
             with pytest.raises(WorktreeError, match="#17"):
                 await manager.create_worktree_with_new_branch(
@@ -1135,9 +1195,13 @@ class TestWorktreeManager:
         worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = 0.0
         try:
             with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+                # Probe runs only when branch is on origin (that's when
+                # a same-repo PR could be backing it). Seed ls-remote
+                # to return the branch so we reach the probe path.
                 mock_git.side_effect = [
                     "",  # show-ref
                     "",  # worktree list
+                    "abc\trefs/heads/fix/issue-1\n",  # ls-remote
                 ]
                 with pytest.raises(
                     WorktreeError, match="backs an open PR"

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1034,7 +1034,12 @@ class TestWorktreeManager:
             worktrees_dir=tmp_path / "worktrees",
             bare_repos_dir=tmp_path / "repos",
         )
-        bare = tmp_path / "repos" / "owner-repo.git"
+        # Bare dir name derives from the repo string verbatim — the
+        # code does `repo.replace("/", "-")` without lowering, so the
+        # "Owner/Repo" config produces "Owner-Repo.git" on disk. On
+        # Linux (case-sensitive FS) this must match exactly; macOS
+        # would accept either casing.
+        bare = tmp_path / "repos" / "Owner-Repo.git"
         bare.mkdir(parents=True)
 
         # Config says "Owner/Repo"; API returns lowercase.

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -134,7 +134,7 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.return_value = ""
 
-            worktree_path = await manager.create_worktree_with_new_branch(
+            worktree_path, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="sess-456",
                 new_branch="feature/my-branch",
@@ -143,6 +143,10 @@ class TestWorktreeManager:
 
             assert worktree_path.parent == tmp_path / "worktrees"
             assert "sess-456" in str(worktree_path)
+            # Fresh-branch path must signal ownership to the caller so
+            # run_dev_issue's FAILED cleanup can delete the branch
+            # (issue #51).
+            assert created_fresh is True
 
             # Verify -b flag was used with the new branch name
             call_args = mock_git.call_args
@@ -190,13 +194,17 @@ class TestWorktreeManager:
                 "",                                  # worktree add
             ]
 
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-1",
                 new_branch="fix/issue-5",
             )
 
         assert "retry-1" in str(wt)
+        # Reuse path: branch existed, we did NOT create it. Cleanup on
+        # failure must NOT delete this branch — the prior PR may still
+        # reference it (issue #51).
+        assert created_fresh is False
 
         # Fetch goes into the dedicated scratch ref, NOT overwriting refs/heads.
         fetch_calls = [c for c in mock_git.call_args_list if "fetch" in c[0]]
@@ -271,13 +279,15 @@ class TestWorktreeManager:
                 "",                                  # worktree add (reuse as-is)
             ]
 
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-ahead",
                 new_branch="fix/issue-9",
             )
 
         assert "retry-ahead" in str(wt)
+        # Reused an existing branch (unpushed commits preserved) → not fresh.
+        assert created_fresh is False
         # CRITICAL: no update-ref that touches refs/heads/fix/issue-9 ran.
         refs_heads_updates = [
             c for c in mock_git.call_args_list
@@ -355,13 +365,15 @@ class TestWorktreeManager:
                 WorktreeError("gh ls-remote auth"),  # strict ls-remote raises
                 "",                                  # worktree add (reuse as-is)
             ]
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-probe-fail",
                 new_branch="fix/issue-77",
             )
 
         assert "retry-probe-fail" in str(wt)
+        # Probe failed → reuse local as-is, nothing was freshly created.
+        assert created_fresh is False
         # No ref mutation happened — nothing to the live branch.
         mutating = [
             c for c in mock_git.call_args_list
@@ -406,13 +418,15 @@ class TestWorktreeManager:
                 "",                                  # worktree add (proceed)
             ]
 
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-timeout",
                 new_branch="fix/issue-42",
             )
 
         assert "retry-timeout" in str(wt)
+        # Fetch timeout → reuse local as-is, not a fresh creation.
+        assert created_fresh is False
         # Worktree add must still have been called.
         worktree_add_calls = [
             c for c in mock_git.call_args_list
@@ -525,13 +539,16 @@ class TestWorktreeManager:
                 stale_porcelain,                         # porcelain probe for stale entry
                 "",                                      # worktree add (retry succeeds)
             ]
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-after-crash",
                 new_branch="fix/issue-99",
             )
 
         assert "retry-after-crash" in str(wt)
+        # Cherry returned "unique" → reuse path (local-only with unpushed
+        # work). Created_fresh stays False.
+        assert created_fresh is False
         # No repo-wide `git worktree prune` was called.
         prune_calls = [
             c for c in mock_git.call_args_list
@@ -648,13 +665,15 @@ class TestWorktreeManager:
                 "+ abc unique\n",                        # cherry: unique → reuse
                 "",                                      # worktree add (reuse)
             ]
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-after-crash",
                 new_branch="fix/issue-88",
             )
 
         assert "retry-after-crash" in str(wt)
+        # Prunable stanza was correctly ignored; reuse path fires → not fresh.
+        assert created_fresh is False
         # Reuse must have happened — no `already checked out` error raised.
         worktree_add = [
             c for c in mock_git.call_args_list
@@ -688,13 +707,15 @@ class TestWorktreeManager:
                 "+ abc123 unpushed\n+ def456 more\n",    # cherry default branch — all unique
                 "",                                      # worktree add (reuse)
             ]
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="retry-keep",
                 new_branch="fix/issue-9",
             )
 
         assert "retry-keep" in str(wt)
+        # Unique commits → reused, not freshly created.
+        assert created_fresh is False
         # No delete + no fresh-branch creation.
         delete_calls = [
             c for c in mock_git.call_args_list
@@ -738,13 +759,20 @@ class TestWorktreeManager:
                 "refs/heads/main\n",                     # get_default_branch (2nd, for fresh path)
                 "",                                      # worktree add -b
             ]
-            wt = await manager.create_worktree_with_new_branch(
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="rerun-merged",
                 new_branch="fix/issue-7",
             )
 
         assert "rerun-merged" in str(wt)
+        # Issue #51 regression: the branch in the repo AFTER this call
+        # was created by THIS session (we deleted the stale merged local
+        # ref and recreated from default). Cleanup on FAILED must treat
+        # it as ours. Before #51 fix, run_dev_issue snapshotted
+        # branch_preexisted=True before the call and incorrectly skipped
+        # delete_branch, leaking partial commits into the next retry.
+        assert created_fresh is True
         # update-ref -d refs/heads/<branch> was called.
         delete_calls = [
             c for c in mock_git.call_args_list
@@ -789,13 +817,14 @@ class TestWorktreeManager:
                 "refs/heads/main\n",     # get_default_branch (fresh path)
                 "",                      # worktree add -b
             ]
-            await manager.create_worktree_with_new_branch(
+            _wt, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="s",
                 new_branch="fix/issue-x",
             )
 
-        # Path took the stale-merged branch (delete + recreate).
+        # Path took the stale-merged branch (delete + recreate) → fresh.
+        assert created_fresh is True
         delete_calls = [
             c for c in mock_git.call_args_list
             if "update-ref" in c[0] and "-d" in c[0]
@@ -806,6 +835,166 @@ class TestWorktreeManager:
             if "worktree" in c[0] and "add" in c[0]
         ]
         assert "-b" in worktree_add_calls[0][0]
+
+    @pytest.mark.asyncio
+    async def test_reuse_refuses_branch_backing_open_pr(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #52: if ``new_branch`` already exists locally AND still
+        backs an open PR on GitHub (prior DONE session whose PR wasn't
+        merged, or any external source), the reuse path must refuse
+        before any ref mutation. Running Claude on the reviewer's
+        already-reviewed branch would hijack the PR or later trip
+        ``gh pr create``'s "A pull request already exists"."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        mock_github.list_prs.return_value = [
+            {"number": 42, "headRefName": "fix/issue-13"},
+        ]
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # show-ref (branch exists) + worktree list (no live checkout).
+            # Probe happens BEFORE ls-remote / cherry — nothing else runs.
+            mock_git.side_effect = [
+                "",        # show-ref (branch exists)
+                "",        # worktree list --porcelain (no live checkout)
+            ]
+            with pytest.raises(WorktreeError, match="#42") as exc_info:
+                await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-13",
+                    new_branch="fix/issue-13",
+                    github=mock_github,
+                )
+
+        # Error message names the branch and gives a concrete action.
+        msg = str(exc_info.value)
+        assert "fix/issue-13" in msg
+        assert "open PR #42" in msg
+        assert "close or merge" in msg.lower() or "close" in msg.lower()
+
+        # GitHub was asked with state=open and head filter.
+        mock_github.list_prs.assert_awaited_once()
+        kwargs = mock_github.list_prs.await_args.kwargs
+        assert kwargs.get("state") == "open"
+        assert kwargs.get("head") == "fix/issue-13"
+
+        # No ref mutation or worktree add happened — the refusal is
+        # BEFORE any branch touches.
+        mutating_calls = [
+            c for c in mock_git.call_args_list
+            if "update-ref" in c[0]
+            or ("worktree" in c[0] and "add" in c[0])
+            or "fetch" in c[0]
+        ]
+        assert mutating_calls == [], (
+            f"no ref mutation allowed when branch backs an open PR; "
+            f"got {mutating_calls}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_reuse_proceeds_when_no_open_pr(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #52 happy path: the branch exists locally but has NO
+        open PR on GitHub (prior PR was merged OR the branch is a local
+        leftover from a session that died before pushing). Reuse must
+        proceed normally — the open-PR probe is a filter, not a
+        blanket block on reused branches."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        mock_github.list_prs.return_value = []  # no open PR
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Happy-case reuse: branch exists locally, no open PR, remote
+            # has the branch → sync + reuse (no -b).
+            mock_git.side_effect = [
+                "",                                      # show-ref
+                "",                                      # worktree list
+                "abc\trefs/heads/fix/issue-5\n",         # ls-remote
+                "",                                      # fetch scratch
+                "",                                      # merge-base local→remote (ok)
+                "",                                      # update-ref refs/heads
+                "",                                      # update-ref -d scratch
+                "",                                      # worktree add
+            ]
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-clean",
+                new_branch="fix/issue-5",
+                github=mock_github,
+            )
+
+        assert "retry-clean" in str(wt)
+        # Reused existing branch; not a fresh creation.
+        assert created_fresh is False
+        mock_github.list_prs.assert_awaited_once()
+        # Normal reuse path: worktree add WITHOUT -b.
+        worktree_add = [
+            c for c in mock_git.call_args_list
+            if "worktree" in c[0] and "add" in c[0]
+        ]
+        assert len(worktree_add) == 1
+        assert "-b" not in worktree_add[0][0]
+
+    @pytest.mark.asyncio
+    async def test_reuse_survives_pr_probe_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """Issue #52: if the PR probe itself fails (transient gh/network
+        error), don't wedge the retry — the later ``gh pr create`` is
+        defence in depth. This keeps a flaky GitHub API from blocking
+        every retry on every issue."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        mock_github.list_prs.side_effect = GitHubError("network timeout")
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            # Happy-case reuse path after the probe swallowed the failure.
+            mock_git.side_effect = [
+                "",                                      # show-ref
+                "",                                      # worktree list
+                "abc\trefs/heads/fix/issue-1\n",         # ls-remote
+                "",                                      # fetch scratch
+                "",                                      # merge-base local→remote
+                "",                                      # update-ref refs/heads
+                "",                                      # update-ref -d scratch
+                "",                                      # worktree add
+            ]
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-probe-flaky",
+                new_branch="fix/issue-1",
+                github=mock_github,
+            )
+
+        assert "retry-probe-flaky" in str(wt)
+        assert created_fresh is False
 
     @pytest.mark.asyncio
     async def test_create_worktree_with_new_branch_uses_default_branch(
@@ -822,13 +1011,14 @@ class TestWorktreeManager:
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
             mock_git.side_effect = ["refs/heads/main\n", ""]
 
-            worktree_path = await manager.create_worktree_with_new_branch(
+            worktree_path, created_fresh = await manager.create_worktree_with_new_branch(
                 repo="owner/repo",
                 session_id="sess-789",
                 new_branch="feature/auto-base",
             )
 
             assert worktree_path is not None
+            assert created_fresh is True
             # First call: symbolic-ref HEAD (default branch probe).
             first_call_args = mock_git.call_args_list[0][0]
             assert "symbolic-ref" in first_call_args

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1106,15 +1106,18 @@ class TestWorktreeManager:
         assert "-b" not in worktree_add[0][0]
 
     @pytest.mark.asyncio
-    async def test_reuse_survives_pr_probe_failure(
+    async def test_reuse_refuses_when_pr_probe_fails_closed(
         self, tmp_path: Path
     ) -> None:
-        """Issue #52: if the PR probe itself fails (transient gh/network
-        error), don't wedge the retry — the later ``gh pr create`` is
-        defence in depth. This keeps a flaky GitHub API from blocking
-        every retry on every issue."""
+        """Codex P1 round-5 on #113: the open-PR probe must fail
+        CLOSED, not open. The dev pipeline pushes to the branch
+        BEFORE `gh pr create`, so silently reusing on probe failure
+        would let a push hijack an existing PR before any later
+        error surfaces. Retry a few times for transient hiccups,
+        then refuse with a clear message."""
+        from ctrlrelay.core import worktree as worktree_mod
         from ctrlrelay.core.github import GitHubError
-        from ctrlrelay.core.worktree import WorktreeManager
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
 
         manager = WorktreeManager(
             worktrees_dir=tmp_path / "worktrees",
@@ -1126,27 +1129,90 @@ class TestWorktreeManager:
         mock_github = AsyncMock()
         mock_github.list_prs.side_effect = GitHubError("network timeout")
 
-        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
-            # Happy-case reuse path after the probe swallowed the failure.
-            mock_git.side_effect = [
-                "",                                      # show-ref
-                "",                                      # worktree list
-                "abc\trefs/heads/fix/issue-1\n",         # ls-remote
-                "",                                      # fetch scratch
-                "",                                      # merge-base local→remote
-                "",                                      # update-ref refs/heads
-                "",                                      # update-ref -d scratch
-                "",                                      # worktree add
-            ]
-            wt, created_fresh = await manager.create_worktree_with_new_branch(
-                repo="owner/repo",
-                session_id="retry-probe-flaky",
-                new_branch="fix/issue-1",
-                github=mock_github,
-            )
+        # Shrink the probe sleep so the test runs fast without
+        # changing the retry count (that's part of the behavior).
+        orig_sleep = worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS
+        worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = 0.0
+        try:
+            with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+                mock_git.side_effect = [
+                    "",  # show-ref
+                    "",  # worktree list
+                ]
+                with pytest.raises(
+                    WorktreeError, match="backs an open PR"
+                ):
+                    await manager.create_worktree_with_new_branch(
+                        repo="owner/repo",
+                        session_id="retry-probe-flaky",
+                        new_branch="fix/issue-1",
+                        github=mock_github,
+                    )
+        finally:
+            worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = orig_sleep
 
-        assert "retry-probe-flaky" in str(wt)
+        # Probe retried the configured number of times before raising.
+        assert mock_github.list_prs.await_count == (
+            worktree_mod._PR_PROBE_RETRY_ATTEMPTS
+        )
+
+    @pytest.mark.asyncio
+    async def test_reuse_survives_transient_probe_error(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P1 round-5: a single transient probe failure is
+        recovered by retry — the operator shouldn't see WorktreeError
+        every time gh has a blip. Second attempt succeeds with no
+        open PR, reuse proceeds."""
+        from ctrlrelay.core import worktree as worktree_mod
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        call_count = {"n": 0}
+
+        async def flaky_list_prs(*args, **kwargs):
+            call_count["n"] += 1
+            if call_count["n"] == 1:
+                raise GitHubError("transient blip")
+            return []
+
+        mock_github = AsyncMock()
+        mock_github.list_prs.side_effect = flaky_list_prs
+
+        orig_sleep = worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS
+        worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = 0.0
+        try:
+            with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+                mock_git.side_effect = [
+                    "",                                      # show-ref
+                    "",                                      # worktree list
+                    "abc\trefs/heads/fix/issue-1\n",         # ls-remote
+                    "",                                      # fetch scratch
+                    "",                                      # merge-base
+                    "",                                      # update-ref
+                    "",                                      # update-ref -d
+                    "",                                      # worktree add
+                ]
+                wt, created_fresh = await manager.create_worktree_with_new_branch(
+                    repo="owner/repo",
+                    session_id="retry-transient",
+                    new_branch="fix/issue-1",
+                    github=mock_github,
+                )
+        finally:
+            worktree_mod._PR_PROBE_RETRY_SLEEP_SECONDS = orig_sleep
+
+        assert "retry-transient" in str(wt)
         assert created_fresh is False
+        # Retried exactly twice (first raised, second returned []).
+        assert call_count["n"] == 2
 
     @pytest.mark.asyncio
     async def test_create_worktree_with_new_branch_uses_default_branch(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -961,6 +961,47 @@ class TestWorktreeManager:
         assert created_fresh is False
 
     @pytest.mark.asyncio
+    async def test_reuse_refuses_open_pr_with_casing_mismatch(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 round-3 on #113: GitHub owner/repo names are
+        case-insensitive. Config may be ``Owner/Repo`` while the API
+        returns ``owner/repo``; exact equality misses the match and
+        the veto is silently skipped. Normalize both sides."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        # Config says "Owner/Repo"; API returns lowercase.
+        mock_github = AsyncMock()
+        mock_github.list_prs.return_value = [
+            {
+                "number": 17,
+                "headRefName": "fix/issue-13",
+                "headRepositoryOwner": {"login": "owner"},
+                "headRepository": {"name": "repo"},
+            },
+        ]
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",  # show-ref
+                "",  # worktree list
+            ]
+            with pytest.raises(WorktreeError, match="#17"):
+                await manager.create_worktree_with_new_branch(
+                    repo="Owner/Repo",
+                    session_id="retry-case",
+                    new_branch="fix/issue-13",
+                    github=mock_github,
+                )
+
+    @pytest.mark.asyncio
     async def test_reuse_ignores_same_owner_fork_pr(
         self, tmp_path: Path
     ) -> None:

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -860,8 +860,10 @@ class TestWorktreeManager:
             {
                 "number": 42,
                 "headRefName": "fix/issue-13",
-                # Same owner as the target repo — this IS ours.
+                # Same owner AND same repo name as the target — this
+                # is the PR we're about to collide with.
                 "headRepositoryOwner": {"login": "owner"},
+                "headRepository": {"name": "repo"},
             },
         ]
 
@@ -932,6 +934,7 @@ class TestWorktreeManager:
                 "number": 99,
                 "headRefName": "fix/issue-5",
                 "headRepositoryOwner": {"login": "someforker"},
+                "headRepository": {"name": "repo"},
             },
         ]
 
@@ -955,6 +958,57 @@ class TestWorktreeManager:
 
         # Reuse proceeded: fork PR doesn't veto.
         assert "retry-fork" in str(wt)
+        assert created_fresh is False
+
+    @pytest.mark.asyncio
+    async def test_reuse_ignores_same_owner_fork_pr(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 round-2 on #113: same-owner forks (``acme/repo-fork``
+        targeting ``acme/repo``) must also not veto reuse. Matching
+        on headRepositoryOwner.login alone conflated them; the filter
+        must also check headRepository.name."""
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "acme-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        # Same owner but a different repo name (a fork under the same
+        # org). The branch name collides but the PR has nothing to
+        # do with our base repo.
+        mock_github.list_prs.return_value = [
+            {
+                "number": 77,
+                "headRefName": "fix/issue-5",
+                "headRepositoryOwner": {"login": "acme"},
+                "headRepository": {"name": "repo-fork"},
+            },
+        ]
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref
+                "",                                      # worktree list
+                "abc\trefs/heads/fix/issue-5\n",         # ls-remote
+                "",                                      # fetch scratch
+                "",                                      # merge-base
+                "",                                      # update-ref refs/heads
+                "",                                      # update-ref -d scratch
+                "",                                      # worktree add
+            ]
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
+                repo="acme/repo",
+                session_id="retry-same-owner-fork",
+                new_branch="fix/issue-5",
+                github=mock_github,
+            )
+
+        assert "retry-same-owner-fork" in str(wt)
         assert created_fresh is False
 
     @pytest.mark.asyncio

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -857,7 +857,12 @@ class TestWorktreeManager:
 
         mock_github = AsyncMock()
         mock_github.list_prs.return_value = [
-            {"number": 42, "headRefName": "fix/issue-13"},
+            {
+                "number": 42,
+                "headRefName": "fix/issue-13",
+                # Same owner as the target repo — this IS ours.
+                "headRepositoryOwner": {"login": "owner"},
+            },
         ]
 
         with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
@@ -899,6 +904,58 @@ class TestWorktreeManager:
             f"no ref mutation allowed when branch backs an open PR; "
             f"got {mutating_calls}"
         )
+
+    @pytest.mark.asyncio
+    async def test_reuse_ignores_fork_pr_with_same_branch_name(
+        self, tmp_path: Path
+    ) -> None:
+        """Codex P2 on #113: ``gh pr list --head`` filters on branch
+        name alone and can't scope to ``<owner>:<branch>``. An
+        unrelated contributor's fork PR using the same branch name
+        (e.g. another ``fix/issue-13``) must NOT block our reuse —
+        only a PR whose head lives in the target repo's owner veto.
+        """
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        manager = WorktreeManager(
+            worktrees_dir=tmp_path / "worktrees",
+            bare_repos_dir=tmp_path / "repos",
+        )
+        bare = tmp_path / "repos" / "owner-repo.git"
+        bare.mkdir(parents=True)
+
+        mock_github = AsyncMock()
+        # A single PR from a fork with the same branch name. We're
+        # "owner/repo"; the fork lives under "someforker".
+        mock_github.list_prs.return_value = [
+            {
+                "number": 99,
+                "headRefName": "fix/issue-5",
+                "headRepositoryOwner": {"login": "someforker"},
+            },
+        ]
+
+        with patch.object(manager, "_run_git", new_callable=AsyncMock) as mock_git:
+            mock_git.side_effect = [
+                "",                                      # show-ref
+                "",                                      # worktree list
+                "abc\trefs/heads/fix/issue-5\n",         # ls-remote
+                "",                                      # fetch scratch
+                "",                                      # merge-base local→remote
+                "",                                      # update-ref refs/heads
+                "",                                      # update-ref -d scratch
+                "",                                      # worktree add
+            ]
+            wt, created_fresh = await manager.create_worktree_with_new_branch(
+                repo="owner/repo",
+                session_id="retry-fork",
+                new_branch="fix/issue-5",
+                github=mock_github,
+            )
+
+        # Reuse proceeded: fork PR doesn't veto.
+        assert "retry-fork" in str(wt)
+        assert created_fresh is False
 
     @pytest.mark.asyncio
     async def test_reuse_proceeds_when_no_open_pr(


### PR DESCRIPTION
## Summary

Fixes two follow-up issues flagged by codex during the #50 review. Both
touch `create_worktree_with_new_branch` semantics so they land together.

**#51** — After PR #50's stale-merged delete+recreate path, the
`branch_preexisted = await worktree.branch_exists_locally(...)` snapshot
in `run_dev_issue` became wrong. When the helper detected a fully-merged
local ref, deleted it, and recreated fresh from default, the snapshot
still said `True` (it was taken BEFORE the call) — so a FAILED cleanup
skipped `delete_branch` and partial commits leaked into the next retry.

**#52** — The #50 reuse path happily checked out a branch that still
backed an open PR (prior DONE session whose PR hadn't been merged yet,
or any external source). The next session would commit into the
reviewer's already-reviewed branch or hit "A pull request already
exists" on `gh pr create`.

## Design (option 1 for each)

### #51 — return `(path, created_fresh)`
`create_worktree_with_new_branch` now returns a tuple. `created_fresh`
is `True` when THIS call either created a new branch from default OR
went through the delete+recreate path for a stale merged local branch.
`run_dev_issue` keys its FAILED `delete_branch` gate on `created_fresh`
instead of the stale pre-call snapshot.

A pre-call `branch_exists_locally` snapshot is still captured, but now
ONLY as a fallback for the rare partial-create exception path where
`git worktree add -b` registers the branch ref before the directory
step crashes (helper raises before returning, so `created_fresh` never
gets set). The snapshot is only consulted when `created_fresh=False`
— so the #51 stale-snapshot bug can't reappear.

### #52 — probe GitHub for an open PR before reuse
Added a `head` parameter to `GitHubCLI.list_prs` that forwards to
`gh pr list --head`. `create_worktree_with_new_branch` now accepts an
optional `github: GitHubCLI` and, when provided, probes for an open PR
with the target branch as head BEFORE any ref mutations. If one
exists, raises `WorktreeError` with the PR number and a concrete
operator action:

> Branch `'fix/issue-N'` already has open PR #42 on `'owner/repo'` —
> close or merge it before retrying this issue.

Probe failures (gh/network) are swallowed so a flaky GitHub API doesn't
wedge every retry — the later `gh pr create` call still provides
defence-in-depth.

## Callsite updates

- `run_dev_issue` — unpacks the tuple, passes `github=github` to enable
  the PR probe.
- `resume_dev_from_pending` — unpacks and discards `created_fresh`
  (resume doesn't own cleanup decisions), skips the `github` param
  since a BLOCKED session may legitimately have an open PR.
- All test mocks updated to return tuples.

## Test plan

- [ ] `test_local_only_fully_merged_is_deleted_and_recreated` asserts
      `created_fresh is True` (the exact #51 scenario — stale merged
      local ref → delete+recreate).
- [ ] `test_local_only_empty_cherry_is_treated_as_merged` — same.
- [ ] `test_reuse_refuses_branch_backing_open_pr` — PR probe returns
      a match → `WorktreeError` with "open PR #42" in the message.
- [ ] `test_reuse_proceeds_when_no_open_pr` — empty probe → normal
      reuse (no `-b`).
- [ ] `test_reuse_survives_pr_probe_failure` — `GitHubError` → fall
      through to normal reuse.
- [ ] `test_failed_with_created_fresh_deletes_branch_even_if_preexisting_locally`
      — the key #51 regression: `branch_exists_locally=True` but
      `created_fresh=True` → cleanup deletes.
- [ ] `test_list_prs_passes_head_filter` + `_without_head_omits_flag`
      — `gh pr list --head` filter wiring.
- [ ] Existing reuse / divergence / stale-admin regressions still
      pass (all 32 worktree tests, all 427 total).
- [ ] `ruff check src/ tests/` clean.