### PR TITLE
fix(install): set PYTHONUNBUFFERED=1 in launchd / systemd templates

### DIFF
--- a/src/ctrlrelay/templates/launchd/bridge.plist.template
+++ b/src/ctrlrelay/templates/launchd/bridge.plist.template
@@ -16,7 +16,12 @@
         <key>CTRLRELAY_TELEGRAM_TOKEN</key>
         <string>${CTRLRELAY_TELEGRAM_TOKEN}</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- Without PYTHONUNBUFFERED, ctrlrelay's stdout sits in Python's
+             stdio buffer instead of flushing line-by-line, making
+             `tail -f ~/.ctrlrelay/logs/bridge.log` lag noticeably. -->
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
     </dict>
     <key>WorkingDirectory</key>
     <string>${WORKDIR}</string>

--- a/src/ctrlrelay/templates/launchd/poller.plist.template
+++ b/src/ctrlrelay/templates/launchd/poller.plist.template
@@ -18,7 +18,12 @@
         <key>CTRLRELAY_TELEGRAM_TOKEN</key>
         <string>${CTRLRELAY_TELEGRAM_TOKEN}</string>
         <key>PATH</key>
-        <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <string>/opt/homebrew/bin:/opt/homebrew/sbin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
+        <!-- Without PYTHONUNBUFFERED, ctrlrelay's stdout sits in Python's
+             stdio buffer instead of flushing line-by-line, making
+             `tail -f ~/.ctrlrelay/logs/poller.log` lag noticeably. -->
+        <key>PYTHONUNBUFFERED</key>
+        <string>1</string>
     </dict>
     <key>WorkingDirectory</key>
     <string>${WORKDIR}</string>

--- a/src/ctrlrelay/templates/systemd/bridge.service.template
+++ b/src/ctrlrelay/templates/systemd/bridge.service.template
@@ -6,6 +6,10 @@ After=network-online.target
 Type=simple
 WorkingDirectory=${WORKDIR}
 Environment=CTRLRELAY_TELEGRAM_TOKEN=${CTRLRELAY_TELEGRAM_TOKEN}
+# Without PYTHONUNBUFFERED, ctrlrelay's stdout sits in Python's stdio
+# buffer instead of flushing line-by-line, making `tail -f` and
+# `journalctl -f` lag noticeably.
+Environment=PYTHONUNBUFFERED=1
 ExecStart=${CTRLRELAY_BIN} bridge start --foreground
 Restart=always
 RestartSec=5

--- a/src/ctrlrelay/templates/systemd/poller.service.template
+++ b/src/ctrlrelay/templates/systemd/poller.service.template
@@ -6,6 +6,10 @@ After=network-online.target ctrlrelay-bridge.service
 Type=simple
 WorkingDirectory=${WORKDIR}
 Environment=CTRLRELAY_TELEGRAM_TOKEN=${CTRLRELAY_TELEGRAM_TOKEN}
+# Without PYTHONUNBUFFERED, ctrlrelay's stdout sits in Python's stdio
+# buffer instead of flushing line-by-line, making `tail -f` and
+# `journalctl -f` lag noticeably.
+Environment=PYTHONUNBUFFERED=1
 ExecStart=${CTRLRELAY_BIN} poller start --foreground --interval ${POLLER_INTERVAL}
 Restart=always
 RestartSec=5

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -101,6 +101,18 @@ class TestRenderLaunchd:
             assert "${CTRLRELAY_TELEGRAM_TOKEN}" in u.content
             assert "CTRLRELAY_TELEGRAM_TOKEN" in u.unresolved
 
+    def test_pythonunbuffered_set_in_both_units(
+        self, workdir: Path, target_dir: Path
+    ) -> None:
+        # PYTHONUNBUFFERED=1 is load-bearing for live log tailing under
+        # launchd — without it, Python buffers stdout and `tail -f` lags
+        # by minutes. Both bridge and poller need it; assert so the
+        # template can't quietly drop it again.
+        units = render_launchd(workdir=workdir, target_dir=target_dir)
+        for u in units:
+            assert "<key>PYTHONUNBUFFERED</key>" in u.content
+            assert "<string>1</string>" in u.content
+
     def test_poller_interval_is_substituted(
         self, workdir: Path, target_dir: Path
     ) -> None:
@@ -119,6 +131,15 @@ class TestRenderSystemd:
         units = render_systemd(workdir=workdir, target_dir=target_dir)
         names = sorted(u.target_path.name for u in units)
         assert names == ["ctrlrelay-bridge.service", "ctrlrelay-poller.service"]
+
+    def test_pythonunbuffered_set_in_both_units(
+        self, workdir: Path, target_dir: Path
+    ) -> None:
+        # Same buffering concern as the launchd plists — journalctl -f
+        # also waits on stdio buffers if PYTHONUNBUFFERED is unset.
+        units = render_systemd(workdir=workdir, target_dir=target_dir)
+        for u in units:
+            assert "Environment=PYTHONUNBUFFERED=1" in u.content
 
     def test_systemd_units_have_install_section(
         self, workdir: Path, target_dir: Path


### PR DESCRIPTION
## Summary

Spotted while migrating an existing install to the new \`ctrlrelay install\` command — the old hand-written plist had \`PYTHONUNBUFFERED=1\` and the new template didn't.

Without it, ctrlrelay's stdout sits in Python's stdio buffer instead of flushing line-by-line. \`tail -f ~/.ctrlrelay/logs/{bridge,poller}.log\` (launchd) and \`journalctl -fu ctrlrelay-{bridge,poller}\` (systemd) lag by minutes, which makes \"is the daemon hung or just quiet?\" impossible to answer during incidents.

Adds the env var to all four templates and a regression test per platform.

## Test plan

- [x] \`pytest tests/test_install.py\` — 20 passed (was 18)
- [x] \`ruff check\` clean
- [x] Verified the rendered plist now matches the working hand-written version