### PR TITLE
feat(cli): add ctrlrelay repos clone-all/pull-all/status

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -2059,5 +2059,227 @@ def status(
         db.close()
 
 
+repos_app = typer.Typer(help="Bulk repo operations across the orchestrator manifest.")
+app.add_typer(repos_app, name="repos")
+
+
+def _iter_repos(config_path: str, filter_str: str | None):
+    """Yield (name, org, repo, remote) tuples for repos in the orchestrator config."""
+    try:
+        config = load_config(config_path)
+    except ConfigError as e:
+        console.print(f"[red]Error loading config:[/red] {e}")
+        raise typer.Exit(1)
+
+    needle = filter_str.lower() if filter_str else None
+    for r in config.repos:
+        if needle and needle not in r.name.lower():
+            continue
+        if "/" not in r.name:
+            console.print(
+                f"[yellow]skip[/yellow] {r.name} — name must be 'org/repo'"
+            )
+            continue
+        org, repo = r.name.split("/", 1)
+        remote = f"git@github.com:{r.name}.git"
+        yield r.name, org, repo, remote
+
+
+@repos_app.command("clone-all")
+def repos_clone_all(
+    dest: Path = typer.Argument(..., help="Workspace root (e.g. ~/code/myproject)"),
+    config_path: str = typer.Option(
+        "config/orchestrator.yaml", "--config", "-c", help="Path to orchestrator.yaml"
+    ),
+    filter_str: str | None = typer.Option(
+        None, "--filter", "-f", help="Substring filter on repo name (e.g. 'AInvirion')"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show actions without running"),
+) -> None:
+    """Clone every configured repo into DEST/<org>/<repo>."""
+    import subprocess
+
+    root = Path(dest).expanduser().resolve()
+    cloned = skipped = failed = 0
+
+    for name, org, repo, remote in _iter_repos(config_path, filter_str):
+        target = root / org / repo
+        if (target / ".git").exists():
+            console.print(f"[dim]✓ {name} (already cloned)[/dim]")
+            skipped += 1
+            continue
+        if target.exists() and any(target.iterdir()):
+            console.print(f"[yellow]skip[/yellow] {name} — {target} exists and is not empty")
+            skipped += 1
+            continue
+        if dry_run:
+            console.print(f"[blue]would clone[/blue] {remote} → {target}")
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        result = subprocess.run(
+            ["git", "clone", "--quiet", remote, str(target)],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            console.print(f"[green]cloned[/green] {name}")
+            cloned += 1
+        else:
+            console.print(f"[red]failed[/red] {name}: {result.stderr.strip()}")
+            failed += 1
+
+    if not dry_run:
+        console.print(
+            f"\n[bold]{cloned} cloned, {skipped} skipped, {failed} failed[/bold]"
+        )
+    if failed:
+        raise typer.Exit(1)
+
+
+@repos_app.command("pull-all")
+def repos_pull_all(
+    dest: Path = typer.Argument(..., help="Workspace root to pull (must already be cloned)"),
+    config_path: str = typer.Option(
+        "config/orchestrator.yaml", "--config", "-c", help="Path to orchestrator.yaml"
+    ),
+    filter_str: str | None = typer.Option(
+        None, "--filter", "-f", help="Substring filter on repo name"
+    ),
+    dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show actions without running"),
+) -> None:
+    """Fast-forward pull every cloned repo under DEST/<org>/<repo>."""
+    import subprocess
+
+    root = Path(dest).expanduser().resolve()
+    pulled = skipped = dirty = failed = 0
+
+    for name, org, repo, _remote in _iter_repos(config_path, filter_str):
+        target = root / org / repo
+        if not (target / ".git").exists():
+            console.print(f"[dim]– {name} (not cloned)[/dim]")
+            skipped += 1
+            continue
+        if dry_run:
+            console.print(f"[blue]would pull[/blue] {target}")
+            continue
+        # Refuse to pull a dirty tree — fetch only.
+        porcelain = subprocess.run(
+            ["git", "-C", str(target), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+        )
+        if porcelain.returncode != 0:
+            console.print(
+                f"[red]failed[/red] {name}: git status — {porcelain.stderr.strip()}"
+            )
+            failed += 1
+            continue
+        if porcelain.stdout.strip():
+            fetched = subprocess.run(
+                ["git", "-C", str(target), "fetch", "--quiet"],
+                capture_output=True,
+                text=True,
+            )
+            if fetched.returncode != 0:
+                console.print(
+                    f"[red]failed[/red] {name}: fetch — {fetched.stderr.strip()}"
+                )
+                failed += 1
+            else:
+                console.print(f"[yellow]dirty[/yellow] {name} — fetched only")
+                dirty += 1
+            continue
+        result = subprocess.run(
+            ["git", "-C", str(target), "pull", "--ff-only", "--quiet"],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode == 0:
+            console.print(f"[green]pulled[/green] {name}")
+            pulled += 1
+        else:
+            console.print(f"[red]failed[/red] {name}: {result.stderr.strip()}")
+            failed += 1
+
+    if not dry_run:
+        console.print(
+            f"\n[bold]{pulled} pulled, {dirty} dirty, {skipped} skipped, "
+            f"{failed} failed[/bold]"
+        )
+    if failed:
+        raise typer.Exit(1)
+
+
+@repos_app.command("status")
+def repos_status(
+    dest: Path = typer.Argument(..., help="Workspace root to inspect"),
+    config_path: str = typer.Option(
+        "config/orchestrator.yaml", "--config", "-c", help="Path to orchestrator.yaml"
+    ),
+    filter_str: str | None = typer.Option(
+        None, "--filter", "-f", help="Substring filter on repo name"
+    ),
+) -> None:
+    """Show clean/dirty/ahead/behind for every repo under DEST/<org>/<repo>."""
+    import subprocess
+
+    root = Path(dest).expanduser().resolve()
+    table = Table(title=f"Repo status — {root}")
+    table.add_column("Repo", style="cyan")
+    table.add_column("Branch", style="blue")
+    table.add_column("State")
+    table.add_column("Ahead/Behind", justify="right")
+
+    for name, org, repo, _remote in _iter_repos(config_path, filter_str):
+        target = root / org / repo
+        if not (target / ".git").exists():
+            table.add_row(name, "-", "[red]not cloned[/red]", "")
+            continue
+        branch = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--abbrev-ref", "HEAD"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        porcelain = subprocess.run(
+            ["git", "-C", str(target), "status", "--porcelain"],
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
+        state = "[yellow]dirty[/yellow]" if porcelain else "[green]clean[/green]"
+
+        upstream = subprocess.run(
+            ["git", "-C", str(target), "rev-parse", "--abbrev-ref", "@{upstream}"],
+            capture_output=True,
+            text=True,
+        )
+        ahead_behind = ""
+        if upstream.returncode == 0:
+            def _count(spec: str) -> int:
+                proc = subprocess.run(
+                    ["git", "-C", str(target), "rev-list", "--count", spec],
+                    capture_output=True,
+                    text=True,
+                )
+                if proc.returncode != 0:
+                    return 0
+                try:
+                    return int(proc.stdout.strip() or "0")
+                except ValueError:
+                    return 0
+
+            ahead_n = _count("@{upstream}..HEAD")
+            behind_n = _count("HEAD..@{upstream}")
+            parts = []
+            if ahead_n > 0:
+                parts.append(f"[green]+{ahead_n}[/green]")
+            if behind_n > 0:
+                parts.append(f"[red]-{behind_n}[/red]")
+            ahead_behind = " ".join(parts)
+
+        table.add_row(name, branch or "-", state, ahead_behind)
+
+    console.print(table)
+
+
 if __name__ == "__main__":
     app()

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -161,6 +162,9 @@ class AutomationConfig(BaseModel):
     task_labels: list[str] = Field(default_factory=lambda: ["task"])
 
 
+_REPO_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")
+
+
 class RepoConfig(BaseModel):
     """Configuration for a single repository."""
 
@@ -170,6 +174,19 @@ class RepoConfig(BaseModel):
     deploy: DeployConfig | None = None
     code_review: CodeReviewConfig = Field(default_factory=CodeReviewConfig)
     dev_branch_template: str = "fix/issue-{n}"
+
+    @field_validator("name")
+    @classmethod
+    def validate_name(cls, v: str) -> str:
+        # GitHub-shaped owner/repo. Rejects "..", empty segments, extra slashes,
+        # and shell metacharacters — `name` ends up in derived filesystem paths
+        # and remote URLs, so a malicious manifest must not escape DEST.
+        if not _REPO_NAME_RE.match(v):
+            raise ValueError(
+                f"repo name {v!r} must match 'owner/repo' "
+                f"(letters, digits, '.', '_', '-')"
+            )
+        return v
 
     @field_validator("local_path", mode="before")
     @classmethod

--- a/tests/test_cli_repos.py
+++ b/tests/test_cli_repos.py
@@ -53,7 +53,11 @@ class TestCloneAllDryRun:
     def test_remote_uses_ssh_github_convention(self, repos_config: Path, tmp_path: Path) -> None:
         result = runner.invoke(
             app,
-            ["repos", "clone-all", str(tmp_path / "ws"), "--config", str(repos_config), "--dry-run"],
+            [
+                "repos", "clone-all", str(tmp_path / "ws"),
+                "--config", str(repos_config),
+                "--dry-run",
+            ],
         )
         assert "git@github.com:AInvirion/aiproxyguard.git" in result.output
         assert "git@github.com:SemClone/binarysniffer.git" in result.output

--- a/tests/test_cli_repos.py
+++ b/tests/test_cli_repos.py
@@ -1,0 +1,264 @@
+"""Tests for `ctrlrelay repos` bulk-clone/pull/status commands."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from typer.testing import CliRunner
+
+from ctrlrelay.cli import app
+
+runner = CliRunner()
+
+
+@pytest.fixture
+def repos_config(sample_config_dict: dict, tmp_path: Path) -> Path:
+    sample_config_dict["repos"] = [
+        {"name": "AInvirion/aiproxyguard", "local_path": "~/Projects/AINVIRION/aiproxyguard"},
+        {"name": "AInvirion/aiproxyguard-cloud", "local_path": "~/Projects/AINVIRION/cloud"},
+        {"name": "SemClone/binarysniffer", "local_path": "~/Projects/SEMCL.ONE/binarysniffer"},
+    ]
+    path = tmp_path / "orchestrator.yaml"
+    path.write_text(yaml.dump(sample_config_dict))
+    return path
+
+
+class TestCloneAllDryRun:
+    def test_emits_one_line_per_repo(self, repos_config: Path, tmp_path: Path) -> None:
+        dest = tmp_path / "workspace"
+        result = runner.invoke(
+            app,
+            ["repos", "clone-all", str(dest), "--config", str(repos_config), "--dry-run"],
+        )
+        assert result.exit_code == 0
+        assert "AInvirion/aiproxyguard" in result.output
+        assert "AInvirion/aiproxyguard-cloud" in result.output
+        assert "SemClone/binarysniffer" in result.output
+
+    def test_path_is_dest_slash_org_slash_repo(self, repos_config: Path, tmp_path: Path) -> None:
+        dest = tmp_path / "workspace"
+        result = runner.invoke(
+            app,
+            ["repos", "clone-all", str(dest), "--config", str(repos_config), "--dry-run"],
+        )
+        # Rich line-wraps long paths — collapse whitespace before substring check.
+        flat = "".join(result.output.split())
+        assert "workspace/AInvirion/aiproxyguard" in flat
+        assert "workspace/SemClone/binarysniffer" in flat
+
+    def test_remote_uses_ssh_github_convention(self, repos_config: Path, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            ["repos", "clone-all", str(tmp_path / "ws"), "--config", str(repos_config), "--dry-run"],
+        )
+        assert "git@github.com:AInvirion/aiproxyguard.git" in result.output
+        assert "git@github.com:SemClone/binarysniffer.git" in result.output
+
+    def test_filter_narrows_to_substring(self, repos_config: Path, tmp_path: Path) -> None:
+        result = runner.invoke(
+            app,
+            [
+                "repos", "clone-all", str(tmp_path / "ws"),
+                "--config", str(repos_config),
+                "--filter", "SemClone",
+                "--dry-run",
+            ],
+        )
+        assert result.exit_code == 0
+        assert "SemClone/binarysniffer" in result.output
+        assert "AInvirion" not in result.output
+
+
+class TestCloneAllExecution:
+    def test_invokes_git_clone_with_exact_argv(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        """clone-all must invoke `git clone --quiet REMOTE TARGET` exactly."""
+        dest = tmp_path / "workspace"
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = runner.invoke(
+                app,
+                ["repos", "clone-all", str(dest), "--config", str(repos_config)],
+            )
+
+        assert result.exit_code == 0
+        clone_cmds = [c for c in calls if c[:2] == ["git", "clone"]]
+        assert len(clone_cmds) == 3
+
+        target = (dest / "AInvirion" / "aiproxyguard").resolve()
+        expected = [
+            "git",
+            "clone",
+            "--quiet",
+            "git@github.com:AInvirion/aiproxyguard.git",
+            str(target),
+        ]
+        assert expected in clone_cmds, (
+            f"expected exact argv {expected} in {clone_cmds}"
+        )
+
+    def test_skips_already_cloned_repos(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        dest = tmp_path / "workspace"
+        # Pre-create one repo as if already cloned.
+        already = dest / "AInvirion" / "aiproxyguard" / ".git"
+        already.mkdir(parents=True)
+
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "", "")
+            result = runner.invoke(
+                app,
+                ["repos", "clone-all", str(dest), "--config", str(repos_config)],
+            )
+
+        assert result.exit_code == 0
+        clone_cmds = [
+            c for c in [args[0] for args, _ in mock_run.call_args_list]
+            if c[:2] == ["git", "clone"]
+        ]
+        # Only 2 clones — the third was skipped.
+        assert len(clone_cmds) == 2
+
+
+class TestPullAll:
+    def test_skips_repos_that_are_not_cloned(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        dest = tmp_path / "workspace"
+        with patch("subprocess.run") as mock_run:
+            result = runner.invoke(
+                app,
+                ["repos", "pull-all", str(dest), "--config", str(repos_config)],
+            )
+        assert result.exit_code == 0
+        assert "not cloned" in result.output
+        # No git was invoked because nothing was cloned.
+        assert mock_run.call_count == 0
+
+    def test_pull_uses_correct_flags_and_cwd(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        """pull-all on a clean tree must call `git -C TARGET pull --ff-only --quiet`."""
+        dest = tmp_path / "workspace"
+        target = dest / "AInvirion" / "aiproxyguard"
+        (target / ".git").mkdir(parents=True)
+
+        calls: list[list[str]] = []
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            calls.append(cmd)
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = runner.invoke(
+                app,
+                [
+                    "repos", "pull-all", str(dest),
+                    "--config", str(repos_config),
+                    "--filter", "aiproxyguard",
+                ],
+            )
+
+        assert result.exit_code == 0
+        target_resolved = str(target.resolve())
+        # Clean tree: status check, then pull (no fetch path).
+        expected_status = ["git", "-C", target_resolved, "status", "--porcelain"]
+        expected_pull = ["git", "-C", target_resolved, "pull", "--ff-only", "--quiet"]
+        assert expected_status in calls
+        assert expected_pull in calls
+
+    def test_dirty_tree_fetch_failure_is_reported_as_failed(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        """If `git fetch` returns non-zero on a dirty tree, count it as failed (not dirty)."""
+        dest = tmp_path / "workspace"
+        target = dest / "AInvirion" / "aiproxyguard"
+        (target / ".git").mkdir(parents=True)
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if "status" in cmd:
+                return subprocess.CompletedProcess(cmd, 0, stdout=" M file.txt\n", stderr="")
+            if "fetch" in cmd:
+                return subprocess.CompletedProcess(cmd, 128, stdout="", stderr="auth failed")
+            return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            result = runner.invoke(
+                app,
+                [
+                    "repos", "pull-all", str(dest),
+                    "--config", str(repos_config),
+                    "--filter", "aiproxyguard",
+                ],
+            )
+
+        # Failed because fetch errored out.
+        assert result.exit_code == 1
+        assert "failed" in result.output
+        assert "auth failed" in result.output
+        # Crucially, it must NOT have been counted as a successful "dirty — fetched only".
+        assert "fetched only" not in result.output
+
+
+class TestStatus:
+    def test_shows_not_cloned_for_missing_directories(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        result = runner.invoke(
+            app,
+            ["repos", "status", str(tmp_path / "workspace"), "--config", str(repos_config)],
+        )
+        assert result.exit_code == 0
+        assert "not cloned" in result.output
+
+
+class TestRepoConfigNameValidation:
+    """Belt-and-suspenders: malicious manifest names must be rejected at config load."""
+
+    def test_traversal_name_is_rejected(self, sample_config_dict: dict, tmp_path: Path) -> None:
+        from ctrlrelay.core.config import ConfigError, load_config
+
+        sample_config_dict["repos"] = [
+            {"name": "foo/../../tmp/pwn", "local_path": "~/pwn"},
+        ]
+        path = tmp_path / "orchestrator.yaml"
+        path.write_text(yaml.dump(sample_config_dict))
+
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_extra_slash_name_is_rejected(self, sample_config_dict: dict, tmp_path: Path) -> None:
+        from ctrlrelay.core.config import ConfigError, load_config
+
+        sample_config_dict["repos"] = [
+            {"name": "owner/sub/repo", "local_path": "~/x"},
+        ]
+        path = tmp_path / "orchestrator.yaml"
+        path.write_text(yaml.dump(sample_config_dict))
+
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_well_formed_name_passes(self, sample_config_dict: dict, tmp_path: Path) -> None:
+        from ctrlrelay.core.config import load_config
+
+        sample_config_dict["repos"] = [
+            {"name": "AInvirion/aiproxyguard-cloud.v2", "local_path": "~/x"},
+        ]
+        path = tmp_path / "orchestrator.yaml"
+        path.write_text(yaml.dump(sample_config_dict))
+
+        cfg = load_config(path)
+        assert cfg.repos[0].name == "AInvirion/aiproxyguard-cloud.v2"


### PR DESCRIPTION
## Summary
- New `ctrlrelay repos clone-all DEST` / `pull-all DEST` / `status DEST` commands that read `config/orchestrator.yaml` (79 repos) and stand up an isolated workspace at `DEST/<org>/<repo>`. Replaces the legacy `bkp/sync` shell scripts that broke when the manifest moved during the rewrite.
- Remotes derived as `git@github.com:{name}.git`; configured `local_path` ignored when `DEST` is passed, so existing `~/Projects/...` checkouts stay untouched.
- Hardening from an independent codex review (see Test plan): `RepoConfig.name` validator rejects path traversal at config load; `pull-all` checks `git status` + `git fetch` returncodes (no more silent failures); `status` no longer crashes on non-numeric `rev-list` output.

## Test plan
- [ ] `uv run pytest tests/test_cli_repos.py tests/test_config.py -v` (13 new tests, all pass locally)
- [ ] `uv run ctrlrelay repos clone-all ~/code/test --dry-run --filter SemClone` shows `<DEST>/SemClone/<repo>` paths
- [ ] `uv run ctrlrelay repos clone-all ~/code/test --filter SemClone` actually clones (one-time check on a real workspace)
- [ ] `uv run ctrlrelay repos pull-all ~/code/test --filter SemClone` fast-forwards
- [ ] CI green on the branch