### PR TITLE
feat(personalization): cross-machine sync of operator state via private GitHub repo

### DIFF
--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -52,6 +52,70 @@ dashboard:
 schedules:
   secops_cron: "0 6 * * *"
 
+# Optional: cross-machine personalization sync.
+#
+# A separate (typically PRIVATE) GitHub repo holds the operator's Claude
+# config, per-project memory, spec/superpower outputs, and workspace
+# planning notes — anything that survives across sessions and computers
+# but doesn't belong inside any project's source tree. ctrlrelay clones
+# the repo to `checkout_path` and wires the symlinks in `paths`.
+#
+# Per-machine work happens on a `personalization/<node_id>` branch; push
+# rebases onto `main` (no force-push, ever), so two machines pushing
+# concurrently never overwrite each other's deltas.
+#
+# Slice 1: manual `ctrlrelay personalization init/status/push/pull`.
+# Daemon scheduling, Telegram conflict escalation, and adopt-flow for
+# pre-existing target files are deferred to Slice 2+.
+#
+# Placeholders allowed in `source` and `target`:
+#   ${HOME}             -- current user's home
+#   ${PROJECT}          -- <owner>-<repo> flat slug (project_scoped only)
+#   ${PROJECT_ENCODED}  -- Claude's path encoding (project_scoped only)
+#   ${PROJECT_LOCAL}    -- absolute path of the repo's local checkout
+#   ${PROJECT_PARENT}   -- parent dir of ${PROJECT_LOCAL}
+#
+# personalization:
+#   repo: "oscarvalenzuelab/dotclaude"
+#   # checkout_path: "~/.ctrlrelay/personalization"   # default
+#   # main_branch: "main"                              # default
+#   # node_id: "macbook"   # default: top-level node_id (i.e. hostname)
+#   paths:
+#     # Global Claude config — fixed paths, one entry each so individual
+#     # files can come and go without ripping a whole `~/.claude/` symlink.
+#     - source: "global/CLAUDE.md"
+#       target: "~/.claude/CLAUDE.md"
+#     - source: "global/skills/"
+#       target: "~/.claude/skills/"
+#     - source: "global/agents/"
+#       target: "~/.claude/agents/"
+#     - source: "global/commands/"
+#       target: "~/.claude/commands/"
+#     - source: "global/keybindings.json"
+#       target: "~/.claude/keybindings.json"
+#
+#     # Per-project Claude memory. ${PROJECT_ENCODED} resolves at
+#     # link-time from the repo's local_path, so the same config works
+#     # on machines with different home directories or repo layouts.
+#     - source: "claude-memory/${PROJECT}/"
+#       target: "~/.claude/projects/${PROJECT_ENCODED}/memory/"
+#       project_scoped: true
+#
+#     # Spec / superpower outputs Claude writes per the convention
+#     # documented in templates/global-CLAUDE.md.snippet. Lives next to
+#     # the repo (NOT inside it) so the project's own git history stays
+#     # uncontaminated.
+#     - source: "specs/${PROJECT}/"
+#       target: "${PROJECT_PARENT}/specs/${PROJECT}/"
+#       project_scoped: true
+#
+#     # Workspace-level planning docs (multi-repo workspace, e.g. a
+#     # research project that spans 3 repos under a single parent dir).
+#     # Use one entry per workspace; if you accumulate many, this will
+#     # be promoted to a first-class `workspaces:` config block.
+#     # - source: "workspaces/RESEARCH-DMP/"
+#     #   target: "~/Projects/RESEARCH/DMP/notes/"
+
 repos: []
   # Example repo configuration:
   # - name: "owner/repo"

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -70,7 +70,8 @@ schedules:
 #
 # Placeholders allowed in `source` and `target`:
 #   ${HOME}             -- current user's home
-#   ${PROJECT}          -- <owner>-<repo> flat slug (project_scoped only)
+#   ${PROJECT}          -- <owner>--<repo> flat slug (project_scoped only;
+#                          double hyphen avoids collisions like a-b/c vs a/b-c)
 #   ${PROJECT_ENCODED}  -- Claude's path encoding (project_scoped only)
 #   ${PROJECT_LOCAL}    -- absolute path of the repo's local checkout
 #   ${PROJECT_PARENT}   -- parent dir of ${PROJECT_LOCAL}

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -2083,8 +2083,14 @@ def personalization_push(
     the conflicting files are listed; resolve them in the checkout (the
     target of any symlinked path), commit manually, and re-run push.
     """
+    from ctrlrelay.personalization.manager import PersonalizationError
+
     mgr = _make_personalization_manager(config_path)
-    result = mgr.push(message=message)
+    try:
+        result = mgr.push(message=message)
+    except PersonalizationError as e:
+        console.print(f"[red]Push failed:[/red] {e}")
+        raise typer.Exit(1)
     console.print(result.summary)
     if result.conflict_files:
         console.print("[yellow]conflicts:[/yellow]")
@@ -2104,8 +2110,14 @@ def personalization_pull(
     ),
 ) -> None:
     """Fetch + rebase the local working branch and re-wire symlinks."""
+    from ctrlrelay.personalization.manager import PersonalizationError
+
     mgr = _make_personalization_manager(config_path)
-    result = mgr.pull()
+    try:
+        result = mgr.pull()
+    except PersonalizationError as e:
+        console.print(f"[red]Pull failed:[/red] {e}")
+        raise typer.Exit(1)
     console.print(result.summary)
     if result.conflict_files:
         console.print("[yellow]conflicts:[/yellow]")

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1989,6 +1989,132 @@ def poller_status(
     raise typer.Exit(1)
 
 
+personalization_app = typer.Typer(help="Personalization sync (cross-machine operator state).")
+app.add_typer(personalization_app, name="personalization")
+
+
+def _load_config_or_exit(config_path: str | None):
+    """Resolve --config and load it, mapping ConfigError to a typer.Exit."""
+    path = _resolve_config_or_exit(config_path)
+    try:
+        return load_config(path)
+    except ConfigError as e:
+        console.print(f"[red]Error loading config:[/red] {e}")
+        raise typer.Exit(1)
+
+
+def _make_personalization_manager(config_path: str | None):
+    """Return a configured PersonalizationManager or exit with a helpful error."""
+    from ctrlrelay.personalization import PersonalizationManager
+    from ctrlrelay.personalization.manager import PersonalizationError
+
+    config = _load_config_or_exit(config_path)
+    if config.personalization is None:
+        console.print(
+            "[red]Error:[/red] No personalization config in orchestrator.yaml. "
+            "Add a `personalization:` section (see config/orchestrator.yaml.example) "
+            "and re-run."
+        )
+        raise typer.Exit(1)
+    try:
+        return PersonalizationManager(config)
+    except PersonalizationError as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise typer.Exit(1)
+
+
+@personalization_app.command("init")
+def personalization_init(
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to orchestrator.yaml (default: auto-discover; see $CTRLRELAY_CONFIG).",
+    ),
+) -> None:
+    """Clone the personalization repo and wire symlinks.
+
+    Idempotent: re-running on a machine that already cloned the repo
+    converges branch + symlinks rather than failing.
+    """
+    from ctrlrelay.personalization.manager import PersonalizationError
+
+    mgr = _make_personalization_manager(config_path)
+    try:
+        summary = mgr.init()
+    except PersonalizationError as e:
+        console.print(f"[red]Init failed:[/red] {e}")
+        raise typer.Exit(1)
+    console.print(summary)
+
+
+@personalization_app.command("status")
+def personalization_status(
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to orchestrator.yaml (default: auto-discover; see $CTRLRELAY_CONFIG).",
+    ),
+) -> None:
+    """Show working-tree state and per-symlink correctness. Read-only."""
+    mgr = _make_personalization_manager(config_path)
+    console.print(mgr.status())
+
+
+@personalization_app.command("push")
+def personalization_push(
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to orchestrator.yaml (default: auto-discover; see $CTRLRELAY_CONFIG).",
+    ),
+    message: str | None = typer.Option(
+        None,
+        "--message",
+        "-m",
+        help="Commit message override (default: auto-generated from branch name).",
+    ),
+) -> None:
+    """Commit, rebase onto main, and push. Aborts the rebase on conflict.
+
+    On conflict the working tree is restored to its pre-rebase state and
+    the conflicting files are listed; resolve them in the checkout (the
+    target of any symlinked path), commit manually, and re-run push.
+    """
+    mgr = _make_personalization_manager(config_path)
+    result = mgr.push(message=message)
+    console.print(result.summary)
+    if result.conflict_files:
+        console.print("[yellow]conflicts:[/yellow]")
+        for f in result.conflict_files:
+            console.print(f"  {f}")
+    if not result.success:
+        raise typer.Exit(1)
+
+
+@personalization_app.command("pull")
+def personalization_pull(
+    config_path: str | None = typer.Option(
+        None,
+        "--config",
+        "-c",
+        help="Path to orchestrator.yaml (default: auto-discover; see $CTRLRELAY_CONFIG).",
+    ),
+) -> None:
+    """Fetch + rebase the local working branch and re-wire symlinks."""
+    mgr = _make_personalization_manager(config_path)
+    result = mgr.pull()
+    console.print(result.summary)
+    if result.conflict_files:
+        console.print("[yellow]conflicts:[/yellow]")
+        for f in result.conflict_files:
+            console.print(f"  {f}")
+    if not result.success:
+        raise typer.Exit(1)
+
+
 @app.command("version")
 def version() -> None:
     """Print the package version."""

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -334,6 +334,19 @@ class PersonalizationPath(BaseModel):
                 "${HOME}; sources are paths inside the personalization "
                 "checkout and cannot reference the user's home directory"
             )
+        # Reject git pathspec magic prefixes/characters (Codex pass
+        # 17). ``:(top)`` / ``:!`` / leading ``:`` would otherwise
+        # let ``git add -- <rel>`` interpret the config value as
+        # a pathspec rather than a literal filename and reach
+        # outside the allowlist. ``GIT_LITERAL_PATHSPECS=1`` in the
+        # subprocess env is the defense-in-depth, but failing config
+        # load surfaces operator typos earlier.
+        if ":" in self.source:
+            raise ValueError(
+                f"personalization path source {self.source!r} contains "
+                "':'; ':' is reserved by git for pathspec magic and "
+                "cannot appear in a configured source path"
+            )
         for side, value in (("source", self.source), ("target", self.target)):
             for segment in value.split("/"):
                 if segment == "..":

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -459,11 +459,48 @@ class Config(BaseModel):
 
         Falls back to the top-level ``node_id`` when ``personalization.node_id``
         is unset. Returns ``None`` if personalization isn't configured.
+
+        ``validate_effective_personalization_node_id`` ensures the
+        effective node id is git-branch-safe at load time, so this
+        property never returns a name git would reject.
         """
         if self.personalization is None:
             return None
         node = self.personalization.node_id or self.node_id
         return f"personalization/{node}"
+
+    @model_validator(mode="after")
+    def validate_effective_personalization_node_id(self) -> "Config":
+        """Reject configs where the EFFECTIVE personalization node_id
+        (after fallback to top-level ``node_id`` / hostname) is not
+        safe as part of a git branch name.
+
+        ``Personalization.node_id`` is already validated when set
+        explicitly, but the fallback path takes the top-level
+        ``node_id`` whose constraints are looser (it's used for
+        non-git purposes too — dashboard identity, etc.). Without
+        this check, a host whose ``socket.gethostname()`` returns
+        ``"Oscar's MacBook"`` would load fine and only fail later
+        when ``ctrlrelay personalization init`` shells out to
+        ``git checkout -b personalization/Oscar's MacBook``.
+        """
+        if self.personalization is None:
+            return self
+        if self.personalization.node_id is not None:
+            # Already validated by Personalization.validate_node_id.
+            return self
+        node = self.node_id
+        if not node or node.startswith("-") or any(
+            c in node for c in " \t\n\\\"'$;|&<>/"
+        ):
+            raise ValueError(
+                f"effective personalization node_id {node!r} (from top-level "
+                "node_id) is not safe as part of a git branch name; either "
+                "set personalization.node_id explicitly to a branch-safe "
+                "value (letters, digits, '.', '_', '-') or change the "
+                "top-level node_id"
+            )
+        return self
 
     @model_validator(mode="after")
     def derive_repo_local_paths(self) -> "Config":

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -232,20 +232,19 @@ _GIT_BRANCH_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
 def _is_safe_git_ref_component(value: str) -> bool:
     """Return True iff ``value`` is safe as part of a git branch/ref name.
 
-    Stricter than ``git check-ref-format --branch`` on purpose: the
-    config's documented allow-list is exactly ``letters, digits, '.',
-    '_', '-'`` (the same set we use for repo names) plus the rule that
-    ``..`` and a leading ``-``/``.`` are disallowed. Earlier validators
-    used a denylist for shell metacharacters which silently accepted
-    things git later rejects (Codex review pass 7 caught e.g.
-    ``main_branch: "main:backup"`` and ``node_id: "foo..bar"`` slipping
-    through). Doing this as an explicit allow-list keeps the config
-    error synchronous with load and avoids late git failures during
-    ``init``/``push``.
+    Allow-list: ``letters, digits, '.', '_', '-'`` (Codex pass 7).
+    Plus the structural rules ``git check-ref-format --branch``
+    enforces — no leading ``-``/``.``, no ``..``, no trailing ``.``,
+    no ``.lock`` suffix (Codex pass 8 caught the trailing-``.``
+    case slipping through). Doing this as an explicit allow-list
+    keeps the config error synchronous with load and avoids late git
+    failures during ``init``/``push``.
     """
     if not value:
         return False
     if value.startswith("-") or value.startswith("."):
+        return False
+    if value.endswith(".") or value.endswith(".lock"):
         return False
     if ".." in value:
         return False
@@ -314,6 +313,26 @@ class PersonalizationPath(BaseModel):
                     "placeholders but project_scoped is false; either set "
                     "project_scoped: true or remove the placeholders"
                 )
+
+        # ``source`` is documented as a path inside the personalization
+        # repo (joined to ``checkout_path`` at wire time). Reject ``..``
+        # segments and absolute paths so an entry can't escape the
+        # checkout, e.g. ``source: ../secret`` (Codex pass 8 caught
+        # this). Also reject ``..`` in target — if a target uses ``..``
+        # we may still wire a symlink, but it makes auditing harder
+        # for no upside.
+        if self.source.startswith("/"):
+            raise ValueError(
+                f"personalization path source {self.source!r} must be "
+                "relative to the personalization checkout, not absolute"
+            )
+        for side, value in (("source", self.source), ("target", self.target)):
+            for segment in value.split("/"):
+                if segment == "..":
+                    raise ValueError(
+                        f"personalization path {side} {value!r} contains "
+                        "'..' segment; paths must not escape their root"
+                    )
 
         # File-vs-dir agreement: if one side ends with '/', the other must too.
         src_is_dir = self.source.endswith("/")

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -226,6 +226,32 @@ class RepoConfig(BaseModel):
         return v
 
 
+_GIT_BRANCH_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+$")
+
+
+def _is_safe_git_ref_component(value: str) -> bool:
+    """Return True iff ``value`` is safe as part of a git branch/ref name.
+
+    Stricter than ``git check-ref-format --branch`` on purpose: the
+    config's documented allow-list is exactly ``letters, digits, '.',
+    '_', '-'`` (the same set we use for repo names) plus the rule that
+    ``..`` and a leading ``-``/``.`` are disallowed. Earlier validators
+    used a denylist for shell metacharacters which silently accepted
+    things git later rejects (Codex review pass 7 caught e.g.
+    ``main_branch: "main:backup"`` and ``node_id: "foo..bar"`` slipping
+    through). Doing this as an explicit allow-list keeps the config
+    error synchronous with load and avoids late git failures during
+    ``init``/``push``.
+    """
+    if not value:
+        return False
+    if value.startswith("-") or value.startswith("."):
+        return False
+    if ".." in value:
+        return False
+    return bool(_GIT_BRANCH_NAME_RE.match(value))
+
+
 _ALLOWED_PATH_PLACEHOLDERS = frozenset({
     "HOME",
     "PROJECT",
@@ -348,11 +374,12 @@ class Personalization(BaseModel):
     @field_validator("main_branch")
     @classmethod
     def validate_main_branch(cls, v: str) -> str:
-        # Refuse anything that's not a plain branch name. The value is
-        # spliced into ``git`` invocations, so option-like inputs (``--`` or
-        # leading dashes) and shell metacharacters must not get through.
-        if not v or v.startswith("-") or any(c in v for c in " \t\n\\\"'$;|&<>"):
-            raise ValueError(f"invalid main_branch {v!r}")
+        if not _is_safe_git_ref_component(v):
+            raise ValueError(
+                f"invalid main_branch {v!r} "
+                "(allowed: letters, digits, '.', '_', '-'; no leading "
+                "'-' or '.', no '..')"
+            )
         return v
 
     @field_validator("node_id")
@@ -360,10 +387,11 @@ class Personalization(BaseModel):
     def validate_node_id(cls, v: str | None) -> str | None:
         if v is None:
             return None
-        if not v or v.startswith("-") or any(c in v for c in " \t\n\\\"'$;|&<>/"):
+        if not _is_safe_git_ref_component(v):
             raise ValueError(
                 f"invalid personalization node_id {v!r} "
-                "(used as part of a git branch name)"
+                "(used as a git branch component; allowed: letters, "
+                "digits, '.', '_', '-'; no leading '-' or '.', no '..')"
             )
         return v
 
@@ -489,16 +517,14 @@ class Config(BaseModel):
         if self.personalization.node_id is not None:
             # Already validated by Personalization.validate_node_id.
             return self
-        node = self.node_id
-        if not node or node.startswith("-") or any(
-            c in node for c in " \t\n\\\"'$;|&<>/"
-        ):
+        if not _is_safe_git_ref_component(self.node_id):
             raise ValueError(
-                f"effective personalization node_id {node!r} (from top-level "
-                "node_id) is not safe as part of a git branch name; either "
-                "set personalization.node_id explicitly to a branch-safe "
-                "value (letters, digits, '.', '_', '-') or change the "
-                "top-level node_id"
+                f"effective personalization node_id {self.node_id!r} (from "
+                "top-level node_id) is not safe as part of a git branch "
+                "name; either set personalization.node_id explicitly to a "
+                "branch-safe value (letters, digits, '.', '_', '-'; no "
+                "leading '-' or '.', no '..') or change the top-level "
+                "node_id"
             )
         return self
 

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -226,6 +226,148 @@ class RepoConfig(BaseModel):
         return v
 
 
+_ALLOWED_PATH_PLACEHOLDERS = frozenset({
+    "HOME",
+    "PROJECT",
+    "PROJECT_ENCODED",
+    "PROJECT_LOCAL",
+    "PROJECT_PARENT",
+})
+
+_PROJECT_PLACEHOLDERS = frozenset({
+    "PROJECT",
+    "PROJECT_ENCODED",
+    "PROJECT_LOCAL",
+    "PROJECT_PARENT",
+})
+
+_PLACEHOLDER_RE = re.compile(r"\$\{([A-Z_]+)\}")
+
+
+def _extract_placeholders(text: str) -> set[str]:
+    return set(_PLACEHOLDER_RE.findall(text))
+
+
+class PersonalizationPath(BaseModel):
+    """One source-to-target sync entry inside the personalization repo.
+
+    ``source`` is a path inside the personalization repo working tree
+    (e.g. ``global/CLAUDE.md`` or ``claude-memory/${PROJECT}/``).
+    ``target`` is the on-disk symlink destination outside the repo
+    (e.g. ``~/.claude/CLAUDE.md`` or ``${PROJECT_PARENT}/specs/${PROJECT}/``).
+
+    A trailing ``/`` on either side denotes a directory; a missing slash
+    denotes a single file. The two sides must agree — a directory source
+    cannot map to a file target. Validation enforces this at load time.
+
+    ``project_scoped: true`` makes the entry iterate over ``config.repos``
+    at wire-time. A non-project-scoped entry that references project
+    placeholders is rejected: it would resolve to garbage.
+    """
+
+    source: str
+    target: str
+    project_scoped: bool = False
+
+    @model_validator(mode="after")
+    def validate_placeholders_and_shape(self) -> "PersonalizationPath":
+        for side, value in (("source", self.source), ("target", self.target)):
+            if not value:
+                raise ValueError(f"personalization path {side} must not be empty")
+            placeholders = _extract_placeholders(value)
+            unknown = placeholders - _ALLOWED_PATH_PLACEHOLDERS
+            if unknown:
+                raise ValueError(
+                    f"personalization path {side} {value!r} references unknown "
+                    f"placeholders: {sorted(unknown)} "
+                    f"(allowed: {sorted(_ALLOWED_PATH_PLACEHOLDERS)})"
+                )
+            if not self.project_scoped and (placeholders & _PROJECT_PLACEHOLDERS):
+                raise ValueError(
+                    f"personalization path {side} {value!r} uses project "
+                    "placeholders but project_scoped is false; either set "
+                    "project_scoped: true or remove the placeholders"
+                )
+
+        # File-vs-dir agreement: if one side ends with '/', the other must too.
+        src_is_dir = self.source.endswith("/")
+        tgt_is_dir = self.target.endswith("/")
+        if src_is_dir != tgt_is_dir:
+            raise ValueError(
+                f"personalization path source {self.source!r} and target "
+                f"{self.target!r} disagree on directory vs file (trailing "
+                "slash must match on both)"
+            )
+        return self
+
+
+class Personalization(BaseModel):
+    """Personalization sync configuration.
+
+    A separate (typically private) GitHub repo holds the operator's
+    cross-machine context: global Claude config, per-project memory,
+    spec/superpower outputs, workspace planning docs. ctrlrelay clones
+    it once per machine and wires symlinks per the ``paths`` list. Per-
+    machine work happens on a ``personalization/<node_id>`` branch that
+    auto-rebases onto ``main_branch`` on push, so concurrent edits across
+    machines never force-push each other's deltas.
+    """
+
+    repo: str
+    checkout_path: Path = Field(
+        default_factory=lambda: Path("~/.ctrlrelay/personalization").expanduser()
+    )
+    # Branch name on the remote that holds the canonical state. ``push``
+    # rebases the per-node working branch onto this; ``pull`` resets the
+    # local copy of this branch to match origin so a fresh wire reflects
+    # what the rest of the fleet has agreed on.
+    main_branch: str = "main"
+    # Per-machine working branch is ``personalization/<node_id>``. When
+    # unset, the parent ``Config`` substitutes its top-level ``node_id``
+    # (which itself defaults to ``socket.gethostname()``).
+    node_id: str | None = None
+    paths: list[PersonalizationPath] = Field(default_factory=list)
+
+    @field_validator("repo")
+    @classmethod
+    def validate_repo(cls, v: str) -> str:
+        if not _REPO_NAME_RE.match(v):
+            raise ValueError(
+                f"personalization repo {v!r} must match 'owner/repo' "
+                f"(letters, digits, '.', '_', '-')"
+            )
+        return v
+
+    @field_validator("checkout_path", mode="before")
+    @classmethod
+    def expand_checkout_path(cls, v: Any) -> Any:
+        if isinstance(v, str):
+            return Path(v).expanduser()
+        return v
+
+    @field_validator("main_branch")
+    @classmethod
+    def validate_main_branch(cls, v: str) -> str:
+        # Refuse anything that's not a plain branch name. The value is
+        # spliced into ``git`` invocations, so option-like inputs (``--`` or
+        # leading dashes) and shell metacharacters must not get through.
+        if not v or v.startswith("-") or any(c in v for c in " \t\n\\\"'$;|&<>"):
+            raise ValueError(f"invalid main_branch {v!r}")
+        return v
+
+    @field_validator("node_id")
+    @classmethod
+    def validate_node_id(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        if not v or v.startswith("-") or any(c in v for c in " \t\n\\\"'$;|&<>/"):
+            raise ValueError(
+                f"invalid personalization node_id {v!r} "
+                "(used as part of a git branch name)"
+            )
+        return v
+
+
 class SchedulesConfig(BaseModel):
     """Cron schedules for background jobs run by the poller daemon.
 
@@ -266,6 +408,7 @@ class Config(BaseModel):
     transport: TransportConfig
     dashboard: DashboardConfig = Field(default_factory=DashboardConfig)
     schedules: SchedulesConfig = Field(default_factory=SchedulesConfig)
+    personalization: Personalization | None = None
     repos: list[RepoConfig] = Field(default_factory=list)
 
     @model_validator(mode="before")
@@ -310,6 +453,17 @@ class Config(BaseModel):
         ``config.claude.binary`` keep working. New code should prefer
         ``config.agent.*``."""
         return self.agent
+
+    def personalization_branch(self) -> str | None:
+        """Per-machine working branch name for personalization sync.
+
+        Falls back to the top-level ``node_id`` when ``personalization.node_id``
+        is unset. Returns ``None`` if personalization isn't configured.
+        """
+        if self.personalization is None:
+            return None
+        node = self.personalization.node_id or self.node_id
+        return f"personalization/{node}"
 
     @model_validator(mode="after")
     def derive_repo_local_paths(self) -> "Config":

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -317,14 +317,22 @@ class PersonalizationPath(BaseModel):
         # ``source`` is documented as a path inside the personalization
         # repo (joined to ``checkout_path`` at wire time). Reject ``..``
         # segments and absolute paths so an entry can't escape the
-        # checkout, e.g. ``source: ../secret`` (Codex pass 8 caught
-        # this). Also reject ``..`` in target — if a target uses ``..``
-        # we may still wire a symlink, but it makes auditing harder
-        # for no upside.
+        # checkout, e.g. ``source: ../secret`` (Codex pass 8). Also
+        # reject ``${HOME}`` in source: it's a valid placeholder for
+        # targets, but in source it's nonsensical (would resolve to a
+        # subdir literally named after $HOME, which the wire code
+        # would silently mark as source-missing — Codex pass 11).
+        # Reject ``..`` in target too for auditability.
         if self.source.startswith("/"):
             raise ValueError(
                 f"personalization path source {self.source!r} must be "
                 "relative to the personalization checkout, not absolute"
+            )
+        if "${HOME}" in self.source:
+            raise ValueError(
+                f"personalization path source {self.source!r} uses "
+                "${HOME}; sources are paths inside the personalization "
+                "checkout and cannot reference the user's home directory"
             )
         for side, value in (("source", self.source), ("target", self.target)):
             for segment in value.split("/"):

--- a/src/ctrlrelay/personalization/__init__.py
+++ b/src/ctrlrelay/personalization/__init__.py
@@ -1,0 +1,26 @@
+"""Personalization sync — operator state shared across machines.
+
+A separate (typically private) GitHub repo holds context that survives
+across sessions and computers but doesn't belong inside any project's
+own source tree: global Claude config, per-project memory, spec docs,
+workspace planning notes. ctrlrelay clones this repo once per machine
+and wires symlinks per the ``personalization.paths`` config so that
+agent and operator writes flow straight into the working tree of the
+checkout, ready to commit.
+
+See ``manager.PersonalizationManager`` for the lifecycle.
+"""
+
+from ctrlrelay.personalization.manager import PersonalizationManager
+from ctrlrelay.personalization.paths import (
+    TemplateContext,
+    encode_project_path,
+    resolve_template,
+)
+
+__all__ = [
+    "PersonalizationManager",
+    "TemplateContext",
+    "encode_project_path",
+    "resolve_template",
+]

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -377,22 +377,24 @@ class PersonalizationManager:
                     conflict_files=files,
                 )
 
-            # Iteration 1: plain push (creates the per-machine branch
-            # on the remote if missing, FF otherwise).
-            # Iteration 2+: ``--force-with-lease``. After an FF-
-            # rejection on the previous iteration, the rebase that
-            # opens this iteration rewrites our local commit on top
-            # of the new origin/main, so a plain push to the per-
-            # machine branch is non-FF on the remote (Codex review
-            # pass 2 caught this). Lease checks against the local
-            # remote-tracking ref, which the fetch above just
-            # refreshed — so this only force-pushes when WE hold the
-            # only outstanding update. Per-machine branches are by
-            # design owned by exactly one node; an unexpected
-            # concurrent update would still be rejected by the lease,
-            # exactly as intended.
+            # Push the per-machine branch. Use ``--force-with-lease``
+            # whenever the local working branch has diverged from
+            # ``origin/<working_branch>`` (i.e., the rebase rewrote
+            # commits that origin already had). This is BROADER than
+            # just iteration > 1 within this call: if a previous
+            # invocation left ``origin/<working_branch>`` updated but
+            # ``origin/main`` not fast-forwarded (process interrupted,
+            # retry budget exhausted, etc.), the rebase at the top of
+            # this iteration rewrites the local commit and a plain
+            # push is non-FF on the per-machine branch. Codex review
+            # pass 9 caught this state-bridging case. Lease still
+            # protects against an unexpected concurrent update to the
+            # per-machine branch — per-machine branches are owned by
+            # exactly one node by design, so the lease almost always
+            # passes here, but if a stray update slips in we fail
+            # safely instead of clobbering it.
             push_cmd: list[str] = ["push", "origin", self.working_branch]
-            if attempt > 1:
+            if self._working_branch_diverged_from_origin():
                 push_cmd.insert(1, "--force-with-lease")
             try:
                 self._git(*push_cmd)
@@ -687,6 +689,33 @@ class PersonalizationManager:
 
     def _current_branch(self) -> str:
         return self._git("rev-parse", "--abbrev-ref", "HEAD").strip()
+
+    def _working_branch_diverged_from_origin(self) -> bool:
+        """Return True iff ``origin/<working_branch>`` exists and is
+        NOT an ancestor of the local ``working_branch``.
+
+        Used to decide whether the per-machine branch push needs
+        ``--force-with-lease``. Plain push works when:
+          - origin counterpart doesn't exist yet (first push), OR
+          - origin counterpart is an ancestor of local (FF possible).
+        Otherwise the rebase has rewritten commits that origin still
+        has on the per-machine branch and we need a leased force.
+        """
+        remote_exists = self._git_capturing(
+            "show-ref", "--verify", "--quiet",
+            f"refs/remotes/origin/{self.working_branch}",
+            check=False,
+        ).returncode == 0
+        if not remote_exists:
+            return False
+        # ``--is-ancestor A B`` exits 0 when A is ancestor of B (or
+        # equal). If origin is ancestor of local, FF push works.
+        is_ancestor = self._git_capturing(
+            "merge-base", "--is-ancestor",
+            f"origin/{self.working_branch}", self.working_branch,
+            check=False,
+        ).returncode == 0
+        return not is_ancestor
 
     def _stage_configured_paths(self) -> bool:
         """``git add -A`` each on-disk location of configured sources.

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -346,9 +346,23 @@ class PersonalizationManager:
         self._require_checkout()
         self._ensure_working_branch()
 
+        # Reset the index to HEAD before staging. This unstages any
+        # ad-hoc ``git add`` the operator (or an interrupted previous
+        # run) left in the index, ensuring:
+        #   1. our commit's pathspec scope matches the actual diff,
+        #   2. ``git rebase`` doesn't refuse with "Your index contains
+        #      uncommitted changes". Working-tree changes are
+        #      preserved (mixed reset is index-only); the operator's
+        #      out-of-allowlist files stay on disk and can be staged/
+        #      committed by them manually after push completes. This
+        #      pairs with the pathspec-scoped commit (Codex pass 12)
+        #      to make the allowlist a hard guarantee.
+        self._git("reset", "--mixed")
+
         # Stage and commit once up-front; the commit object stays the
         # same across retries, only the rebase base shifts.
-        if self._stage_configured_paths():
+        configured_pathspecs = self._stage_configured_paths()
+        if configured_pathspecs:
             # ``git commit`` errors with "Author identity unknown" if
             # neither global nor local user.email/user.name is set.
             # Bootstrap already does this for the empty-repo path;
@@ -358,8 +372,16 @@ class PersonalizationManager:
             commit_msg = message or "personalization: sync from {}".format(
                 self.working_branch
             )
+            # ``-- <pathspecs>`` constrains the commit to ONLY the
+            # allowlisted paths. Anything an operator manually staged
+            # outside the allowlist (Codex pass 12 finding — e.g.
+            # interrupted run, ad-hoc ``git add``) stays in the
+            # index but does NOT enter the personalization repo's
+            # history.
             try:
-                self._git("commit", "-m", commit_msg)
+                self._git(
+                    "commit", "-m", commit_msg, "--", *configured_pathspecs
+                )
             except _GitError as e:
                 # ``git commit`` exits 1 with "nothing to commit" when
                 # the staged set turns out to be a no-op (e.g. only
@@ -738,22 +760,26 @@ class PersonalizationManager:
         ).returncode == 0
         return not is_ancestor
 
-    def _stage_configured_paths(self) -> bool:
-        """``git add -A`` each on-disk location of configured sources.
+    def _stage_configured_paths(self) -> list[str]:
+        """``git add -A`` each on-disk location of configured sources
+        and return the pathspecs that should bound the subsequent
+        ``git commit``.
 
-        Returns True if anything got staged. Selective staging keeps
-        ad-hoc cruft a user dropped in the checkout out of the sync
-        repo's history.
-
-        Uses ``git add -A`` per-path so tracked-file *deletions* are
-        also staged (Codex review caught this: filtering on
-        ``Path.exists()`` would otherwise leave a file the operator
-        deleted in the checkout sitting on the remote forever).
+        The returned list is non-empty whenever the configured paths
+        produced ANY staged change — including tracked-file deletions
+        (Codex review pass 1 finding: filtering on ``Path.exists()``
+        would otherwise leave deletions out of the commit). The
+        caller MUST scope ``git commit`` to these pathspecs (Codex
+        pass 12 finding) so anything an operator pre-staged outside
+        the allowlist (manual ``git add``, interrupted run) does not
+        ride along into the personalization repo's history.
 
         Tolerates ``pathspec did not match any files`` for paths that
         are neither in the working tree nor tracked — typical for a
         project_scoped entry whose source dir was never populated on
         any machine.
+
+        Returns ``[]`` when nothing in the allowlist changed.
         """
         rels: list[str] = []
         for entry in self.cfg.paths:
@@ -764,7 +790,7 @@ class PersonalizationManager:
                     continue
                 rels.append(str(rel))
         if not rels:
-            return False
+            return []
 
         for rel in rels:
             result = self._git_capturing("add", "-A", "--", rel, check=False)
@@ -780,8 +806,14 @@ class PersonalizationManager:
                     stdout=result.stdout,
                     stderr=result.stderr,
                 )
-        staged = self._git("diff", "--cached", "--name-only").strip()
-        return bool(staged)
+        # Only return the pathspecs if SOMETHING in the allowlist
+        # actually has staged changes. Pre-staged files outside the
+        # allowlist won't show up here because we restrict the diff
+        # to the configured pathspecs.
+        diff = self._git(
+            "diff", "--cached", "--name-only", "--", *rels
+        ).strip()
+        return rels if diff else []
 
     def _plan_for_entry(self, entry: PersonalizationPath) -> list[SymlinkPlan]:
         if entry.project_scoped:

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -39,6 +39,7 @@ Design choices that are easy to miss in review:
 from __future__ import annotations
 
 import os
+import re
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -132,17 +133,25 @@ class PersonalizationManager:
         Returns a human-readable summary.
         """
         if self.checkout_path.exists():
-            if not self._is_existing_checkout_ours():
-                raise PersonalizationError(
-                    f"checkout_path {self.checkout_path} already exists and is not a "
-                    f"clone of {self.cfg.repo}; back it up or remove it before "
-                    "running init"
-                )
-            # Same repo already there — converge to the right branch and
-            # re-wire. Useful when ``init`` is re-run after a config change.
-            self._ensure_working_branch()
-            results = self.wire_symlinks()
-            return self._format_init_summary(results, cloned=False)
+            # An empty directory is fine — ``git clone <url> <empty-dir>``
+            # works. Treat as not-yet-cloned and fall through.
+            is_empty_dir = (
+                self.checkout_path.is_dir()
+                and not any(self.checkout_path.iterdir())
+            )
+            if not is_empty_dir:
+                if not self._is_existing_checkout_ours():
+                    raise PersonalizationError(
+                        f"checkout_path {self.checkout_path} already exists "
+                        f"and is not a clone of {self.cfg.repo}; back it up "
+                        "or remove it before running init"
+                    )
+                # Same repo already there — converge to the right
+                # branch and re-wire. Useful when ``init`` is re-run
+                # after a config change.
+                self._ensure_working_branch()
+                results = self.wire_symlinks()
+                return self._format_init_summary(results, cloned=False)
 
         self.checkout_path.parent.mkdir(parents=True, exist_ok=True)
         self._git_global("clone", self.repo_url, str(self.checkout_path))
@@ -602,17 +611,39 @@ class PersonalizationManager:
 
     # ----- internals: git helpers --------------------------------------------
 
+    # Parses owner/repo out of any common GitHub remote URL shape:
+    #   https://github.com/owner/repo(.git)?
+    #   git@github.com:owner/repo(.git)?
+    #   git://github.com/owner/repo(.git)?
+    #   ssh://git@github.com/owner/repo(.git)?
+    # Captures the LAST owner/repo before an optional ``.git`` /
+    # trailing slash. Anchored at end so a matching prefix earlier in
+    # the URL doesn't false-positive.
+    _ORIGIN_OWNER_REPO_RE = re.compile(
+        r"[/:]([^/:]+/[^/:]+?)(?:\.git)?/?\s*\Z"
+    )
+
     def _is_existing_checkout_ours(self) -> bool:
+        """Return True iff ``checkout_path`` is a clone of exactly
+        ``self.cfg.repo``.
+
+        The earlier substring-based check accepted prefix matches
+        (config ``acme/dot`` would accept origin ``acme/dotfiles``)
+        and could let init wire symlinks against the wrong repo.
+        Now we extract the trailing ``owner/repo`` from the origin
+        URL and compare exactly (case-insensitive — GitHub itself is
+        case-insensitive on these).
+        """
         if not (self.checkout_path / ".git").exists():
             return False
         try:
             origin = self._git("remote", "get-url", "origin").strip()
         except _GitError:
             return False
-        # Be permissive about the URL form (https vs ssh) but require
-        # the owner/repo to match.
-        owner_repo = self.cfg.repo.lower()
-        return owner_repo in origin.lower()
+        match = self._ORIGIN_OWNER_REPO_RE.search(origin)
+        if not match:
+            return False
+        return match.group(1).lower() == self.cfg.repo.lower()
 
     def _ensure_working_branch(self) -> None:
         """Make sure HEAD is on ``working_branch``, creating it from

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -148,7 +148,13 @@ class PersonalizationManager:
                     )
                 # Same repo already there — converge to the right
                 # branch and re-wire. Useful when ``init`` is re-run
-                # after a config change.
+                # after a config change. ``_bootstrap_main_if_empty``
+                # also runs here because an existing clone of an
+                # empty remote still has unborn HEAD; without
+                # bootstrap, ``_ensure_working_branch`` would fail
+                # rev-parsing HEAD or origin/<main> (Codex pass 10
+                # caught this).
+                self._bootstrap_main_if_empty()
                 self._ensure_working_branch()
                 results = self.wire_symlinks()
                 return self._format_init_summary(results, cloned=False)

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -618,6 +618,24 @@ class PersonalizationManager:
             # safe to run on a partial repo.
             return SymlinkResult(plan=plan, action="skipped-source-missing")
 
+        # Source's actual on-disk type must match what the config says
+        # (trailing slash → dir, no slash → file). A directory entry
+        # accidentally present as a regular file (or vice versa)
+        # would otherwise wire a symlink that breaks downstream
+        # consumers (Codex pass 15). Refuse loudly with a hint.
+        actual_is_dir = plan.source.is_dir()
+        if plan.is_dir != actual_is_dir:
+            expected = "directory" if plan.is_dir else "file"
+            actual = "directory" if actual_is_dir else "file"
+            return SymlinkResult(
+                plan=plan,
+                action="skipped-source-type-mismatch",
+                detail=(
+                    f"config declares {expected} (target/source trailing "
+                    f"slash) but on-disk source is a {actual}"
+                ),
+            )
+
         # Ensure parent dir of target exists.
         plan.target.parent.mkdir(parents=True, exist_ok=True)
 
@@ -650,6 +668,10 @@ class PersonalizationManager:
         """Read-only counterpart to ``_apply_symlink`` for ``status``."""
         if not plan.source.exists():
             return "source-missing"
+        if plan.is_dir != plan.source.is_dir():
+            expected = "directory" if plan.is_dir else "file"
+            actual = "directory" if plan.source.is_dir() else "file"
+            return f"source-type-mismatch (config={expected}, on-disk={actual})"
         if plan.target.is_symlink():
             current = plan.target.readlink()
             if current == plan.source or self._same_resolved(current, plan.source):
@@ -909,7 +931,15 @@ class PersonalizationManager:
 # Module-level helpers (kept outside the class so tests can patch them)
 
 
-class _GitError(Exception):
+class _GitError(PersonalizationError):
+    """Raised when a git subprocess invoked by the manager exits non-zero.
+
+    Subclasses ``PersonalizationError`` so the CLI's ``PersonalizationError``
+    handlers catch git failures (auth, network, unborn HEAD reads, etc.)
+    and emit a clean error instead of a traceback. Codex pass 15 caught
+    that bare ``Exception`` made these escape the CLI wrappers.
+    """
+
     def __init__(
         self, args: tuple[str, ...], returncode: int, stdout: str, stderr: str
     ):

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -726,12 +726,22 @@ class PersonalizationManager:
 
     def _ensure_working_branch(self) -> None:
         """Make sure HEAD is on ``working_branch``, creating it from
-        ``main_branch`` if it doesn't exist locally yet.
+        ``main_branch`` if it doesn't exist on origin or locally.
+
+        Refreshes remote-tracking refs first via ``git fetch origin``
+        so an existing-but-stale checkout doesn't miss a per-node
+        branch that was created on origin after this clone last
+        fetched. Codex pass 16 caught this P1: without the fetch,
+        ``init`` on a stale clone would branch off main, then
+        ``push`` would later fetch and force-with-lease over commits
+        that only lived on the remote per-node branch.
         """
         current = self._current_branch()
         if current == self.working_branch:
             return
-        # Does the working branch exist locally?
+        # Local branch already present? Just check it out — even if
+        # origin has a divergent copy we'll handle it on push (the
+        # rebase/lease logic is built for exactly that).
         existing = self._git_capturing(
             "show-ref", "--verify", "--quiet",
             f"refs/heads/{self.working_branch}",
@@ -740,13 +750,20 @@ class PersonalizationManager:
         if existing.returncode == 0:
             self._git("checkout", self.working_branch)
             return
-        # Try origin/<working_branch> first (another machine of ours).
+        # Refresh remote-tracking refs so the next show-ref reflects
+        # what origin actually has, not what we last knew. Best-
+        # effort — a fetch failure (offline, auth) shouldn't block
+        # branching off the local main; later push will surface the
+        # network/auth error properly.
+        self._git_capturing("fetch", "origin", "--prune", check=False)
         existing_remote = self._git_capturing(
             "show-ref", "--verify", "--quiet",
             f"refs/remotes/origin/{self.working_branch}",
             check=False,
         )
         if existing_remote.returncode == 0:
+            # Adopt the remote per-node branch instead of clobbering
+            # it later.
             self._git(
                 "checkout", "-b", self.working_branch,
                 f"origin/{self.working_branch}",

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -203,22 +203,38 @@ class PersonalizationManager:
             results.append(self._apply_symlink(plan))
         return results
 
+    # Bounded retries for the rebase + branch-push + FF-push cycle on
+    # FF rejection. Codex review caught the earlier silent-success-on-
+    # FF-rejection bug: if origin/main moved between our fetch and our
+    # FF-push, the per-machine branch lands on the remote but main
+    # stays at the racing machine's commit. Retrying refetches the new
+    # main, rebases on top, and tries again. Cap is small because the
+    # fleet should be ~3-5 machines and a hot loop here usually means
+    # a deeper problem (auth, branch protection, network) that won't
+    # fix itself.
+    _PUSH_MAX_ATTEMPTS = 3
+
     def push(self, message: str | None = None) -> PushResult:
         """Commit working-tree changes on the per-machine branch, then
         rebase onto ``origin/<main>`` and push. On rebase conflict,
         abort the rebase and return a ``PushResult`` listing the
         conflict files; the working tree is left in its pre-rebase
         state so the operator can resolve manually.
+
+        On a successful per-branch push but rejected FF of main
+        (concurrent push from another node), retries the cycle up to
+        ``_PUSH_MAX_ATTEMPTS`` times. Returns ``success=False`` if the
+        cycle never lands main — silently reporting success would
+        leave this node's commit reachable only via
+        ``origin/personalization/<node>``, never on main, which other
+        machines wouldn't see.
         """
         self._require_checkout()
         self._ensure_working_branch()
 
-        # Stage and commit if dirty. We add only paths declared in the
-        # config (their actual on-disk location inside the checkout),
-        # not ``-A``, so a stray test artifact in the checkout doesn't
-        # ride along into the personalization repo.
-        added = self._stage_configured_paths()
-        if added:
+        # Stage and commit once up-front; the commit object stays the
+        # same across retries, only the rebase base shifts.
+        if self._stage_configured_paths():
             commit_msg = message or "personalization: sync from {}".format(
                 self.working_branch
             )
@@ -226,83 +242,86 @@ class PersonalizationManager:
                 self._git("commit", "-m", commit_msg)
             except _GitError as e:
                 # ``git commit`` exits 1 with "nothing to commit" when
-                # the staged set turns out to be a no-op (e.g. the
-                # working tree only has whitespace differences that
-                # aren't actually staged). Treat as a no-op.
-                if "nothing to commit" in (e.stdout + e.stderr).lower():
-                    pass
-                else:
+                # the staged set turns out to be a no-op (e.g. only
+                # mode-bit churn). Treat as a no-op so push is
+                # idempotent.
+                if "nothing to commit" not in (e.stdout + e.stderr).lower():
                     raise
 
-        # Fetch and try to fast-forward main locally so the rebase
-        # base is current. Failures here are not fatal — we'll surface
-        # them as part of the rebase attempt.
-        try:
-            self._git("fetch", "origin", "--prune")
-        except _GitError as e:
-            return PushResult(
-                success=False,
-                summary=f"fetch failed: {e.stderr.strip() or e.stdout.strip()}",
-            )
+        last_summary = ""
+        for attempt in range(1, self._PUSH_MAX_ATTEMPTS + 1):
+            try:
+                self._git("fetch", "origin", "--prune")
+            except _GitError as e:
+                return PushResult(
+                    success=False,
+                    summary=f"fetch failed: {e.stderr.strip() or e.stdout.strip()}",
+                )
 
-        # Rebase the working branch onto origin/<main>. ``--keep-base``
-        # is intentional: if origin/<main> hasn't moved relative to the
-        # last rebase point, no commits get rewritten.
-        rebase = self._git_capturing(
-            "rebase", f"origin/{self.main_branch}",
-            check=False,
-        )
-        if rebase.returncode != 0:
-            # Detect conflict and abort cleanly.
-            unmerged = self._git("diff", "--name-only", "--diff-filter=U").strip()
-            self._git_capturing("rebase", "--abort", check=False)
-            files = tuple(unmerged.splitlines()) if unmerged else ()
-            return PushResult(
-                success=False,
-                summary=(
-                    "rebase onto origin/{main} hit conflicts; aborted. "
-                    "Resolve the listed files in the checkout, commit, then "
-                    "re-run push."
-                ).format(main=self.main_branch),
-                conflict_files=files,
+            rebase = self._git_capturing(
+                "rebase", f"origin/{self.main_branch}",
+                check=False,
             )
+            if rebase.returncode != 0:
+                unmerged = self._git(
+                    "diff", "--name-only", "--diff-filter=U"
+                ).strip()
+                self._git_capturing("rebase", "--abort", check=False)
+                files = tuple(unmerged.splitlines()) if unmerged else ()
+                return PushResult(
+                    success=False,
+                    summary=(
+                        "rebase onto origin/{main} hit conflicts; aborted. "
+                        "Resolve the listed files in the checkout, commit, "
+                        "then re-run push."
+                    ).format(main=self.main_branch),
+                    conflict_files=files,
+                )
 
-        # Push the working branch, then FF the remote main from it.
-        try:
-            self._git("push", "origin", self.working_branch)
-        except _GitError as e:
-            return PushResult(
-                success=False,
-                summary=(
-                    f"push of {self.working_branch} failed: "
-                    f"{e.stderr.strip() or e.stdout.strip()}"
-                ),
+            try:
+                self._git("push", "origin", self.working_branch)
+            except _GitError as e:
+                return PushResult(
+                    success=False,
+                    summary=(
+                        f"push of {self.working_branch} failed: "
+                        f"{e.stderr.strip() or e.stdout.strip()}"
+                    ),
+                )
+
+            ff_push = self._git_capturing(
+                "push", "origin",
+                f"{self.working_branch}:{self.main_branch}",
+                check=False,
             )
-
-        # FF-push main: only succeeds if origin/<main> hasn't moved
-        # since our fetch. If another machine raced us, this push is
-        # rejected — that's fine, the next machine that pushes will
-        # pick up our commits via origin/<branch> and FF then. No
-        # force-push, ever.
-        ff_push = self._git_capturing(
-            "push", "origin",
-            f"{self.working_branch}:{self.main_branch}",
-            check=False,
-        )
-        ff_note = ""
-        if ff_push.returncode != 0:
-            ff_note = (
-                f"; note: could not FF origin/{self.main_branch} "
-                "(another machine may have pushed first; their commits "
-                "will be picked up on the next pull)"
+            if ff_push.returncode == 0:
+                return PushResult(
+                    success=True,
+                    summary=(
+                        f"pushed {self.working_branch} and fast-forwarded "
+                        f"origin/{self.main_branch}"
+                        + (
+                            f" (after {attempt} attempts)"
+                            if attempt > 1 else ""
+                        )
+                    ),
+                )
+            # FF rejected — another machine pushed to main between our
+            # fetch and our push. Loop and try again on top of the new
+            # tip. Capture the last error message in case we exhaust
+            # the retry budget.
+            last_summary = (
+                ff_push.stderr.strip() or ff_push.stdout.strip()
+                or "fast-forward of origin/main rejected"
             )
 
         return PushResult(
-            success=True,
+            success=False,
             summary=(
-                f"pushed {self.working_branch}; "
-                f"{'fast-forwarded' if not ff_note else 'did not fast-forward'} "
-                f"origin/{self.main_branch}{ff_note}"
+                f"push of {self.working_branch} succeeded but origin/"
+                f"{self.main_branch} could not be fast-forwarded after "
+                f"{self._PUSH_MAX_ATTEMPTS} attempts ({last_summary}); "
+                "another node is racing pushes — re-run push to retry"
             ),
         )
 
@@ -516,40 +535,63 @@ class PersonalizationManager:
                 f"origin/{self.working_branch}",
             )
             return
-        # Brand new — branch off main.
-        self._git("checkout", "-b", self.working_branch, self.main_branch)
+        # Brand new — branch off origin's main. ``origin/<main>``
+        # rather than the bare local name so a non-default
+        # ``main_branch`` (e.g. ``develop``) works on a fresh clone:
+        # ``git clone`` only checks out the repository's default
+        # branch locally, so ``git checkout -b ... develop`` would
+        # fail with "did not match any file(s) known to git". The
+        # remote ref is always present after ``fetch``/``clone``.
+        self._git(
+            "checkout", "-b", self.working_branch,
+            f"origin/{self.main_branch}",
+        )
 
     def _current_branch(self) -> str:
         return self._git("rev-parse", "--abbrev-ref", "HEAD").strip()
 
     def _stage_configured_paths(self) -> bool:
-        """``git add`` only the on-disk locations of configured sources.
+        """``git add -A`` each on-disk location of configured sources.
 
-        Returns True if anything got staged. The selective staging
-        keeps ad-hoc cruft a user might have dropped in the checkout
-        out of the personalization repo's history.
+        Returns True if anything got staged. Selective staging keeps
+        ad-hoc cruft a user dropped in the checkout out of the sync
+        repo's history.
+
+        Uses ``git add -A`` per-path so tracked-file *deletions* are
+        also staged (Codex review caught this: filtering on
+        ``Path.exists()`` would otherwise leave a file the operator
+        deleted in the checkout sitting on the remote forever).
+
+        Tolerates ``pathspec did not match any files`` for paths that
+        are neither in the working tree nor tracked — typical for a
+        project_scoped entry whose source dir was never populated on
+        any machine.
         """
         rels: list[str] = []
         for entry in self.cfg.paths:
-            # Source paths can carry placeholders, which would expand
-            # to per-repo subdirs. Stage each *resolved* source that
-            # actually exists. ``git add -- <missing>`` exits 128 with
-            # ``pathspec did not match any files``, so pre-filtering
-            # is required to keep ``push`` a no-op when the working
-            # tree is clean.
             for plan in self._plan_for_entry(entry):
-                if not plan.source.exists():
-                    continue
                 try:
                     rel = plan.source.relative_to(self.checkout_path)
                 except ValueError:
-                    # Source escaped the checkout — config bug, but
-                    # don't crash on push; surface in status.
                     continue
                 rels.append(str(rel))
         if not rels:
             return False
-        self._git("add", "--", *rels)
+
+        for rel in rels:
+            result = self._git_capturing("add", "-A", "--", rel, check=False)
+            if result.returncode != 0:
+                # ``did not match`` is the benign case: path is
+                # neither in the working tree nor in the index.
+                # Anything else is a real error and should propagate.
+                if "did not match" in (result.stderr + result.stdout):
+                    continue
+                raise _GitError(
+                    args=("add", "-A", "--", rel),
+                    returncode=result.returncode,
+                    stdout=result.stdout,
+                    stderr=result.stderr,
+                )
         staged = self._git("diff", "--cached", "--name-only").strip()
         return bool(staged)
 

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -178,31 +178,45 @@ class PersonalizationManager:
         otherwise silently create a parallel ``main_branch`` and push
         it, which is rarely what the user wants. Treat that case as a
         configuration error and surface it loudly with a hint.
+
+        Note: a missing local ``refs/remotes/origin/<main>`` is NOT
+        proof the remote lacks the branch — a ``--single-branch`` or
+        stale clone may not have fetched it. Always consult
+        ``ls-remote`` for the authoritative answer (Codex pass 11
+        caught this).
         """
-        # If origin/<main_branch> already exists, nothing to do.
-        existing_remote = self._git_capturing(
-            "show-ref", "--verify", "--quiet",
-            f"refs/remotes/origin/{self.main_branch}",
-            check=False,
-        )
-        if existing_remote.returncode == 0:
+        # Authoritative check against the remote: does it have
+        # refs/heads/<main_branch>?
+        ls = self._git_capturing("ls-remote", "origin", check=False)
+        if ls.returncode != 0:
+            # Network / auth failure: surface, don't silently bootstrap.
+            raise PersonalizationError(
+                f"`git ls-remote origin` failed: "
+                f"{ls.stderr.strip() or ls.stdout.strip()}"
+            )
+
+        # Parse ``<sha>\trefs/...`` lines.
+        remote_refs: list[str] = []
+        for line in ls.stdout.strip().splitlines():
+            parts = line.split("\t", 1)
+            if len(parts) == 2:
+                remote_refs.append(parts[1])
+
+        wanted_ref = f"refs/heads/{self.main_branch}"
+        if wanted_ref in remote_refs:
+            # Remote has main_branch. Make sure our local remote-
+            # tracking ref reflects it (single-branch clones may not
+            # have it without an explicit fetch) so subsequent
+            # operations can use ``origin/<main_branch>``.
+            self._git_capturing(
+                "fetch", "origin",
+                f"+{wanted_ref}:refs/remotes/origin/{self.main_branch}",
+                check=False,
+            )
             return
 
-        # Distinguish truly-empty from "main_branch is wrong". Truly-
-        # empty: ``ls-remote`` returns no refs. Otherwise some other
-        # branch exists upstream and we should not bootstrap.
-        ls = self._git_capturing("ls-remote", "origin", check=False)
-        # ls-remote prints one ref per line (sha\tref). Empty stdout
-        # ⇒ zero refs ⇒ empty repo.
-        has_refs = bool(ls.stdout.strip())
-        if has_refs:
-            # List the branches the remote actually has so the user
-            # can see what to set ``main_branch`` to.
-            actual = "\n".join(
-                "  " + line.split("\t", 1)[1]
-                for line in ls.stdout.strip().splitlines()
-                if "\t" in line
-            ) or "  (none)"
+        if remote_refs:
+            actual = "\n".join("  " + r for r in remote_refs)
             raise PersonalizationError(
                 f"remote {self.cfg.repo} has no branch named "
                 f"'{self.main_branch}', but the repo is not empty. "
@@ -211,6 +225,7 @@ class PersonalizationManager:
                 "remote branch). Existing refs:\n" + actual
             )
 
+        # Truly empty remote — bootstrap.
         self._ensure_local_identity()
         readme = self.checkout_path / "README.md"
         if not readme.exists():

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -143,19 +143,9 @@ class PersonalizationManager:
                 if not self._is_existing_checkout_ours():
                     raise PersonalizationError(
                         f"checkout_path {self.checkout_path} already exists "
-                        f"and is not a clone of {self.cfg.repo}; back it up "
-                        "or remove it before running init"
+                        f"and is not a clone of github.com:{self.cfg.repo}; "
+                        "back it up or remove it before running init"
                     )
-                # Force origin to our canonical URL. The owner/repo
-                # match in ``_is_existing_checkout_ours`` accepts any
-                # host whose trailing path equals our configured repo
-                # (Codex pass 18 caught this) — a malicious clone of
-                # ``https://evil.example/<owner>/<repo>.git`` would
-                # otherwise have init keep using that origin for the
-                # subsequent fetch/push and tunnel personalization
-                # data outside the user's intended remote. No-op if
-                # origin already points at the canonical URL.
-                self._git("remote", "set-url", "origin", self.repo_url)
                 # Same repo already there — converge to the right
                 # branch and re-wire. Useful when ``init`` is re-run
                 # after a config change. ``_bootstrap_main_if_empty``
@@ -715,28 +705,43 @@ class PersonalizationManager:
 
     # ----- internals: git helpers --------------------------------------------
 
-    # Parses owner/repo out of any common GitHub remote URL shape:
+    # Parses host + owner/repo out of any common GitHub remote URL:
     #   https://github.com/owner/repo(.git)?
     #   git@github.com:owner/repo(.git)?
     #   git://github.com/owner/repo(.git)?
     #   ssh://git@github.com/owner/repo(.git)?
-    # Captures the LAST owner/repo before an optional ``.git`` /
-    # trailing slash. Anchored at end so a matching prefix earlier in
-    # the URL doesn't false-positive.
-    _ORIGIN_OWNER_REPO_RE = re.compile(
-        r"[/:]([^/:]+/[^/:]+?)(?:\.git)?/?\s*\Z"
+    # The host capture must be exactly ``github.com`` (case-
+    # insensitive). Owner/repo is captured separately and compared
+    # against ``cfg.repo``. Codex pass 20 caught that an earlier
+    # tail-only match accepted any host; a foreign clone with a
+    # matching tail (``https://evil.example/owner/repo.git``) would
+    # be wired against, leaking personalization data.
+    _ORIGIN_GITHUB_RE = re.compile(
+        r"^(?:"
+        r"https?://(?P<host_https>[^/]+)/"
+        r"|git@(?P<host_ssh>[^:]+):"
+        r"|git://(?P<host_git>[^/]+)/"
+        r"|ssh://(?:git@)?(?P<host_sshurl>[^/]+)/"
+        r")"
+        r"(?P<owner_repo>[^/:]+/[^/:]+?)"
+        r"(?:\.git)?/?\s*\Z",
+        re.IGNORECASE,
     )
 
     def _is_existing_checkout_ours(self) -> bool:
-        """Return True iff ``checkout_path`` is a clone of exactly
-        ``self.cfg.repo``.
+        """Return True iff ``checkout_path`` is a clone of
+        ``github.com:<self.cfg.repo>``.
 
-        The earlier substring-based check accepted prefix matches
-        (config ``acme/dot`` would accept origin ``acme/dotfiles``)
-        and could let init wire symlinks against the wrong repo.
-        Now we extract the trailing ``owner/repo`` from the origin
-        URL and compare exactly (case-insensitive — GitHub itself is
-        case-insensitive on these).
+        Tail-only matching (Codex pass 6 fix) was insufficient: an
+        existing checkout whose origin pointed at a non-github host
+        with the matching ``owner/repo`` tail would still be
+        accepted, and after the origin-URL reset (Codex pass 18 fix)
+        the foreign checkout's working tree / branch contents would
+        get wired into ``~/.claude/`` and friends. Now we require
+        the host to be ``github.com`` exactly. Anything else is
+        treated as not-ours and ``init`` refuses, telling the
+        operator to back up + remove the directory before retrying
+        (Codex pass 20 P1 fix).
         """
         if not (self.checkout_path / ".git").exists():
             return False
@@ -744,10 +749,19 @@ class PersonalizationManager:
             origin = self._git("remote", "get-url", "origin").strip()
         except _GitError:
             return False
-        match = self._ORIGIN_OWNER_REPO_RE.search(origin)
+        match = self._ORIGIN_GITHUB_RE.match(origin)
         if not match:
             return False
-        return match.group(1).lower() == self.cfg.repo.lower()
+        host = (
+            match.group("host_https")
+            or match.group("host_ssh")
+            or match.group("host_git")
+            or match.group("host_sshurl")
+            or ""
+        )
+        if host.lower() != "github.com":
+            return False
+        return match.group("owner_repo").lower() == self.cfg.repo.lower()
 
     def _ensure_working_branch(self) -> None:
         """Make sure HEAD is on ``working_branch``, creating it from

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -152,22 +152,19 @@ class PersonalizationManager:
         return self._format_init_summary(results, cloned=True)
 
     def _bootstrap_main_if_empty(self) -> None:
-        """Create an initial commit on ``main_branch`` if the cloned
-        repo has none yet.
+        """Create an initial commit on ``main_branch`` ONLY if the
+        remote has zero refs.
 
         A brand-new GitHub repo (no commits, no default branch) clones
-        with an "unborn HEAD" — ``origin/<main>`` doesn't exist, so
-        ``_ensure_working_branch`` would later fail trying to branch
-        from it. To make ``init`` the natural bootstrap path, we
-        detect this state, write a tiny ``README.md``, commit it on
-        ``main_branch``, and push. After this the rest of init
-        proceeds normally.
-
-        We only act when ``origin/<main_branch>`` is missing — an
-        existing remote branch (whether the user's default or one
-        they created) is left alone.
+        with an "unborn HEAD" and ``git ls-remote origin`` is empty —
+        bootstrap is safe and required. But if the remote has commits
+        under a DIFFERENT branch (typical when an existing repo uses
+        ``master`` and ``main_branch`` is misconfigured), we'd
+        otherwise silently create a parallel ``main_branch`` and push
+        it, which is rarely what the user wants. Treat that case as a
+        configuration error and surface it loudly with a hint.
         """
-        # If origin/<main_branch> already exists, nothing to bootstrap.
+        # If origin/<main_branch> already exists, nothing to do.
         existing_remote = self._git_capturing(
             "show-ref", "--verify", "--quiet",
             f"refs/remotes/origin/{self.main_branch}",
@@ -176,19 +173,30 @@ class PersonalizationManager:
         if existing_remote.returncode == 0:
             return
 
-        # Configure user identity if not already set on this clone —
-        # ``git commit`` errors out without one. Only override when
-        # missing so the operator's global config still wins on
-        # machines where they've set it.
-        if not self._git_capturing(
-            "config", "--get", "user.email", check=False
-        ).stdout.strip():
-            self._git("config", "user.email", "ctrlrelay@local")
-        if not self._git_capturing(
-            "config", "--get", "user.name", check=False
-        ).stdout.strip():
-            self._git("config", "user.name", "ctrlrelay")
+        # Distinguish truly-empty from "main_branch is wrong". Truly-
+        # empty: ``ls-remote`` returns no refs. Otherwise some other
+        # branch exists upstream and we should not bootstrap.
+        ls = self._git_capturing("ls-remote", "origin", check=False)
+        # ls-remote prints one ref per line (sha\tref). Empty stdout
+        # ⇒ zero refs ⇒ empty repo.
+        has_refs = bool(ls.stdout.strip())
+        if has_refs:
+            # List the branches the remote actually has so the user
+            # can see what to set ``main_branch`` to.
+            actual = "\n".join(
+                "  " + line.split("\t", 1)[1]
+                for line in ls.stdout.strip().splitlines()
+                if "\t" in line
+            ) or "  (none)"
+            raise PersonalizationError(
+                f"remote {self.cfg.repo} has no branch named "
+                f"'{self.main_branch}', but the repo is not empty. "
+                "Set personalization.main_branch in orchestrator.yaml "
+                "to one of the existing remote refs (or rename the "
+                "remote branch). Existing refs:\n" + actual
+            )
 
+        self._ensure_local_identity()
         readme = self.checkout_path / "README.md"
         if not readme.exists():
             readme.write_text(
@@ -203,6 +211,28 @@ class PersonalizationManager:
             "personalization: bootstrap empty repo",
         )
         self._git("push", "-u", "origin", self.main_branch)
+
+    def _ensure_local_identity(self) -> None:
+        """Ensure ``user.email`` and ``user.name`` are set on this
+        checkout so ``git commit`` doesn't fail with "Author identity
+        unknown".
+
+        Only writes when the value is missing — never overrides an
+        existing setting (operator's global ``~/.gitconfig`` values
+        come through to the cloned repo on default git settings, and
+        we don't want to silently shadow them). Used by both
+        bootstrap and the regular ``push`` commit path so a fresh
+        machine without global identity can still complete the first
+        sync.
+        """
+        if not self._git_capturing(
+            "config", "--get", "user.email", check=False
+        ).stdout.strip():
+            self._git("config", "user.email", "ctrlrelay@local")
+        if not self._git_capturing(
+            "config", "--get", "user.name", check=False
+        ).stdout.strip():
+            self._git("config", "user.name", "ctrlrelay")
 
     def status(self) -> str:
         """Return a human-readable summary of working-tree state +
@@ -289,6 +319,12 @@ class PersonalizationManager:
         # Stage and commit once up-front; the commit object stays the
         # same across retries, only the rebase base shifts.
         if self._stage_configured_paths():
+            # ``git commit`` errors with "Author identity unknown" if
+            # neither global nor local user.email/user.name is set.
+            # Bootstrap already does this for the empty-repo path;
+            # call it here too so a fresh machine cloning a non-empty
+            # personalization repo can complete its first sync.
+            self._ensure_local_identity()
             commit_msg = message or "personalization: sync from {}".format(
                 self.working_branch
             )

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -792,28 +792,42 @@ class PersonalizationManager:
         if not rels:
             return []
 
+        # Only paths that ``git add`` actually matched (path exists
+        # in the working tree or is tracked) survive. The caller
+        # passes the survivors to ``git commit -- <paths>``; commit
+        # would fail with "pathspec did not match" if we left a
+        # never-tracked, never-present path in the list (Codex
+        # review pass 13 caught this — a normal partial-repo state
+        # where one configured source is populated and another is
+        # not blocked the whole push).
+        matched: list[str] = []
         for rel in rels:
             result = self._git_capturing("add", "-A", "--", rel, check=False)
-            if result.returncode != 0:
-                # ``did not match`` is the benign case: path is
-                # neither in the working tree nor in the index.
-                # Anything else is a real error and should propagate.
-                if "did not match" in (result.stderr + result.stdout):
-                    continue
-                raise _GitError(
-                    args=("add", "-A", "--", rel),
-                    returncode=result.returncode,
-                    stdout=result.stdout,
-                    stderr=result.stderr,
-                )
+            if result.returncode == 0:
+                matched.append(rel)
+                continue
+            if "did not match" in (result.stderr + result.stdout):
+                # Benign — path is neither in the working tree nor
+                # in the index. Skip it.
+                continue
+            raise _GitError(
+                args=("add", "-A", "--", rel),
+                returncode=result.returncode,
+                stdout=result.stdout,
+                stderr=result.stderr,
+            )
+
+        if not matched:
+            return []
+
         # Only return the pathspecs if SOMETHING in the allowlist
         # actually has staged changes. Pre-staged files outside the
         # allowlist won't show up here because we restrict the diff
         # to the configured pathspecs.
         diff = self._git(
-            "diff", "--cached", "--name-only", "--", *rels
+            "diff", "--cached", "--name-only", "--", *matched
         ).strip()
-        return rels if diff else []
+        return matched if diff else []
 
     def _plan_for_entry(self, entry: PersonalizationPath) -> list[SymlinkPlan]:
         if entry.project_scoped:

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -295,6 +295,21 @@ class PersonalizationManager:
                 f"checkout_path {self.checkout_path} exists but is not a "
                 "git checkout yet; run `ctrlrelay personalization init`"
             )
+        # Unborn HEAD (clone of an empty repo, or interrupted init
+        # right after ``git clone``): ``rev-parse HEAD`` and
+        # ``rev-parse --abbrev-ref HEAD`` would both error. Detect
+        # and return the same friendly message instead of letting
+        # the error escape (Codex pass 19).
+        unborn = self._git_capturing(
+            "rev-parse", "--verify", "--quiet", "HEAD",
+            check=False,
+        )
+        if unborn.returncode != 0:
+            return (
+                f"checkout at {self.checkout_path} has unborn HEAD (no "
+                "commits yet); run `ctrlrelay personalization init` to "
+                "bootstrap"
+            )
 
         lines: list[str] = []
         lines.append(f"checkout: {self.checkout_path}")

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -984,6 +984,15 @@ def _run_git(
     """
     env = os.environ.copy()
     env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    # Treat all pathspecs as LITERAL filenames — never as git
+    # pathspec magic (``:(top)``, ``:(glob)``, ``:!exclude``, etc.).
+    # A config ``source: ":(top)secrets.txt"`` (or any other
+    # magic prefix) would otherwise let ``git add -- <rel>`` reach
+    # outside the intended allowlist (Codex pass 17 caught this).
+    # Forced on the env so every subprocess invoked via ``_run_git``
+    # gets the protection — manager-side validators already reject
+    # ``:`` in sources but defense-in-depth here is cheap.
+    env["GIT_LITERAL_PATHSPECS"] = "1"
     proc = subprocess.run(
         ["git", *args],
         cwd=str(cwd) if cwd else None,

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -146,6 +146,16 @@ class PersonalizationManager:
                         f"and is not a clone of {self.cfg.repo}; back it up "
                         "or remove it before running init"
                     )
+                # Force origin to our canonical URL. The owner/repo
+                # match in ``_is_existing_checkout_ours`` accepts any
+                # host whose trailing path equals our configured repo
+                # (Codex pass 18 caught this) — a malicious clone of
+                # ``https://evil.example/<owner>/<repo>.git`` would
+                # otherwise have init keep using that origin for the
+                # subsequent fetch/push and tunnel personalization
+                # data outside the user's intended remote. No-op if
+                # origin already points at the canonical URL.
+                self._git("remote", "set-url", "origin", self.repo_url)
                 # Same repo already there — converge to the right
                 # branch and re-wire. Useful when ``init`` is re-run
                 # after a config change. ``_bootstrap_main_if_empty``

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -267,11 +267,23 @@ class PersonalizationManager:
     def status(self) -> str:
         """Return a human-readable summary of working-tree state +
         symlink correctness. Read-only; does not fetch from origin.
+
+        Safe to run before ``init`` — the same path checks ``init``
+        uses to decide whether to clone (missing dir / empty dir /
+        non-checkout) all return a friendly "run init" message
+        instead of raising. Codex pass 14 caught the gap where an
+        existing non-checkout (e.g. empty dir or stray files) would
+        fall through to ``git rev-parse`` and traceback.
         """
         if not self.checkout_path.exists():
             return (
                 f"checkout_path {self.checkout_path} does not exist; "
                 "run `ctrlrelay personalization init`"
+            )
+        if not (self.checkout_path / ".git").exists():
+            return (
+                f"checkout_path {self.checkout_path} exists but is not a "
+                "git checkout yet; run `ctrlrelay personalization init`"
             )
 
         lines: list[str] = []

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -278,8 +278,25 @@ class PersonalizationManager:
                     conflict_files=files,
                 )
 
+            # Iteration 1: plain push (creates the per-machine branch
+            # on the remote if missing, FF otherwise).
+            # Iteration 2+: ``--force-with-lease``. After an FF-
+            # rejection on the previous iteration, the rebase that
+            # opens this iteration rewrites our local commit on top
+            # of the new origin/main, so a plain push to the per-
+            # machine branch is non-FF on the remote (Codex review
+            # pass 2 caught this). Lease checks against the local
+            # remote-tracking ref, which the fetch above just
+            # refreshed — so this only force-pushes when WE hold the
+            # only outstanding update. Per-machine branches are by
+            # design owned by exactly one node; an unexpected
+            # concurrent update would still be rejected by the lease,
+            # exactly as intended.
+            push_cmd: list[str] = ["push", "origin", self.working_branch]
+            if attempt > 1:
+                push_cmd.insert(1, "--force-with-lease")
             try:
-                self._git("push", "origin", self.working_branch)
+                self._git(*push_cmd)
             except _GitError as e:
                 return PushResult(
                     success=False,

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -1,0 +1,685 @@
+"""PersonalizationManager — clone, sync, wire symlinks for the
+operator's cross-machine personalization repo.
+
+Lifecycle:
+    init  — clone the repo (or refuse if checkout already populated),
+            check out the per-machine working branch, wire symlinks.
+    wire_symlinks — (re-)apply the ``paths`` config; idempotent.
+    status — print working-tree state + per-symlink correctness.
+    push  — stage allowlisted paths, commit on per-machine branch,
+            fetch, rebase onto ``main_branch``. Clean rebase → push
+            branch + FF-push ``main_branch``. Conflict → abort rebase
+            and surface the conflict files (Telegram escalation comes
+            in Slice 2).
+    pull  — fetch, rebase local working branch onto origin/<main>,
+            FF local main, re-wire symlinks (config-as-code may have
+            changed under us).
+
+Design choices that are easy to miss in review:
+
+* The personalization checkout is a regular ``git clone``, NOT a
+  ctrlrelay worktree-from-bare. Worktree-per-session semantics fight
+  the requirement that Claude writes flow straight to the working tree
+  in real time.
+* Per-machine branches (``personalization/<node_id>``) are the
+  conflict-avoidance mechanism. Each machine pushes its own branch and
+  then attempts a fast-forward of ``main``. Two machines pushing
+  simultaneously: one wins the FF, the other's next push starts with a
+  rebase onto the new ``main`` and tries again — never force-pushes,
+  never silently drops the other side's deltas.
+* Symlinks point INTO the checkout, not the other way around. ``git
+  status`` is therefore the source of truth for "what changed since
+  last push" — no filesystem watcher needed.
+* ``git`` is invoked synchronously via ``subprocess.run``. The rest of
+  the codebase is asyncio but the CLI commands using this manager are
+  Typer (sync), so threading an event loop through is overhead with no
+  payoff for a tool that runs ``git`` a handful of times per command.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from collections.abc import Iterable
+from dataclasses import dataclass
+from pathlib import Path
+
+from ctrlrelay.core.config import Config, Personalization, PersonalizationPath
+from ctrlrelay.personalization.paths import (
+    TemplateContext,
+    project_slug,
+    resolve_template,
+)
+
+
+class PersonalizationError(Exception):
+    """Raised on any unrecoverable personalization-sync failure."""
+
+
+@dataclass(frozen=True)
+class SymlinkPlan:
+    """One concrete (resolved) source → target wiring decision.
+
+    Produced by ``PersonalizationManager._plan_symlinks`` from the
+    user's ``PersonalizationPath`` config + the available
+    ``RepoConfig`` rows. ``apply`` turns the plan into a real
+    filesystem mutation (idempotent).
+    """
+
+    source: Path  # absolute path inside the checkout
+    target: Path  # absolute path on disk where the symlink lives
+    is_dir: bool  # whether source/target denote a directory (per template)
+    repo_name: str | None  # populated for project_scoped entries
+
+
+@dataclass(frozen=True)
+class SymlinkResult:
+    """What ``apply`` actually did, for status/diagnostic display."""
+
+    plan: SymlinkPlan
+    action: str  # "created" | "already-correct" | "replaced-stale-symlink"
+                 # | "skipped-source-missing" | "skipped-real-file-at-target"
+    detail: str = ""
+
+
+@dataclass(frozen=True)
+class PushResult:
+    success: bool
+    summary: str
+    conflict_files: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class PullResult:
+    success: bool
+    summary: str
+    conflict_files: tuple[str, ...] = ()
+
+
+class PersonalizationManager:
+    """Orchestrates a personalization-sync repo on the local machine."""
+
+    def __init__(self, config: Config) -> None:
+        if config.personalization is None:
+            raise PersonalizationError(
+                "personalization is not configured in orchestrator.yaml"
+            )
+        self.config = config
+        self.cfg: Personalization = config.personalization
+        self.checkout_path: Path = self.cfg.checkout_path
+        # ``Config.personalization_branch`` is the single source of
+        # truth for the per-machine branch (handles default-from-top-
+        # level-node_id). Memoize so subsequent git invocations don't
+        # re-derive.
+        branch = config.personalization_branch()
+        if branch is None:
+            # Defensive — shouldn't happen given the personalization
+            # check above, but explicit beats AttributeError later.
+            raise PersonalizationError("personalization_branch is unset")
+        self.working_branch: str = branch
+        self.main_branch: str = self.cfg.main_branch
+        self.repo_url: str = f"https://github.com/{self.cfg.repo}.git"
+
+    # ----- top-level commands ------------------------------------------------
+
+    def init(self) -> str:
+        """Clone the personalization repo into ``checkout_path`` and
+        wire symlinks. Refuses to overwrite an existing non-empty
+        directory; if the checkout already looks like a clone of the
+        right repo, falls through to ``wire_symlinks`` so a re-run is
+        idempotent.
+
+        Returns a human-readable summary.
+        """
+        if self.checkout_path.exists():
+            if not self._is_existing_checkout_ours():
+                raise PersonalizationError(
+                    f"checkout_path {self.checkout_path} already exists and is not a "
+                    f"clone of {self.cfg.repo}; back it up or remove it before "
+                    "running init"
+                )
+            # Same repo already there — converge to the right branch and
+            # re-wire. Useful when ``init`` is re-run after a config change.
+            self._ensure_working_branch()
+            results = self.wire_symlinks()
+            return self._format_init_summary(results, cloned=False)
+
+        self.checkout_path.parent.mkdir(parents=True, exist_ok=True)
+        self._git_global("clone", self.repo_url, str(self.checkout_path))
+        self._ensure_working_branch()
+        results = self.wire_symlinks()
+        return self._format_init_summary(results, cloned=True)
+
+    def status(self) -> str:
+        """Return a human-readable summary of working-tree state +
+        symlink correctness. Read-only; does not fetch from origin.
+        """
+        if not self.checkout_path.exists():
+            return (
+                f"checkout_path {self.checkout_path} does not exist; "
+                "run `ctrlrelay personalization init`"
+            )
+
+        lines: list[str] = []
+        lines.append(f"checkout: {self.checkout_path}")
+        lines.append(f"repo:     {self.cfg.repo}")
+        lines.append(f"branch:   {self.working_branch} (main: {self.main_branch})")
+
+        current = self._current_branch()
+        if current != self.working_branch:
+            lines.append(
+                f"  ⚠  HEAD is on {current!r}, not {self.working_branch!r}"
+            )
+
+        porcelain = self._git("status", "--porcelain").strip()
+        if porcelain:
+            lines.append("dirty working tree:")
+            for entry in porcelain.splitlines():
+                lines.append(f"  {entry}")
+        else:
+            lines.append("working tree clean")
+
+        plans = list(self._plan_symlinks())
+        if plans:
+            lines.append(f"symlinks ({len(plans)} entries):")
+            for plan in plans:
+                state = self._inspect_symlink(plan)
+                lines.append(f"  [{state}] {plan.target} -> {plan.source}")
+        else:
+            lines.append("no symlinks configured")
+
+        return "\n".join(lines)
+
+    def wire_symlinks(self) -> list[SymlinkResult]:
+        """Apply the ``paths`` config to the filesystem. Idempotent.
+
+        For each plan: create missing symlinks, replace pointing-
+        elsewhere symlinks, refuse to clobber a real file/dir, skip
+        entries whose source doesn't exist in the checkout yet (so a
+        partially-populated personalization repo is OK).
+        """
+        results: list[SymlinkResult] = []
+        for plan in self._plan_symlinks():
+            results.append(self._apply_symlink(plan))
+        return results
+
+    def push(self, message: str | None = None) -> PushResult:
+        """Commit working-tree changes on the per-machine branch, then
+        rebase onto ``origin/<main>`` and push. On rebase conflict,
+        abort the rebase and return a ``PushResult`` listing the
+        conflict files; the working tree is left in its pre-rebase
+        state so the operator can resolve manually.
+        """
+        self._require_checkout()
+        self._ensure_working_branch()
+
+        # Stage and commit if dirty. We add only paths declared in the
+        # config (their actual on-disk location inside the checkout),
+        # not ``-A``, so a stray test artifact in the checkout doesn't
+        # ride along into the personalization repo.
+        added = self._stage_configured_paths()
+        if added:
+            commit_msg = message or "personalization: sync from {}".format(
+                self.working_branch
+            )
+            try:
+                self._git("commit", "-m", commit_msg)
+            except _GitError as e:
+                # ``git commit`` exits 1 with "nothing to commit" when
+                # the staged set turns out to be a no-op (e.g. the
+                # working tree only has whitespace differences that
+                # aren't actually staged). Treat as a no-op.
+                if "nothing to commit" in (e.stdout + e.stderr).lower():
+                    pass
+                else:
+                    raise
+
+        # Fetch and try to fast-forward main locally so the rebase
+        # base is current. Failures here are not fatal — we'll surface
+        # them as part of the rebase attempt.
+        try:
+            self._git("fetch", "origin", "--prune")
+        except _GitError as e:
+            return PushResult(
+                success=False,
+                summary=f"fetch failed: {e.stderr.strip() or e.stdout.strip()}",
+            )
+
+        # Rebase the working branch onto origin/<main>. ``--keep-base``
+        # is intentional: if origin/<main> hasn't moved relative to the
+        # last rebase point, no commits get rewritten.
+        rebase = self._git_capturing(
+            "rebase", f"origin/{self.main_branch}",
+            check=False,
+        )
+        if rebase.returncode != 0:
+            # Detect conflict and abort cleanly.
+            unmerged = self._git("diff", "--name-only", "--diff-filter=U").strip()
+            self._git_capturing("rebase", "--abort", check=False)
+            files = tuple(unmerged.splitlines()) if unmerged else ()
+            return PushResult(
+                success=False,
+                summary=(
+                    "rebase onto origin/{main} hit conflicts; aborted. "
+                    "Resolve the listed files in the checkout, commit, then "
+                    "re-run push."
+                ).format(main=self.main_branch),
+                conflict_files=files,
+            )
+
+        # Push the working branch, then FF the remote main from it.
+        try:
+            self._git("push", "origin", self.working_branch)
+        except _GitError as e:
+            return PushResult(
+                success=False,
+                summary=(
+                    f"push of {self.working_branch} failed: "
+                    f"{e.stderr.strip() or e.stdout.strip()}"
+                ),
+            )
+
+        # FF-push main: only succeeds if origin/<main> hasn't moved
+        # since our fetch. If another machine raced us, this push is
+        # rejected — that's fine, the next machine that pushes will
+        # pick up our commits via origin/<branch> and FF then. No
+        # force-push, ever.
+        ff_push = self._git_capturing(
+            "push", "origin",
+            f"{self.working_branch}:{self.main_branch}",
+            check=False,
+        )
+        ff_note = ""
+        if ff_push.returncode != 0:
+            ff_note = (
+                f"; note: could not FF origin/{self.main_branch} "
+                "(another machine may have pushed first; their commits "
+                "will be picked up on the next pull)"
+            )
+
+        return PushResult(
+            success=True,
+            summary=(
+                f"pushed {self.working_branch}; "
+                f"{'fast-forwarded' if not ff_note else 'did not fast-forward'} "
+                f"origin/{self.main_branch}{ff_note}"
+            ),
+        )
+
+    def pull(self) -> PullResult:
+        """Fetch and rebase the per-machine branch onto ``origin/<main>``.
+        FF-update local main if possible. Re-wire symlinks at the end
+        because the config-as-code shipped in the personalization repo
+        may have changed.
+        """
+        self._require_checkout()
+        self._ensure_working_branch()
+
+        try:
+            self._git("fetch", "origin", "--prune")
+        except _GitError as e:
+            return PullResult(
+                success=False,
+                summary=f"fetch failed: {e.stderr.strip() or e.stdout.strip()}",
+            )
+
+        rebase = self._git_capturing(
+            "rebase", f"origin/{self.main_branch}",
+            check=False,
+        )
+        if rebase.returncode != 0:
+            unmerged = self._git("diff", "--name-only", "--diff-filter=U").strip()
+            self._git_capturing("rebase", "--abort", check=False)
+            files = tuple(unmerged.splitlines()) if unmerged else ()
+            return PullResult(
+                success=False,
+                summary=(
+                    "rebase onto origin/{main} hit conflicts; aborted. "
+                    "Resolve in the checkout, then re-run pull."
+                ).format(main=self.main_branch),
+                conflict_files=files,
+            )
+
+        # FF local main if it's a strict ancestor of origin/main.
+        ff = self._git_capturing(
+            "fetch", "origin",
+            f"{self.main_branch}:{self.main_branch}",
+            check=False,
+        )
+        # Re-wire (config may have changed; harmless if not).
+        self.wire_symlinks()
+
+        ff_note = "" if ff.returncode == 0 else (
+            f" (local {self.main_branch} not fast-forwarded — diverged "
+            "from origin)"
+        )
+        return PullResult(
+            success=True,
+            summary=(
+                f"pulled and rebased {self.working_branch} onto "
+                f"origin/{self.main_branch}{ff_note}"
+            ),
+        )
+
+    # ----- internals: symlink planning + apply -------------------------------
+
+    def _plan_symlinks(self) -> Iterable[SymlinkPlan]:
+        """Yield resolved (source, target) plans from the config.
+
+        For non-project-scoped paths: one plan with the configured
+        source/target, resolved against ``${HOME}`` only.
+        For project-scoped paths: one plan per local repo whose
+        ``RepoConfig.local_path`` exists on disk. Repos that aren't
+        cloned on this machine are silently skipped (lazy wiring is a
+        feature — a memory entry for a project this machine doesn't
+        have is a no-op until the project arrives).
+        """
+        for entry in self.cfg.paths:
+            if entry.project_scoped:
+                yield from self._plan_project_scoped(entry)
+            else:
+                yield self._plan_global(entry)
+
+    def _plan_global(self, entry: PersonalizationPath) -> SymlinkPlan:
+        ctx = TemplateContext()
+        source = self.checkout_path / entry.source.lstrip("/")
+        target = resolve_template(entry.target, ctx)
+        return SymlinkPlan(
+            source=source,
+            target=target,
+            is_dir=entry.target.endswith("/"),
+            repo_name=None,
+        )
+
+    def _plan_project_scoped(
+        self, entry: PersonalizationPath
+    ) -> Iterable[SymlinkPlan]:
+        for repo in self.config.repos:
+            local = repo.local_path
+            if local is None or not local.exists():
+                continue
+            ctx = TemplateContext(
+                project=project_slug(repo.name),
+                project_local=local,
+            )
+            source_rel = resolve_template(entry.source, ctx)
+            # ``source`` is interpreted relative to the checkout root,
+            # but ``resolve_template`` returns an absolute Path on
+            # systems where the source happens to start with ``/``.
+            # Strip a leading ``/`` if present and re-anchor under the
+            # checkout. Any ``${HOME}``/``${PROJECT_LOCAL}`` etc. in
+            # the source field would be a config bug — we still defend
+            # against it by anchoring.
+            source = self.checkout_path / str(source_rel).lstrip("/")
+            target = resolve_template(entry.target, ctx)
+            yield SymlinkPlan(
+                source=source,
+                target=target,
+                is_dir=entry.target.endswith("/"),
+                repo_name=repo.name,
+            )
+
+    def _apply_symlink(self, plan: SymlinkPlan) -> SymlinkResult:
+        if not plan.source.exists():
+            # Tolerated: the user may not have populated this entry on
+            # any machine yet. Skip without failing so wire-symlinks is
+            # safe to run on a partial repo.
+            return SymlinkResult(plan=plan, action="skipped-source-missing")
+
+        # Ensure parent dir of target exists.
+        plan.target.parent.mkdir(parents=True, exist_ok=True)
+
+        if plan.target.is_symlink():
+            current = plan.target.readlink()
+            if current == plan.source or self._same_resolved(current, plan.source):
+                return SymlinkResult(plan=plan, action="already-correct")
+            # Wrong symlink — replace.
+            plan.target.unlink()
+            plan.target.symlink_to(plan.source)
+            return SymlinkResult(
+                plan=plan,
+                action="replaced-stale-symlink",
+                detail=f"was -> {current}",
+            )
+
+        if plan.target.exists():
+            # Real file or directory at the target. Refuse — the user
+            # must back up and remove. Adopt-flow comes in Slice 2.
+            return SymlinkResult(
+                plan=plan,
+                action="skipped-real-file-at-target",
+                detail="back up and remove the existing path before retrying",
+            )
+
+        plan.target.symlink_to(plan.source)
+        return SymlinkResult(plan=plan, action="created")
+
+    def _inspect_symlink(self, plan: SymlinkPlan) -> str:
+        """Read-only counterpart to ``_apply_symlink`` for ``status``."""
+        if not plan.source.exists():
+            return "source-missing"
+        if plan.target.is_symlink():
+            current = plan.target.readlink()
+            if current == plan.source or self._same_resolved(current, plan.source):
+                return "ok"
+            return f"wrong-symlink->{current}"
+        if plan.target.exists():
+            return "real-file-blocking"
+        return "missing"
+
+    @staticmethod
+    def _same_resolved(a: Path, b: Path) -> bool:
+        try:
+            return a.resolve() == b.resolve()
+        except (OSError, RuntimeError):
+            return False
+
+    # ----- internals: git helpers --------------------------------------------
+
+    def _is_existing_checkout_ours(self) -> bool:
+        if not (self.checkout_path / ".git").exists():
+            return False
+        try:
+            origin = self._git("remote", "get-url", "origin").strip()
+        except _GitError:
+            return False
+        # Be permissive about the URL form (https vs ssh) but require
+        # the owner/repo to match.
+        owner_repo = self.cfg.repo.lower()
+        return owner_repo in origin.lower()
+
+    def _ensure_working_branch(self) -> None:
+        """Make sure HEAD is on ``working_branch``, creating it from
+        ``main_branch`` if it doesn't exist locally yet.
+        """
+        current = self._current_branch()
+        if current == self.working_branch:
+            return
+        # Does the working branch exist locally?
+        existing = self._git_capturing(
+            "show-ref", "--verify", "--quiet",
+            f"refs/heads/{self.working_branch}",
+            check=False,
+        )
+        if existing.returncode == 0:
+            self._git("checkout", self.working_branch)
+            return
+        # Try origin/<working_branch> first (another machine of ours).
+        existing_remote = self._git_capturing(
+            "show-ref", "--verify", "--quiet",
+            f"refs/remotes/origin/{self.working_branch}",
+            check=False,
+        )
+        if existing_remote.returncode == 0:
+            self._git(
+                "checkout", "-b", self.working_branch,
+                f"origin/{self.working_branch}",
+            )
+            return
+        # Brand new — branch off main.
+        self._git("checkout", "-b", self.working_branch, self.main_branch)
+
+    def _current_branch(self) -> str:
+        return self._git("rev-parse", "--abbrev-ref", "HEAD").strip()
+
+    def _stage_configured_paths(self) -> bool:
+        """``git add`` only the on-disk locations of configured sources.
+
+        Returns True if anything got staged. The selective staging
+        keeps ad-hoc cruft a user might have dropped in the checkout
+        out of the personalization repo's history.
+        """
+        rels: list[str] = []
+        for entry in self.cfg.paths:
+            # Source paths can carry placeholders, which would expand
+            # to per-repo subdirs. Stage each *resolved* source that
+            # actually exists. ``git add -- <missing>`` exits 128 with
+            # ``pathspec did not match any files``, so pre-filtering
+            # is required to keep ``push`` a no-op when the working
+            # tree is clean.
+            for plan in self._plan_for_entry(entry):
+                if not plan.source.exists():
+                    continue
+                try:
+                    rel = plan.source.relative_to(self.checkout_path)
+                except ValueError:
+                    # Source escaped the checkout — config bug, but
+                    # don't crash on push; surface in status.
+                    continue
+                rels.append(str(rel))
+        if not rels:
+            return False
+        self._git("add", "--", *rels)
+        staged = self._git("diff", "--cached", "--name-only").strip()
+        return bool(staged)
+
+    def _plan_for_entry(self, entry: PersonalizationPath) -> list[SymlinkPlan]:
+        if entry.project_scoped:
+            return list(self._plan_project_scoped(entry))
+        return [self._plan_global(entry)]
+
+    def _require_checkout(self) -> None:
+        if not (self.checkout_path / ".git").exists():
+            raise PersonalizationError(
+                f"no checkout at {self.checkout_path}; run "
+                "`ctrlrelay personalization init` first"
+            )
+
+    # ----- subprocess wrappers ------------------------------------------------
+
+    def _git(self, *args: str) -> str:
+        """Run ``git <args>`` inside the checkout and return stdout.
+
+        Uses ``check=True`` semantics; failures raise ``_GitError``
+        carrying captured stderr/stdout for the caller to inspect.
+        """
+        result = self._git_capturing(*args, check=True)
+        return result.stdout
+
+    def _git_capturing(
+        self, *args: str, check: bool = True
+    ) -> subprocess.CompletedProcess:
+        return _run_git(
+            args,
+            cwd=self.checkout_path,
+            check=check,
+        )
+
+    def _git_global(self, *args: str) -> str:
+        """Run ``git <args>`` without a cwd inside the checkout (for
+        operations like ``clone`` that target a path that doesn't
+        exist yet).
+        """
+        result = _run_git(args, cwd=None, check=True)
+        return result.stdout
+
+    # ----- formatting --------------------------------------------------------
+
+    def _format_init_summary(
+        self, results: list[SymlinkResult], *, cloned: bool
+    ) -> str:
+        lines: list[str] = []
+        if cloned:
+            lines.append(f"cloned {self.cfg.repo} -> {self.checkout_path}")
+        else:
+            lines.append(
+                f"checkout already at {self.checkout_path}; converged config"
+            )
+        lines.append(f"working branch: {self.working_branch}")
+        if results:
+            counts: dict[str, int] = {}
+            for r in results:
+                counts[r.action] = counts.get(r.action, 0) + 1
+            for action, n in sorted(counts.items()):
+                lines.append(f"  {action}: {n}")
+        else:
+            lines.append("  (no symlinks configured)")
+        return "\n".join(lines)
+
+
+# -----------------------------------------------------------------------------
+# Module-level helpers (kept outside the class so tests can patch them)
+
+
+class _GitError(Exception):
+    def __init__(
+        self, args: tuple[str, ...], returncode: int, stdout: str, stderr: str
+    ):
+        super().__init__(
+            f"git {' '.join(args)} exited {returncode}: {stderr.strip() or stdout.strip()}"
+        )
+        self.args_run = args
+        self.returncode = returncode
+        self.stdout = stdout
+        self.stderr = stderr
+
+
+def _run_git(
+    args: tuple[str, ...] | list[str],
+    *,
+    cwd: Path | None,
+    check: bool,
+) -> subprocess.CompletedProcess:
+    """Thin wrapper around ``subprocess.run(['git', ...])``.
+
+    Captures both stdout and stderr as text (utf-8 with replacement so
+    a stray non-utf-8 byte from a remote can't blow up the orchestrator).
+    Sets ``GIT_TERMINAL_PROMPT=0`` so an HTTP auth prompt against a
+    private repo fails fast instead of hanging the daemon.
+    """
+    env = os.environ.copy()
+    env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    proc = subprocess.run(
+        ["git", *args],
+        cwd=str(cwd) if cwd else None,
+        env=env,
+        capture_output=True,
+        text=True,
+        encoding="utf-8",
+        errors="replace",
+        check=False,
+    )
+    if check and proc.returncode != 0:
+        raise _GitError(
+            args=tuple(args),
+            returncode=proc.returncode,
+            stdout=proc.stdout,
+            stderr=proc.stderr,
+        )
+    return proc
+
+
+def remove_symlink(target: Path) -> None:
+    """Best-effort symlink removal helper used by the CLI's
+    ``unwire`` future command (Slice 2). Kept here so tests can hit it
+    without spinning up a full manager.
+    """
+    if target.is_symlink():
+        target.unlink()
+    elif target.exists() and not target.is_symlink():
+        # Real file/dir — refuse to delete; that's a manual operator
+        # decision.
+        raise PersonalizationError(
+            f"refusing to delete real path at {target}; not a symlink"
+        )
+    # Missing is fine — nothing to remove.

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -146,9 +146,63 @@ class PersonalizationManager:
 
         self.checkout_path.parent.mkdir(parents=True, exist_ok=True)
         self._git_global("clone", self.repo_url, str(self.checkout_path))
+        self._bootstrap_main_if_empty()
         self._ensure_working_branch()
         results = self.wire_symlinks()
         return self._format_init_summary(results, cloned=True)
+
+    def _bootstrap_main_if_empty(self) -> None:
+        """Create an initial commit on ``main_branch`` if the cloned
+        repo has none yet.
+
+        A brand-new GitHub repo (no commits, no default branch) clones
+        with an "unborn HEAD" — ``origin/<main>`` doesn't exist, so
+        ``_ensure_working_branch`` would later fail trying to branch
+        from it. To make ``init`` the natural bootstrap path, we
+        detect this state, write a tiny ``README.md``, commit it on
+        ``main_branch``, and push. After this the rest of init
+        proceeds normally.
+
+        We only act when ``origin/<main_branch>`` is missing — an
+        existing remote branch (whether the user's default or one
+        they created) is left alone.
+        """
+        # If origin/<main_branch> already exists, nothing to bootstrap.
+        existing_remote = self._git_capturing(
+            "show-ref", "--verify", "--quiet",
+            f"refs/remotes/origin/{self.main_branch}",
+            check=False,
+        )
+        if existing_remote.returncode == 0:
+            return
+
+        # Configure user identity if not already set on this clone —
+        # ``git commit`` errors out without one. Only override when
+        # missing so the operator's global config still wins on
+        # machines where they've set it.
+        if not self._git_capturing(
+            "config", "--get", "user.email", check=False
+        ).stdout.strip():
+            self._git("config", "user.email", "ctrlrelay@local")
+        if not self._git_capturing(
+            "config", "--get", "user.name", check=False
+        ).stdout.strip():
+            self._git("config", "user.name", "ctrlrelay")
+
+        readme = self.checkout_path / "README.md"
+        if not readme.exists():
+            readme.write_text(
+                "# personalization\n\n"
+                "Managed by ctrlrelay personalization sync. "
+                "See `ctrlrelay personalization --help`.\n"
+            )
+        self._git("checkout", "-b", self.main_branch)
+        self._git("add", "README.md")
+        self._git(
+            "commit", "-m",
+            "personalization: bootstrap empty repo",
+        )
+        self._git("push", "-u", "origin", self.main_branch)
 
     def status(self) -> str:
         """Return a human-readable summary of working-tree state +

--- a/src/ctrlrelay/personalization/paths.py
+++ b/src/ctrlrelay/personalization/paths.py
@@ -124,13 +124,20 @@ def resolve_template(template: str, ctx: TemplateContext) -> Path:
     return Path(result).expanduser()
 
 
+_PROJECT_SLUG_SEP = "--"
+
+
 def project_slug(repo_name: str) -> str:
-    """Flatten an ``owner/repo`` string to ``owner-repo``.
+    """Flatten an ``owner/repo`` string to ``owner--repo``.
 
     Used both for the ``${PROJECT}`` placeholder value and for the
     on-disk source-tree directory name inside the personalization
-    repo (e.g. ``claude-memory/AInvirion-ctrlrelay/``). Avoids nested
-    owner subdirectories and avoids collisions across orgs that use
-    the same repo name.
+    repo (e.g. ``claude-memory/AInvirion--ctrlrelay/``). Avoids
+    nested owner subdirectories and, importantly, avoids collisions
+    where ``a-b/c`` and ``a/b-c`` would both flatten to ``a-b-c``
+    under a single-hyphen scheme. Double-hyphen is collision-free
+    for valid GitHub owner/repo pairs because GitHub disallows
+    consecutive hyphens in owner names (Codex review pass 6 caught
+    this).
     """
-    return repo_name.replace("/", "-")
+    return repo_name.replace("/", _PROJECT_SLUG_SEP)

--- a/src/ctrlrelay/personalization/paths.py
+++ b/src/ctrlrelay/personalization/paths.py
@@ -1,0 +1,136 @@
+"""Path encoding and template resolution for personalization sync.
+
+Two responsibilities:
+
+1. ``encode_project_path`` — replicate Claude Code's directory-name
+   encoding for ``~/.claude/projects/<encoded>/``. Verified empirically
+   against ~/.claude/projects/ on a real install: every character that
+   is not ``[A-Za-z0-9-]`` is replaced by ``-``. No collapsing of runs;
+   ``/.ctrlrelay/`` becomes ``--ctrlrelay-`` (the slash + dot each
+   produce their own ``-``).
+
+2. ``resolve_template`` — substitute the placeholder set declared in
+   ``config.py`` (``${HOME}``, ``${PROJECT}``, ``${PROJECT_ENCODED}``,
+   ``${PROJECT_LOCAL}``, ``${PROJECT_PARENT}``) in source/target paths
+   from ``Personalization.paths``.
+
+Kept dependency-free so the manager can use it during init/wire without
+loading the rest of the package.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+# Anything outside [A-Za-z0-9-] becomes '-'. Hyphens already in the
+# original path stay as hyphens (idempotent under this rule).
+_NON_SAFE_CHAR_RE = re.compile(r"[^A-Za-z0-9-]")
+
+
+def encode_project_path(absolute_path: Path | str, *, resolve_symlinks: bool = False) -> str:
+    """Encode an absolute filesystem path the way Claude Code does for
+    its per-project directory under ``~/.claude/projects/``.
+
+    Args:
+        absolute_path: Absolute path or ``~``-prefixed path. Relative
+            paths are an error.
+        resolve_symlinks: When True, follow symlinks before encoding.
+            Default False — match the path as configured in
+            ``orchestrator.yaml`` (``RepoConfig.local_path``) which is
+            ``expanduser``'d but not resolved. Set True only if you
+            observe Claude using the resolved form on this machine.
+
+    Returns:
+        The encoded directory name (no leading slash; first character
+        is ``-`` because absolute paths start with ``/``).
+
+    Raises:
+        ValueError: If ``absolute_path`` is not absolute after
+            ``expanduser``.
+    """
+    p = Path(absolute_path).expanduser()
+    if not p.is_absolute():
+        raise ValueError(
+            f"encode_project_path requires an absolute path, got {absolute_path!r}"
+        )
+    if resolve_symlinks:
+        p = p.resolve()
+    return _NON_SAFE_CHAR_RE.sub("-", str(p))
+
+
+@dataclass(frozen=True)
+class TemplateContext:
+    """Inputs for ``resolve_template``.
+
+    For non-project-scoped sync entries leave both fields ``None``.
+    For project-scoped entries set both: ``project`` is the
+    ``<owner>-<repo>`` flat slug (avoids nested-owner-dir surprises and
+    name collisions across orgs); ``project_local`` is the
+    ``RepoConfig.local_path`` value (already ``expanduser``'d at config
+    load time).
+    """
+
+    project: str | None = None
+    project_local: Path | None = None
+
+
+def resolve_template(template: str, ctx: TemplateContext) -> Path:
+    """Substitute placeholders in a source/target template and return a Path.
+
+    Recognized placeholders:
+      - ``${HOME}`` — current user's home directory.
+      - ``${PROJECT}`` — ``<owner>-<repo>`` flat slug.
+      - ``${PROJECT_ENCODED}`` — Claude's path encoding of
+        ``project_local`` (cf. ``encode_project_path``).
+      - ``${PROJECT_LOCAL}`` — absolute path to the project working tree.
+      - ``${PROJECT_PARENT}`` — parent directory of ``project_local``.
+
+    Project placeholders raise ``ValueError`` when the context lacks
+    project information; ``HOME`` always works. Trailing slashes on the
+    template are preserved on the returned ``Path`` only by virtue of
+    the caller — ``Path`` itself does not retain trailing slashes —
+    so callers that care about file-vs-directory distinction must
+    inspect the *template string* (e.g., ``template.endswith("/")``)
+    not the returned path.
+    """
+    result = template
+    if "${HOME}" in result:
+        result = result.replace("${HOME}", str(Path.home()))
+
+    needs_project = any(
+        marker in result
+        for marker in (
+            "${PROJECT}",
+            "${PROJECT_ENCODED}",
+            "${PROJECT_LOCAL}",
+            "${PROJECT_PARENT}",
+        )
+    )
+    if needs_project:
+        if ctx.project is None or ctx.project_local is None:
+            raise ValueError(
+                f"template {template!r} uses project placeholders but no "
+                "project context was provided"
+            )
+        # Replace longest matches first so ``${PROJECT_ENCODED}`` doesn't
+        # get partially-eaten by a ``${PROJECT}`` substitution.
+        result = result.replace("${PROJECT_ENCODED}", encode_project_path(ctx.project_local))
+        result = result.replace("${PROJECT_LOCAL}", str(ctx.project_local))
+        result = result.replace("${PROJECT_PARENT}", str(ctx.project_local.parent))
+        result = result.replace("${PROJECT}", ctx.project)
+
+    return Path(result).expanduser()
+
+
+def project_slug(repo_name: str) -> str:
+    """Flatten an ``owner/repo`` string to ``owner-repo``.
+
+    Used both for the ``${PROJECT}`` placeholder value and for the
+    on-disk source-tree directory name inside the personalization
+    repo (e.g. ``claude-memory/AInvirion-ctrlrelay/``). Avoids nested
+    owner subdirectories and avoids collisions across orgs that use
+    the same repo name.
+    """
+    return repo_name.replace("/", "-")

--- a/src/ctrlrelay/templates/global-CLAUDE.md.snippet
+++ b/src/ctrlrelay/templates/global-CLAUDE.md.snippet
@@ -21,18 +21,20 @@ personalization repo and stay out of the project's own git history.
 - **Per-project specs and superpower outputs** — write to:
 
   ```
-  <project-parent>/specs/<owner>-<project-name>/<topic>.md
+  <project-parent>/specs/<owner>--<project-name>/<topic>.md
   ```
 
-  The `<owner>-<project-name>` flat slug matches the `${PROJECT}` placeholder
-  in `orchestrator.yaml` (e.g. `AInvirion-ctrlrelay`), so the file lands inside
-  the directory ctrlrelay symlinks into the personalization repo. Using the
-  bare repo name (e.g. just `ctrlrelay`) instead would write outside the
-  symlinked dir and the artifact would never sync.
+  The `<owner>--<project-name>` (DOUBLE hyphen) flat slug matches the
+  `${PROJECT}` placeholder in `orchestrator.yaml` (e.g.
+  `AInvirion--ctrlrelay`), so the file lands inside the directory ctrlrelay
+  symlinks into the personalization repo. Double hyphen avoids collisions
+  like `a-b/c` vs `a/b-c` flattening to the same single-hyphen string.
+  Using the bare repo name (e.g. just `ctrlrelay`) instead would write
+  outside the symlinked dir and the artifact would never sync.
 
   Example: working in `~/Projects/AINVIRION/ctrlrelay`, a feature spec for
   "personalization-sync" goes in
-  `~/Projects/AINVIRION/specs/AInvirion-ctrlrelay/personalization-sync.md`.
+  `~/Projects/AINVIRION/specs/AInvirion--ctrlrelay/personalization-sync.md`.
   Never inside the project repo itself — keeps the project's `git status`
   and PR diff clean and avoids leaking instructions/strategy notes if the
   repo is shared or made public.

--- a/src/ctrlrelay/templates/global-CLAUDE.md.snippet
+++ b/src/ctrlrelay/templates/global-CLAUDE.md.snippet
@@ -1,0 +1,53 @@
+<!--
+  Append the block below to your global ~/.claude/CLAUDE.md. It establishes
+  a filing convention for spec docs and superpower outputs that pairs with
+  ctrlrelay's personalization sync — Claude writes to predictable paths,
+  ctrlrelay's `paths` config picks them up by default, and nothing pollutes
+  the project's own git repo.
+
+  The placeholders below (<project>, <project-parent>, <workspace>) are
+  illustrative for human readers. Claude resolves them from the cwd it
+  was launched in; ctrlrelay's `${PROJECT}`, `${PROJECT_PARENT}`, etc.
+  resolve them from `RepoConfig.local_path` at symlink-time.
+-->
+
+## Filing convention for generated artifacts
+
+When you produce artifacts that should outlive a single conversation (spec
+docs, design notes, superpower definitions, multi-step plans, runbooks),
+follow these paths so they sync across machines via ctrlrelay's
+personalization repo and stay out of the project's own git history.
+
+- **Per-project specs and superpower outputs** — write to:
+
+  ```
+  <project-parent>/specs/<project-name>/<topic>.md
+  ```
+
+  Example: working in `~/Projects/AINVIRION/ctrlrelay`, a feature spec for
+  "personalization-sync" goes in
+  `~/Projects/AINVIRION/specs/ctrlrelay/personalization-sync.md`. Never
+  inside the project repo — keeps the project's `git status` and PR diff
+  clean and avoids leaking instructions/strategy notes if the repo is
+  shared or made public.
+
+- **Multi-repo workspace planning docs** — write to:
+
+  ```
+  <workspace>/notes/<topic>.md
+  ```
+
+  Example: `~/Projects/RESEARCH/DMP/notes/RELEASE_ROADMAP.md`. Use this
+  for content that spans several repos under one parent directory.
+
+- **Per-project Claude memory** — keep using
+  `~/.claude/projects/<encoded>/memory/` as you do now; ctrlrelay
+  manages the symlink to the personalization repo.
+
+- **Global Claude config (this file, skills, agents, commands)** —
+  edit normally under `~/.claude/`; ctrlrelay's symlinks make those
+  edits land in the personalization repo for sync.
+
+If you produce an artifact and these paths don't fit, ASK before writing
+it inside a project's source tree. The default answer is "outside the
+project, in the workspace's `specs/` or `notes/`."

--- a/src/ctrlrelay/templates/global-CLAUDE.md.snippet
+++ b/src/ctrlrelay/templates/global-CLAUDE.md.snippet
@@ -21,15 +21,21 @@ personalization repo and stay out of the project's own git history.
 - **Per-project specs and superpower outputs** — write to:
 
   ```
-  <project-parent>/specs/<project-name>/<topic>.md
+  <project-parent>/specs/<owner>-<project-name>/<topic>.md
   ```
+
+  The `<owner>-<project-name>` flat slug matches the `${PROJECT}` placeholder
+  in `orchestrator.yaml` (e.g. `AInvirion-ctrlrelay`), so the file lands inside
+  the directory ctrlrelay symlinks into the personalization repo. Using the
+  bare repo name (e.g. just `ctrlrelay`) instead would write outside the
+  symlinked dir and the artifact would never sync.
 
   Example: working in `~/Projects/AINVIRION/ctrlrelay`, a feature spec for
   "personalization-sync" goes in
-  `~/Projects/AINVIRION/specs/ctrlrelay/personalization-sync.md`. Never
-  inside the project repo — keeps the project's `git status` and PR diff
-  clean and avoids leaking instructions/strategy notes if the repo is
-  shared or made public.
+  `~/Projects/AINVIRION/specs/AInvirion-ctrlrelay/personalization-sync.md`.
+  Never inside the project repo itself — keeps the project's `git status`
+  and PR diff clean and avoids leaking instructions/strategy notes if the
+  repo is shared or made public.
 
 - **Multi-repo workspace planning docs** — write to:
 

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -692,6 +692,92 @@ class TestPushDeletionAndContention:
         assert (c_checkout / "global" / "from-a.md").exists()
         assert (c_checkout / "global" / "from-b.md").exists()
 
+    def test_retry_loop_recovers_from_simulated_ff_rejection(
+        self, tmp_path: Path, remote_bare: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Force the FF-push of main to fail once, then succeed. The
+        retry loop must:
+          1. detect the FF rejection,
+          2. fetch the advanced main,
+          3. rebase the local working branch (rewriting commits),
+          4. push the per-machine branch with --force-with-lease
+             (otherwise non-FF on the rewritten branch),
+          5. retry the FF push of main.
+        """
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        a_mgr = PersonalizationManager(a_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("rev1\n")
+
+        # Patch ``_git_capturing`` to simulate one FF rejection on the
+        # first ``working_branch:main`` push, then let the retry
+        # succeed normally. We also need to actually advance
+        # origin/main between the first FF and the retry, otherwise
+        # the rebase in iteration 2 is a no-op and the retried push
+        # would be identical to the first attempt (and hit the same
+        # patched failure). Spinning up a "phantom" commit on main is
+        # cheap: push a marker commit to the bare via a sidecar clone.
+        from ctrlrelay.personalization import manager as mgr_module
+
+        ff_attempts = {"n": 0}
+        original = mgr_module.PersonalizationManager._git_capturing
+
+        # Sidecar clone we'll use to inject a concurrent commit.
+        sidecar = tmp_path / "sidecar"
+        _git("clone", str(remote_bare), str(sidecar), cwd=tmp_path)
+        _git("config", "user.email", "x@x", cwd=sidecar)
+        _git("config", "user.name", "Sidecar", cwd=sidecar)
+
+        def patched_git_capturing(self, *args: str, check: bool = True):
+            # Detect the FF push: ``push origin <branch>:<main>``.
+            # The colon-form refspec only appears in the FF push
+            # invocation; all other push paths use a plain branch name.
+            is_ff = (
+                args
+                and args[0] == "push"
+                and any(
+                    isinstance(a, str) and a.endswith(":" + self.main_branch)
+                    for a in args
+                )
+            )
+            if is_ff and ff_attempts["n"] == 0:
+                ff_attempts["n"] += 1
+                # Simulate origin/main having advanced under us:
+                # commit + push from the sidecar so the next fetch
+                # actually sees a new main tip.
+                (sidecar / "phantom.md").write_text("phantom\n")
+                _git("add", "phantom.md", cwd=sidecar)
+                _git("commit", "-m", "phantom advance", cwd=sidecar)
+                _git("push", "origin", "main", cwd=sidecar)
+                # Return a synthetic non-zero exit so the retry path
+                # engages — exactly as if the real push had failed.
+                import subprocess
+                return subprocess.CompletedProcess(
+                    args=args,
+                    returncode=1,
+                    stdout="",
+                    stderr=" ! [rejected]        develop -> main (non-fast-forward)\n",
+                )
+            return original(self, *args, check=check)
+
+        monkeypatch.setattr(
+            mgr_module.PersonalizationManager,
+            "_git_capturing",
+            patched_git_capturing,
+        )
+
+        result = a_mgr.push(message="rev1")
+        assert result.success, result.summary
+        assert "after 2 attempts" in result.summary
+        # And the phantom commit didn't get clobbered.
+        c_checkout = tmp_path / "verify"
+        _git("clone", str(remote_bare), str(c_checkout), cwd=tmp_path)
+        assert (c_checkout / "phantom.md").exists()
+        assert (c_checkout / "global" / "CLAUDE.md").read_text() == "rev1\n"
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1100,6 +1100,41 @@ class TestPushDeletionAndContention:
         assert (verify / "advance.md").exists()
         assert (verify / "global" / "CLAUDE.md").read_text() == "rev2\n"
 
+    def test_push_does_not_commit_pre_staged_outside_allowlist(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """If something is pre-staged in the index OUTSIDE the
+        configured allowlist (operator manually ran ``git add``, an
+        interrupted previous run, etc.), push must NOT commit it.
+        Codex pass 12 finding: an unscoped ``git commit`` would
+        publish unrelated/private files alongside legitimate
+        configured changes. The commit must be scoped to the
+        configured pathspecs.
+        """
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        a_mgr = PersonalizationManager(a_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+
+        # Allowlisted change (will be committed):
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("public\n")
+
+        # NON-allowlisted file pre-staged (must NOT be committed):
+        (a_checkout / "secrets.txt").write_text("leak-me-not\n")
+        _git("add", "secrets.txt", cwd=a_checkout)
+
+        result = a_mgr.push(message="legit-change")
+        assert result.success, result.summary
+
+        # Verify on a fresh clone that secrets.txt did NOT travel.
+        verify = tmp_path / "verify"
+        _git("clone", str(remote_bare), str(verify), cwd=tmp_path)
+        assert (verify / "global" / "CLAUDE.md").exists()
+        assert (verify / "global" / "CLAUDE.md").read_text() == "public\n"
+        assert not (verify / "secrets.txt").exists()
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -581,6 +581,173 @@ class TestPushPullIntegration:
         assert not (b_checkout / ".git" / "rebase-apply").exists()
 
 
+class TestPushDeletionAndContention:
+    """Regressions for the three Codex-review findings."""
+
+    def test_push_stages_tracked_file_deletion(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """A configured single-file source that was previously committed
+        and is then deleted in the working tree must have its deletion
+        staged and pushed. Earlier the missing-source filter skipped
+        deletions, leaving a tombstone-only-on-this-machine and a
+        stale file forever on the remote.
+        """
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        a_mgr = PersonalizationManager(a_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+
+        # Add and push a file.
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("v1\n")
+        a_mgr.wire_symlinks()
+        first = a_mgr.push(message="add v1")
+        assert first.success, first.summary
+
+        # Delete it and push the deletion.
+        (a_checkout / "global" / "CLAUDE.md").unlink()
+        deletion = a_mgr.push(message="delete it")
+        assert deletion.success, deletion.summary
+
+        # Verify on a second machine that the file is gone.
+        b_checkout = tmp_path / "machine-b" / "personalization"
+        b_config = _config_for(b_checkout, remote_bare, node_id="machine-b")
+        b_mgr = PersonalizationManager(b_config)
+        _patch_remote_url(b_mgr, str(remote_bare))
+        b_mgr.init()
+        b_mgr.pull()
+        assert not (b_checkout / "global" / "CLAUDE.md").exists()
+
+    def test_push_succeeds_after_concurrent_main_advance(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """If origin/main advances between our fetch and our FF-push
+        (a non-conflicting concurrent push from another machine), the
+        retry loop must rebase onto the new tip and try again rather
+        than reporting a hollow success.
+        """
+        # Use a DIRECTORY path so multiple files match the configured
+        # source. The default ``_config_for`` only configures a single
+        # file; that wouldn't stage A's and B's distinct sibling files.
+        def _dir_config(checkout: Path, node_id: str) -> Config:
+            return Config.model_validate({
+                "version": "1",
+                "node_id": node_id,
+                "timezone": "UTC",
+                "paths": {
+                    "state_db": "/tmp/state.db",
+                    "worktrees": "/tmp/worktrees",
+                    "bare_repos": "/tmp/bare",
+                    "contexts": "/tmp/contexts",
+                    "skills": "/tmp/skills",
+                },
+                "transport": {
+                    "type": "file_mock",
+                    "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+                },
+                "dashboard": {"enabled": False},
+                "personalization": {
+                    "repo": "test/dotclaude",
+                    "checkout_path": str(checkout),
+                    "paths": [
+                        {
+                            "source": "global/",
+                            "target": str(checkout.parent / "fake-home/global") + "/",
+                        },
+                    ],
+                },
+                "repos": [],
+            })
+
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        b_checkout = tmp_path / "machine-b" / "personalization"
+        a_mgr = PersonalizationManager(_dir_config(a_checkout, "machine-a"))
+        b_mgr = PersonalizationManager(_dir_config(b_checkout, "machine-b"))
+        _patch_remote_url(a_mgr, str(remote_bare))
+        _patch_remote_url(b_mgr, str(remote_bare))
+        a_mgr.init()
+        b_mgr.init()
+
+        # A and B touch DIFFERENT files under the configured dir (no
+        # rebase conflict). Both pushes commit; B races A on FF.
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "from-a.md").write_text("a\n")
+        (b_checkout / "global").mkdir()
+        (b_checkout / "global" / "from-b.md").write_text("b\n")
+
+        result_a = a_mgr.push(message="from-a")
+        assert result_a.success
+        result_b = b_mgr.push(message="from-b")
+        assert result_b.success, result_b.summary
+
+        # Verify origin/main contains both commits — i.e. B's push
+        # actually landed on main, not just on the per-machine branch.
+        c_checkout = tmp_path / "machine-c" / "personalization"
+        c_mgr = PersonalizationManager(_dir_config(c_checkout, "machine-c"))
+        _patch_remote_url(c_mgr, str(remote_bare))
+        c_mgr.init()
+        c_mgr.pull()
+        assert (c_checkout / "global" / "from-a.md").exists()
+        assert (c_checkout / "global" / "from-b.md").exists()
+
+    def test_init_works_with_non_default_main_branch(
+        self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """When ``personalization.main_branch`` is not the repo's
+        default (which after ``git clone`` is the only locally-
+        checked-out branch), init must branch from ``origin/<main>``,
+        not the bare name.
+        """
+        # Build a remote whose default is "main" but which also has a
+        # "develop" branch carrying initial content.
+        base = tmp_path_factory.mktemp("alt-main")
+        bare = _git_init_bare(base / "alt.git")
+        seed = base / "seed"
+        _git_init_with_initial_commit(seed, remote_url=str(bare))
+        # Create a 'develop' branch with its own commit and push it.
+        _git("checkout", "-b", "develop", cwd=seed)
+        (seed / "develop-marker.md").write_text("on develop\n")
+        _git("add", "develop-marker.md", cwd=seed)
+        _git("commit", "-m", "develop init", cwd=seed)
+        _git("push", "-u", "origin", "develop", cwd=seed)
+
+        checkout = tmp_path / "personalization"
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-x",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                "repo": "test/dotclaude",
+                "checkout_path": str(checkout),
+                "main_branch": "develop",
+                "paths": [],
+            },
+            "repos": [],
+        })
+        mgr = PersonalizationManager(cfg)
+        mgr.repo_url = str(bare)
+        mgr.init()
+        # On the per-machine branch...
+        head = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=checkout).strip()
+        assert head == "personalization/machine-x"
+        # ...and reachable from develop's content (the marker file).
+        assert (checkout / "develop-marker.md").exists()
+
+
 class TestManagerErrors:
     def test_init_rejected_when_path_exists_and_not_ours(
         self, tmp_path: Path, remote_bare: Path

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -477,6 +477,46 @@ class TestSymlinkWiring:
         assert target.is_symlink() is False
         assert target.read_text() == "real file, do not clobber"
 
+    def test_refuses_source_file_when_config_says_dir(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """Config declares a directory source (trailing slash) but
+        the on-disk source is a regular file. The wire must NOT
+        create a symlink — wiring would point the dir-shaped target
+        at a file and break consumers (Codex pass 15).
+        """
+        # Source path on disk is a FILE, but config says DIRECTORY.
+        (empty_checkout / "skills").write_text("oops, not a dir")
+        target = tmp_path / "home" / ".claude" / "skills"
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[
+                {"source": "skills/", "target": str(target) + "/"},
+            ],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert len(results) == 1
+        assert results[0].action == "skipped-source-type-mismatch"
+        assert not target.exists()
+
+    def test_refuses_source_dir_when_config_says_file(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """Mirror case: config says single-file source, but on disk
+        the source is actually a directory.
+        """
+        (empty_checkout / "CLAUDE.md").mkdir()  # actually a dir
+        target = tmp_path / "home" / ".claude" / "CLAUDE.md"
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[
+                {"source": "CLAUDE.md", "target": str(target)},
+            ],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "skipped-source-type-mismatch"
+        assert not target.exists()
+
     def test_skips_missing_source(
         self, tmp_path: Path, empty_checkout: Path
     ) -> None:
@@ -1477,6 +1517,42 @@ class TestCLI:
         # No traceback in output; the manager's actionable message wins.
         assert "Traceback" not in result.output
         assert "no checkout" in result.output.lower()
+
+    def test_init_clone_failure_returns_exit_1_no_traceback(
+        self, tmp_path: Path
+    ) -> None:
+        """A git clone failure (e.g. unreachable URL) must produce a
+        clean exit code 1, not a traceback. Codex pass 15 finding:
+        ``_GitError`` previously didn't derive from
+        ``PersonalizationError`` and escaped the CLI handler.
+        """
+        from typer.testing import CliRunner
+
+        from ctrlrelay.cli import app
+
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(_base_config_dict({
+            # Point at a path that definitely fails clone.
+            "repo": "owner/repo",
+            "checkout_path": str(tmp_path / "new-checkout"),
+            "paths": [],
+        })))
+        # Block network attempts with a bogus repo URL by using
+        # GIT_TERMINAL_PROMPT=0 (already set by the manager) and
+        # making the URL effectively unreachable. We patch the URL
+        # via env so the clone tries and fails with a non-zero git
+        # exit. The CLI wrapper should catch.
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["personalization", "init", "--config", str(cfg_path)],
+            env={"GIT_HTTP_LOW_SPEED_LIMIT": "1", "GIT_HTTP_LOW_SPEED_TIME": "1"},
+        )
+        # Either auth/network or invalid URL — both exit non-zero
+        # with no traceback now that _GitError is a
+        # PersonalizationError subclass.
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
 
     def test_pull_before_init_returns_exit_1(self, tmp_path: Path) -> None:
         from typer.testing import CliRunner

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -213,6 +213,41 @@ class TestPersonalizationConfig:
         with pytest.raises(ConfigError, match="project_scoped"):
             load_config(path)
 
+    @pytest.mark.parametrize("bad_source", [
+        "../secret",        # parent escape
+        "foo/../etc",       # buried parent escape
+        "/etc/passwd",      # absolute
+    ])
+    def test_source_path_escape_rejected(
+        self, tmp_path: Path, bad_source: str
+    ) -> None:
+        """``source`` must stay inside the personalization checkout —
+        ``..`` segments and absolute paths would let a config wire
+        symlinks pointing outside the repo and crash later in ``git
+        add`` (Codex pass 8 finding).
+        """
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": bad_source, "target": "~/safe"},
+            ],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_target_dotdot_rejected(self, tmp_path: Path) -> None:
+        """``..`` in target is also rejected for auditability."""
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": "global/CLAUDE.md", "target": "~/.claude/../etc"},
+            ],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
     def test_dir_vs_file_mismatch_rejected(self, tmp_path: Path) -> None:
         path = tmp_path / "cfg.yaml"
         path.write_text(yaml.dump(_base_config_dict({
@@ -277,6 +312,8 @@ class TestPersonalizationConfig:
         "caret^here",    # caret — git ref-illegal
         "with/slash",    # slash inside a single component
         "",              # empty
+        "trailing.",     # trailing dot — git rejects (Codex pass 8)
+        "foo.lock",      # .lock suffix — reserved by git
     ])
     def test_main_branch_rejects_git_unsafe_chars(
         self, tmp_path: Path, bad: str

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -236,6 +236,23 @@ class TestPersonalizationConfig:
         with pytest.raises(ConfigError):
             load_config(path)
 
+    def test_home_in_source_rejected(self, tmp_path: Path) -> None:
+        """${HOME} is a valid target placeholder but nonsensical in
+        source — source is rooted at the personalization checkout,
+        not the user's home dir. Earlier the validator accepted it
+        and wire would silently treat it as a literal subdir whose
+        name was ``${HOME}`` (Codex pass 11).
+        """
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": "${HOME}/something", "target": "~/elsewhere"},
+            ],
+        })))
+        with pytest.raises(ConfigError, match="HOME"):
+            load_config(path)
+
     def test_target_dotdot_rejected(self, tmp_path: Path) -> None:
         """``..`` in target is also rejected for auditability."""
         path = tmp_path / "cfg.yaml"

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -860,6 +860,89 @@ class TestPushDeletionAndContention:
         ).strip()
         assert remote_main, "origin/main should exist after bootstrap"
 
+    def test_init_refuses_when_main_branch_misconfigured(
+        self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """If the remote has commits but no branch matching
+        ``main_branch`` (typical when the repo is on ``master`` and
+        the user wrote ``main`` in config), init must NOT silently
+        create a parallel ``main`` — it must surface the
+        misconfiguration so the operator can fix the config.
+        """
+        base = tmp_path_factory.mktemp("master-only")
+        bare = _git_init_bare(base / "master-only.git")
+        seed = base / "seed"
+        _git_init_with_initial_commit(seed, remote_url=str(bare))
+        # Push master, then flip the bare repo's HEAD so deleting
+        # ``main`` on it is allowed (a bare repo refuses to delete
+        # the branch its HEAD points at).
+        _git("branch", "-m", "main", "master", cwd=seed)
+        _git("push", "-u", "origin", "master", cwd=seed)
+        _git(
+            "symbolic-ref", "HEAD", "refs/heads/master",
+            cwd=bare,
+        )
+        _git("push", "origin", "--delete", "main", cwd=seed)
+
+        checkout = tmp_path / "personalization"
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-x",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                "repo": "test/master-only",
+                "checkout_path": str(checkout),
+                # Wrong: remote uses "master".
+                "main_branch": "main",
+                "paths": [],
+            },
+            "repos": [],
+        })
+        mgr = PersonalizationManager(cfg)
+        mgr.repo_url = str(bare)
+        with pytest.raises(PersonalizationError, match="not empty"):
+            mgr.init()
+
+    def test_push_sets_local_identity_when_global_missing(
+        self, tmp_path: Path, remote_bare: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh machine without global user.email / user.name must
+        still be able to commit on push; the manager configures a
+        fallback identity on the local checkout.
+        """
+        # Force git to ignore any system/global config so we mimic a
+        # truly identity-less machine.
+        monkeypatch.setenv("GIT_CONFIG_NOSYSTEM", "1")
+        monkeypatch.setenv("HOME", str(tmp_path / "fresh-home"))
+        (tmp_path / "fresh-home").mkdir()
+
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-fresh")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+        mgr.init()
+
+        # Make a real change so push has something to commit.
+        (checkout / "global").mkdir()
+        (checkout / "global" / "CLAUDE.md").write_text("hi from fresh\n")
+        result = mgr.push(message="from-fresh-machine")
+        assert result.success, result.summary
+        # Local identity got configured on the checkout.
+        email = _git("config", "--get", "user.email", cwd=checkout).strip()
+        assert email == "ctrlrelay@local"
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1135,6 +1135,64 @@ class TestPushDeletionAndContention:
         assert (verify / "global" / "CLAUDE.md").read_text() == "public\n"
         assert not (verify / "secrets.txt").exists()
 
+    def test_push_succeeds_when_some_configured_sources_are_missing(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """A push must succeed when SOME configured sources have
+        changes and OTHERS are missing on disk (the documented
+        partial-repo state — e.g. a machine that uses CLAUDE.md but
+        hasn't populated skills/ yet). Earlier the missing source's
+        pathspec leaked into the commit's ``-- <paths>`` and
+        ``git commit`` failed with "pathspec did not match" — Codex
+        pass 13 caught this P1.
+        """
+        checkout = tmp_path / "personalization"
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-partial",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                "repo": "test/dotclaude",
+                "checkout_path": str(checkout),
+                # Two paths configured. We'll only populate the first.
+                "paths": [
+                    {
+                        "source": "global/CLAUDE.md",
+                        "target": str(tmp_path / "fake/CLAUDE.md"),
+                    },
+                    {
+                        "source": "global/skills/",
+                        "target": str(tmp_path / "fake/skills") + "/",
+                    },
+                ],
+            },
+            "repos": [],
+        })
+        mgr = PersonalizationManager(cfg)
+        _patch_remote_url(mgr, str(remote_bare))
+        mgr.init()
+
+        # Populate ONLY the CLAUDE.md source. The skills/ source is
+        # never created on this machine — the documented "partial"
+        # state.
+        (checkout / "global").mkdir()
+        (checkout / "global" / "CLAUDE.md").write_text("partial-only\n")
+
+        result = mgr.push(message="partial")
+        assert result.success, result.summary
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1579,6 +1579,37 @@ class TestManagerErrors:
         msg = mgr.status()
         assert "does not exist" in msg
 
+    def test_status_works_on_unborn_head(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+        remote_bare: Path,
+    ) -> None:
+        """Codex pass 19: a clone of a brand-new empty repo has
+        ``.git`` but no commits — rev-parse HEAD errors. status
+        must detect unborn HEAD and emit the friendly pre-init
+        message.
+        """
+        # Clone an empty bare repo manually to produce unborn HEAD.
+        empty_base = tmp_path_factory.mktemp("unborn")
+        empty_bare = _git_init_bare(empty_base / "empty.git")
+
+        checkout = tmp_path / "personalization"
+        _git("clone", str(empty_bare), str(checkout), cwd=tmp_path)
+        # Sanity: no commits.
+        rv = _run_git(
+            ("rev-parse", "--verify", "HEAD"),
+            cwd=checkout,
+            check=False,
+        )
+        assert rv.returncode != 0  # confirms unborn
+
+        config = _config_for(checkout, remote_bare, node_id="machine-x")
+        mgr = PersonalizationManager(config)
+        msg = mgr.status()
+        assert "unborn HEAD" in msg
+        assert "init" in msg
+
     def test_status_works_when_checkout_dir_exists_without_git(
         self, tmp_path: Path, remote_bare: Path
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1423,6 +1423,24 @@ class TestManagerErrors:
         msg = mgr.status()
         assert "does not exist" in msg
 
+    def test_status_works_when_checkout_dir_exists_without_git(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """``status`` must remain safe when ``checkout_path`` exists
+        but isn't a git checkout (empty dir created by provisioning,
+        a previous interrupted init that ran ``mkdir`` only, etc.).
+        Codex pass 14 finding: this previously fell through to
+        ``git rev-parse`` and surfaced a traceback through the CLI.
+        """
+        checkout = tmp_path / "personalization"
+        checkout.mkdir()  # exists, no .git
+        # Throw a stray file in too — should still be safe.
+        (checkout / "stray").write_text("x\n")
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        msg = mgr.status()
+        assert "not a git checkout" in msg
+
     def test_push_before_init_errors(self, tmp_path: Path, remote_bare: Path) -> None:
         checkout = tmp_path / "personalization"
         config = _config_for(checkout, remote_bare, node_id="machine-a")

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -253,6 +253,29 @@ class TestPersonalizationConfig:
         with pytest.raises(ConfigError, match="HOME"):
             load_config(path)
 
+    @pytest.mark.parametrize("bad_source", [
+        ":(top)secrets.txt",   # pathspec magic
+        ":(glob)*.md",
+        ":!exclude",
+        ":hidden",
+    ])
+    def test_pathspec_magic_in_source_rejected(
+        self, tmp_path: Path, bad_source: str
+    ) -> None:
+        """Codex pass 17: ``:`` introduces git pathspec magic. A
+        configured source with magic could let ``git add -- <rel>``
+        bypass the allowlist; reject at config load.
+        """
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": bad_source, "target": "~/safe"},
+            ],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
     def test_target_dotdot_rejected(self, tmp_path: Path) -> None:
         """``..`` in target is also rejected for auditability."""
         path = tmp_path / "cfg.yaml"

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1233,6 +1233,43 @@ class TestPushDeletionAndContention:
         result = mgr.push(message="partial")
         assert result.success, result.summary
 
+    def test_init_adopts_per_node_branch_created_after_clone(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """A's init created ``origin/personalization/machine-a``.
+        B clones the repo BEFORE A pushes, then later runs
+        ``personalization init`` again. Init must adopt
+        ``origin/personalization/machine-b`` if it now exists on
+        origin (created by A pushing on machine-b's behalf, or by a
+        previous fleet sync), not branch off main and clobber it on
+        the next push. Codex pass 16 caught this P1.
+        """
+        # Step 1: Pre-create origin/personalization/machine-b on the
+        # remote with a marker commit.
+        seed = tmp_path / "seed-b"
+        _git("clone", str(remote_bare), str(seed), cwd=tmp_path)
+        _git("config", "user.email", "x@x", cwd=seed)
+        _git("config", "user.name", "Seed-B", cwd=seed)
+        _git("checkout", "-b", "personalization/machine-b", cwd=seed)
+        (seed / "marker.md").write_text("seeded for machine-b\n")
+        _git("add", "marker.md", cwd=seed)
+        _git("commit", "-m", "machine-b seed", cwd=seed)
+        _git("push", "-u", "origin", "personalization/machine-b", cwd=seed)
+
+        # Step 2: B clones AFTER seed pushed.
+        b_checkout = tmp_path / "machine-b" / "personalization"
+        b_config = _config_for(b_checkout, remote_bare, node_id="machine-b")
+        b_mgr = PersonalizationManager(b_config)
+        _patch_remote_url(b_mgr, str(remote_bare))
+        b_mgr.init()
+
+        # Init should have adopted the per-node branch — the marker
+        # file should be reachable from HEAD.
+        head = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=b_checkout).strip()
+        assert head == "personalization/machine-b"
+        assert (b_checkout / "marker.md").exists()
+        assert (b_checkout / "marker.md").read_text() == "seeded for machine-b\n"
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1417,6 +1417,57 @@ class TestManagerErrors:
         with pytest.raises(PersonalizationError, match="not a clone"):
             mgr.init()
 
+    def test_init_resets_origin_when_existing_clone_points_at_foreign_host(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """Codex pass 18: ``_is_existing_checkout_ours`` matches on
+        owner/repo only, so a malicious clone of
+        ``https://evil.example/<owner>/<repo>.git`` would otherwise
+        keep that origin and tunnel personalization data outside the
+        intended remote. Init must reset origin to the canonical
+        ``self.repo_url``.
+        """
+        # Spin up a fake foreign bare repo with the matching tail.
+        foreign_base = tmp_path_factory.mktemp("foreign")
+        foreign_bare = _git_init_bare(foreign_base / "victim.git")
+        seed = foreign_base / "seed"
+        _git_init_with_initial_commit(seed, remote_url=str(foreign_bare))
+
+        # Pre-populate checkout_path with a clone of the foreign bare,
+        # but rewrite origin to look like the configured repo's tail
+        # via a github-shaped malicious URL. Then init must redirect.
+        checkout = tmp_path / "personalization"
+        _git("clone", str(foreign_bare), str(checkout), cwd=tmp_path)
+        # Simulate origin pointing at a non-github host with a
+        # matching tail.
+        _git(
+            "remote", "set-url", "origin",
+            "https://evil.example/test/dotclaude.git",
+            cwd=checkout,
+        )
+
+        # Spin up the LEGITIMATE bare we'll redirect to.
+        legit_base = tmp_path_factory.mktemp("legit")
+        legit_bare = _git_init_bare(legit_base / "legit.git")
+        legit_seed = legit_base / "seed"
+        _git_init_with_initial_commit(legit_seed, remote_url=str(legit_bare))
+
+        config = _config_for(checkout, legit_bare, node_id="machine-x")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(legit_bare))
+        # init should detect the URL match by tail (acme-style
+        # check) AND reset origin to the canonical URL — verified
+        # below.
+        mgr.init()
+        actual_origin = _git(
+            "remote", "get-url", "origin", cwd=checkout
+        ).strip()
+        assert actual_origin == str(legit_bare)
+        # No stale "evil.example" reference left over.
+        assert "evil.example" not in actual_origin
+
     def test_init_clones_into_empty_directory(
         self, tmp_path: Path, remote_bare: Path
     ) -> None:
@@ -1502,10 +1553,15 @@ class TestManagerErrors:
             "remote", "set-url", "origin", str(bare), cwd=checkout
         )
         mgr = PersonalizationManager(cfg)
-        # Override the URL extraction since our local bare path
-        # doesn't have an ``owner/repo`` shape — patch the regex
-        # check to recognize this as ours for test purposes.
+        # Override URL handling for the test:
+        #   - ``_is_existing_checkout_ours`` would extract a github-
+        #     shaped owner/repo from origin and compare; our local
+        #     bare path doesn't fit. Force True.
+        #   - ``repo_url`` is what init's origin-reset (Codex pass
+        #     18 fix) writes back. Point it at the local bare so the
+        #     reset doesn't redirect us at github.com.
         mgr._is_existing_checkout_ours = lambda: True  # type: ignore[method-assign]
+        mgr.repo_url = str(bare)
         summary = mgr.init()
         assert "personalization/machine-recover" in summary
         # Bootstrap ran: README on main, our per-machine branch

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1223,6 +1223,87 @@ class TestManagerErrors:
         mgr.init()
         assert (checkout / ".git").exists()
 
+    def test_init_recovers_existing_empty_clone(
+        self,
+        tmp_path: Path,
+        tmp_path_factory: pytest.TempPathFactory,
+    ) -> None:
+        """If checkout_path is already a clone of the configured repo
+        but the remote is still empty (e.g. the user manually cloned
+        and then ran init, or a previous init was interrupted right
+        after ``git clone``), the converge-existing path must
+        bootstrap rather than blow up trying to rev-parse an unborn
+        HEAD. Codex pass 10 finding.
+        """
+        base = tmp_path_factory.mktemp("empty-clone")
+        bare = _git_init_bare(base / "empty.git")
+        # Manually clone (no commits) — simulates the interrupted state.
+        checkout = tmp_path / "personalization"
+        _git("clone", str(bare), str(checkout), cwd=tmp_path)
+
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-recover",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                "repo": "test/empty",
+                "checkout_path": str(checkout),
+                "paths": [],
+            },
+            "repos": [],
+        })
+        # Spoof the origin URL to satisfy ``_is_existing_checkout_ours``.
+        _git(
+            "remote", "set-url", "origin",
+            "https://github.com/test/empty.git",
+            cwd=checkout,
+        )
+        # ...but real fetch/clone target is the local bare.
+        # We re-set origin AGAIN to the local bare so push/clone in
+        # bootstrap can actually reach it. The is-ours check uses the
+        # parsed owner/repo from the URL, so we use a dual approach:
+        # set the remote URL to the local path and also set a
+        # ``url.<base>.insteadOf`` rewrite so the OWNER/REPO check
+        # still passes. Simpler: set the URL to a github-shaped URL
+        # via insteadOf and let the actual operations follow it to
+        # the local bare. But _is_existing_checkout_ours reads
+        # remote.origin.url directly — it doesn't follow insteadOf.
+        # So set origin to the local bare path AND ensure the
+        # checkout-ours check considers it ours by virtue of the
+        # config repo being a sentinel that matches the local URL
+        # tail. Simplest: override the URL parsing for the test. The
+        # cleanest approach is to set origin to an URL whose tail
+        # matches "test/empty" (the configured repo) and use a git
+        # ``url.X.insteadOf`` rewrite so operations against that URL
+        # transparently go to the bare.
+        _git(
+            "remote", "set-url", "origin", str(bare), cwd=checkout
+        )
+        mgr = PersonalizationManager(cfg)
+        # Override the URL extraction since our local bare path
+        # doesn't have an ``owner/repo`` shape — patch the regex
+        # check to recognize this as ours for test purposes.
+        mgr._is_existing_checkout_ours = lambda: True  # type: ignore[method-assign]
+        summary = mgr.init()
+        assert "personalization/machine-recover" in summary
+        # Bootstrap ran: README on main, our per-machine branch
+        # branched off main.
+        assert (checkout / "README.md").exists()
+        head = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=checkout).strip()
+        assert head == "personalization/machine-recover"
+
     def test_status_works_before_init(self, tmp_path: Path, remote_bare: Path) -> None:
         # status should not raise when the checkout doesn't exist yet —
         # it should print a friendly message that a wired CLI can show.
@@ -1238,3 +1319,52 @@ class TestManagerErrors:
         mgr = PersonalizationManager(config)
         with pytest.raises(PersonalizationError, match="no checkout"):
             mgr.push()
+
+
+class TestCLI:
+    """Smoke tests for the Typer wrappers around the manager. Verifies
+    that ``personalization push`` / ``pull`` (Codex pass 10 finding)
+    catch ``PersonalizationError`` and exit cleanly instead of
+    propagating a traceback."""
+
+    def test_push_before_init_returns_exit_1(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from typer.testing import CliRunner
+
+        from ctrlrelay.cli import app
+
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "checkout_path": str(tmp_path / "checkout"),  # absent → error
+            "paths": [],
+        })))
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["personalization", "push", "--config", str(cfg_path)],
+        )
+        assert result.exit_code == 1
+        # No traceback in output; the manager's actionable message wins.
+        assert "Traceback" not in result.output
+        assert "no checkout" in result.output.lower()
+
+    def test_pull_before_init_returns_exit_1(self, tmp_path: Path) -> None:
+        from typer.testing import CliRunner
+
+        from ctrlrelay.cli import app
+
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "checkout_path": str(tmp_path / "checkout"),
+            "paths": [],
+        })))
+        runner = CliRunner()
+        result = runner.invoke(
+            app,
+            ["personalization", "pull", "--config", str(cfg_path)],
+        )
+        assert result.exit_code == 1
+        assert "Traceback" not in result.output

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1,0 +1,612 @@
+"""Tests for personalization sync.
+
+Three layers:
+
+1. ``paths`` — path encoding (matches Claude's actual encoding) +
+   template resolution.
+2. ``manager.wire_symlinks`` — idempotent + replace-stale +
+   refuse-real-file + skip-missing-source.
+3. ``manager.push/pull`` — integration against a tmp bare-repo "remote"
+   and two tmp working checkouts simulating machines A and B. Covers
+   the happy path and the rebase-conflict abort path.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+import yaml
+
+from ctrlrelay.core.config import (
+    Config,
+    ConfigError,
+    load_config,
+)
+from ctrlrelay.personalization import (
+    PersonalizationManager,
+    TemplateContext,
+    encode_project_path,
+    resolve_template,
+)
+from ctrlrelay.personalization.manager import PersonalizationError, _run_git
+from ctrlrelay.personalization.paths import project_slug
+
+# ---------- Layer 1: path encoding + template resolution ---------------------
+
+
+class TestEncodeProjectPath:
+    def test_simple_absolute_path(self) -> None:
+        assert encode_project_path("/Users/foo/Projects/bar") == "-Users-foo-Projects-bar"
+
+    def test_dot_in_path_becomes_dash(self) -> None:
+        # ``.ctrlrelay`` becomes ``-ctrlrelay``; combined with the
+        # preceding ``/`` you get ``--ctrlrelay``.
+        encoded = encode_project_path("/Users/foo/.ctrlrelay/repos/x")
+        assert encoded == "-Users-foo--ctrlrelay-repos-x"
+
+    def test_underscore_becomes_dash(self) -> None:
+        # Verified against ~/.claude/projects/ on a real install:
+        # ``oscarvalenzuelab/my_lalanotes`` is encoded as
+        # ``oscarvalenzuelab-my-lalanotes``.
+        encoded = encode_project_path("/Users/foo/Projects/my_lalanotes")
+        assert encoded == "-Users-foo-Projects-my-lalanotes"
+
+    def test_existing_hyphen_preserved(self) -> None:
+        encoded = encode_project_path("/Users/foo/Projects/dev-sync")
+        assert encoded == "-Users-foo-Projects-dev-sync"
+
+    def test_dot_in_repo_name(self) -> None:
+        # ``SemClone/semcl.one`` per real install → ``semcl-one``.
+        encoded = encode_project_path("/Users/foo/SEMCL.ONE/semcl.one")
+        assert encoded == "-Users-foo-SEMCL-ONE-semcl-one"
+
+    def test_relative_path_rejected(self) -> None:
+        with pytest.raises(ValueError, match="absolute"):
+            encode_project_path("relative/path")
+
+    def test_tilde_expansion(self) -> None:
+        encoded = encode_project_path("~")
+        # The encoding should start with the encoded form of $HOME.
+        # We don't know the literal home in CI so just assert it
+        # starts with ``-`` and contains no unescaped path separators.
+        assert encoded.startswith("-")
+        assert "/" not in encoded
+
+
+class TestResolveTemplate:
+    def test_home_only_no_project_context(self) -> None:
+        result = resolve_template("${HOME}/.claude/CLAUDE.md", TemplateContext())
+        assert result == Path.home() / ".claude" / "CLAUDE.md"
+
+    def test_tilde_works_too(self) -> None:
+        result = resolve_template("~/.claude/CLAUDE.md", TemplateContext())
+        assert result == Path.home() / ".claude" / "CLAUDE.md"
+
+    def test_project_placeholders(self, tmp_path: Path) -> None:
+        local = tmp_path / "owner" / "repo"
+        ctx = TemplateContext(project="owner-repo", project_local=local)
+        assert resolve_template("${PROJECT}", ctx) == Path("owner-repo")
+        assert resolve_template("${PROJECT_LOCAL}", ctx) == local
+        assert resolve_template("${PROJECT_PARENT}", ctx) == tmp_path / "owner"
+        assert resolve_template("${PROJECT_ENCODED}", ctx) == Path(
+            encode_project_path(local)
+        )
+
+    def test_missing_project_context_raises(self) -> None:
+        with pytest.raises(ValueError, match="project context"):
+            resolve_template("${PROJECT}/foo", TemplateContext())
+
+    def test_combined_placeholders(self, tmp_path: Path) -> None:
+        local = tmp_path / "AInvirion" / "ctrlrelay"
+        ctx = TemplateContext(project="AInvirion-ctrlrelay", project_local=local)
+        result = resolve_template("${PROJECT_PARENT}/specs/${PROJECT}/", ctx)
+        assert result == tmp_path / "AInvirion" / "specs" / "AInvirion-ctrlrelay"
+
+    def test_project_encoded_doesnt_eat_project(self, tmp_path: Path) -> None:
+        # Substitution order must replace ``${PROJECT_ENCODED}`` before
+        # ``${PROJECT}`` so the latter doesn't partially-eat the former.
+        local = tmp_path / "x"
+        ctx = TemplateContext(project="x", project_local=local)
+        # Both placeholders in one template:
+        out = resolve_template("a/${PROJECT_ENCODED}/b/${PROJECT}/c", ctx)
+        assert "${PROJECT" not in str(out)
+
+
+class TestProjectSlug:
+    def test_simple(self) -> None:
+        assert project_slug("AInvirion/ctrlrelay") == "AInvirion-ctrlrelay"
+
+    def test_idempotent_on_already_flat(self) -> None:
+        assert project_slug("AInvirion-ctrlrelay") == "AInvirion-ctrlrelay"
+
+
+# ---------- Layer 2: config loading ------------------------------------------
+
+
+def _base_config_dict(personalization: dict | None = None) -> dict:
+    """Minimal valid orchestrator.yaml dict, optionally with a personalization block."""
+    cfg: dict = {
+        "version": "1",
+        "node_id": "test-node",
+        "timezone": "UTC",
+        "paths": {
+            "state_db": "~/.ctrlrelay/state.db",
+            "worktrees": "~/.ctrlrelay/worktrees",
+            "bare_repos": "~/.ctrlrelay/repos",
+            "contexts": "~/.ctrlrelay/contexts",
+            "skills": "~/.ctrlrelay/skills",
+        },
+        "transport": {
+            "type": "file_mock",
+            "file_mock": {
+                "inbox": "~/.ctrlrelay/inbox.txt",
+                "outbox": "~/.ctrlrelay/outbox.txt",
+            },
+        },
+        "dashboard": {"enabled": False},
+        "repos": [],
+    }
+    if personalization is not None:
+        cfg["personalization"] = personalization
+    return cfg
+
+
+class TestPersonalizationConfig:
+    def test_personalization_optional(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict()))
+        config = load_config(path)
+        assert config.personalization is None
+        assert config.personalization_branch() is None
+
+    def test_personalization_loads(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/dotclaude",
+            "paths": [
+                {"source": "global/CLAUDE.md", "target": "~/.claude/CLAUDE.md"},
+            ],
+        })))
+        config = load_config(path)
+        assert config.personalization is not None
+        assert config.personalization.repo == "owner/dotclaude"
+        assert config.personalization_branch() == "personalization/test-node"
+
+    def test_invalid_repo_name(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "not_a_valid/owner/repo",  # extra slash
+            "paths": [],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    def test_unknown_placeholder_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": "x/${BOGUS}/y", "target": "~/x"},
+            ],
+        })))
+        with pytest.raises(ConfigError, match="unknown placeholders"):
+            load_config(path)
+
+    def test_project_placeholder_without_project_scoped_rejected(
+        self, tmp_path: Path
+    ) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": "x/${PROJECT}/", "target": "~/x/"},
+                # missing project_scoped: true
+            ],
+        })))
+        with pytest.raises(ConfigError, match="project_scoped"):
+            load_config(path)
+
+    def test_dir_vs_file_mismatch_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "paths": [
+                {"source": "x/", "target": "~/x"},  # source is dir, target file
+            ],
+        })))
+        with pytest.raises(ConfigError, match="directory vs file"):
+            load_config(path)
+
+    def test_main_branch_validates_safe(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "main_branch": "--exec=evil",
+            "paths": [],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+
+# ---------- Layer 3: symlink wiring ------------------------------------------
+
+
+def _build_config(
+    *,
+    checkout_path: Path,
+    paths: list[dict],
+    repos: list[dict] | None = None,
+) -> Config:
+    """Build a Config object directly (bypassing YAML) for fast tests."""
+    return Config.model_validate({
+        "version": "1",
+        "node_id": "test-node",
+        "timezone": "UTC",
+        "paths": {
+            "state_db": "/tmp/state.db",
+            "worktrees": "/tmp/worktrees",
+            "bare_repos": "/tmp/bare",
+            "contexts": "/tmp/contexts",
+            "skills": "/tmp/skills",
+        },
+        "transport": {
+            "type": "file_mock",
+            "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+        },
+        "dashboard": {"enabled": False},
+        "personalization": {
+            "repo": "owner/dotclaude",
+            "checkout_path": str(checkout_path),
+            "paths": paths,
+        },
+        "repos": repos or [],
+    })
+
+
+@pytest.fixture
+def empty_checkout(tmp_path: Path) -> Path:
+    """A directory pretending to be the personalization checkout. Not a
+    real git repo — symlink wiring tests don't need git, so we skip the
+    cost.
+    """
+    checkout = tmp_path / "personalization"
+    checkout.mkdir()
+    return checkout
+
+
+class TestSymlinkWiring:
+    def test_creates_missing_symlink(self, tmp_path: Path, empty_checkout: Path) -> None:
+        # Source must exist in the checkout for wire to act on it.
+        (empty_checkout / "global").mkdir()
+        (empty_checkout / "global" / "CLAUDE.md").write_text("hi")
+
+        target_dir = tmp_path / "home" / ".claude"
+        target = target_dir / "CLAUDE.md"
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert len(results) == 1
+        assert results[0].action == "created"
+        assert target.is_symlink()
+        assert target.readlink() == empty_checkout / "global" / "CLAUDE.md"
+
+    def test_idempotent(self, tmp_path: Path, empty_checkout: Path) -> None:
+        (empty_checkout / "global").mkdir()
+        (empty_checkout / "global" / "CLAUDE.md").write_text("hi")
+        target = tmp_path / "home" / ".claude" / "CLAUDE.md"
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        mgr = PersonalizationManager(config)
+        mgr.wire_symlinks()
+        # Second run is a no-op.
+        results = mgr.wire_symlinks()
+        assert results[0].action == "already-correct"
+
+    def test_replaces_wrong_symlink(self, tmp_path: Path, empty_checkout: Path) -> None:
+        (empty_checkout / "global").mkdir()
+        (empty_checkout / "global" / "CLAUDE.md").write_text("hi")
+        target = tmp_path / "home" / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        wrong = tmp_path / "wrong"
+        wrong.write_text("wrong")
+        target.symlink_to(wrong)
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "replaced-stale-symlink"
+        assert target.readlink() == empty_checkout / "global" / "CLAUDE.md"
+
+    def test_refuses_real_file_at_target(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        (empty_checkout / "global").mkdir()
+        (empty_checkout / "global" / "CLAUDE.md").write_text("from-checkout")
+        target = tmp_path / "home" / ".claude" / "CLAUDE.md"
+        target.parent.mkdir(parents=True)
+        target.write_text("real file, do not clobber")
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "skipped-real-file-at-target"
+        assert target.is_symlink() is False
+        assert target.read_text() == "real file, do not clobber"
+
+    def test_skips_missing_source(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        target = tmp_path / "home" / ".claude" / "CLAUDE.md"
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "skipped-source-missing"
+        assert target.exists() is False
+
+    def test_project_scoped_only_wires_existing_repos(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        # Two configured repos — one cloned locally, one not.
+        cloned = tmp_path / "cloned"
+        cloned.mkdir()
+        not_cloned = tmp_path / "not_cloned"  # deliberately not created
+
+        # Source dir exists in checkout for the cloned repo only.
+        (empty_checkout / "claude-memory" / "owner-cloned").mkdir(parents=True)
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[
+                {
+                    "source": "claude-memory/${PROJECT}/",
+                    # Explicit trailing slash on the str — pathlib drops it.
+                    "target": str(tmp_path / "claude-projects" / "${PROJECT_ENCODED}") + "/",
+                    "project_scoped": True,
+                },
+            ],
+            repos=[
+                {"name": "owner/cloned", "local_path": str(cloned)},
+                {"name": "owner/not-cloned", "local_path": str(not_cloned)},
+            ],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        # Only the cloned repo gets a plan; not_cloned is filtered by
+        # the ``local_path.exists()`` gate in ``_plan_project_scoped``.
+        assert len(results) == 1
+        assert results[0].action == "created"
+        assert results[0].plan.repo_name == "owner/cloned"
+
+
+# ---------- Layer 4: integration push/pull -----------------------------------
+
+
+def _git(*args: str, cwd: Path) -> str:
+    return _run_git(args, cwd=cwd, check=True).stdout
+
+
+def _git_init_bare(path: Path) -> Path:
+    path.mkdir(parents=True)
+    _git("init", "--bare", "--initial-branch=main", cwd=path)
+    return path
+
+
+def _git_init_with_initial_commit(path: Path, *, remote_url: str) -> None:
+    """Clone an empty bare repo, create main with one commit, push.
+
+    Some git versions refuse to push a brand-new branch named ``main``
+    to a totally-empty bare repo unless we set the upstream explicitly.
+    Doing this in a helper isolates the dance.
+    """
+    path.mkdir(parents=True)
+    env = {**os.environ, "GIT_TERMINAL_PROMPT": "0"}
+    subprocess.run(
+        ["git", "clone", remote_url, str(path)],
+        check=True,
+        env=env,
+        capture_output=True,
+    )
+    # Pin author so commits are deterministic-enough for assertions.
+    _git("config", "user.email", "test@example.com", cwd=path)
+    _git("config", "user.name", "Test", cwd=path)
+    _git("checkout", "-b", "main", cwd=path)
+    (path / "README.md").write_text("seed\n")
+    _git("add", "README.md", cwd=path)
+    _git("commit", "-m", "seed", cwd=path)
+    _git("push", "-u", "origin", "main", cwd=path)
+
+
+@pytest.fixture
+def remote_bare(tmp_path_factory: pytest.TempPathFactory) -> Path:
+    """Local bare repo standing in for the GitHub remote."""
+    base = tmp_path_factory.mktemp("remote")
+    bare = _git_init_bare(base / "dotclaude.git")
+    # Seed the bare repo via a sidecar working clone — easier than
+    # constructing the initial commit manually.
+    seed_dir = base / "seed"
+    _git_init_with_initial_commit(seed_dir, remote_url=str(bare))
+    return bare
+
+
+def _config_for(checkout: Path, remote_bare: Path, *, node_id: str) -> Config:
+    """Build a Config whose personalization repo URL points at the
+    local bare repo (so tests don't hit the network).
+    """
+    cfg = Config.model_validate({
+        "version": "1",
+        "node_id": node_id,
+        "timezone": "UTC",
+        "paths": {
+            "state_db": "/tmp/state.db",
+            "worktrees": "/tmp/worktrees",
+            "bare_repos": "/tmp/bare",
+            "contexts": "/tmp/contexts",
+            "skills": "/tmp/skills",
+        },
+        "transport": {
+            "type": "file_mock",
+            "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+        },
+        "dashboard": {"enabled": False},
+        "personalization": {
+            "repo": "test/dotclaude",   # passes the regex; URL is overridden below
+            "checkout_path": str(checkout),
+            "paths": [
+                {
+                    "source": "global/CLAUDE.md",
+                    "target": str(
+                        checkout.parent / "fake-home/.claude/CLAUDE.md"
+                    ),
+                },
+            ],
+        },
+        "repos": [],
+    })
+    return cfg
+
+
+def _patch_remote_url(mgr: PersonalizationManager, url: str) -> None:
+    """Override the GitHub URL with our local bare-repo path so
+    ``init`` clones from the test fixture.
+    """
+    mgr.repo_url = url
+
+
+class TestPushPullIntegration:
+    def test_init_clones_and_creates_per_machine_branch(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+
+        summary = mgr.init()
+        assert "personalization/machine-a" in summary
+        assert (checkout / ".git").exists()
+        # On the per-machine branch.
+        head = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=checkout).strip()
+        assert head == "personalization/machine-a"
+
+    def test_push_no_changes_is_noop_success(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+        mgr.init()
+
+        # Nothing to commit — push should still succeed (just pushes
+        # the empty branch update, FF main is a no-op).
+        result = mgr.push(message="empty")
+        assert result.success, result.summary
+
+    def test_push_then_pull_propagates_change(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        # Machine A: init, write content, push.
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        a_mgr = PersonalizationManager(a_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("from machine-a\n")
+        # Re-wire so the symlink exists and the source is staged on push.
+        a_mgr.wire_symlinks()
+        push_a = a_mgr.push(message="from-a")
+        assert push_a.success, push_a.summary
+
+        # Machine B: init, expect to pick up A's content.
+        b_checkout = tmp_path / "machine-b" / "personalization"
+        b_config = _config_for(b_checkout, remote_bare, node_id="machine-b")
+        b_mgr = PersonalizationManager(b_config)
+        _patch_remote_url(b_mgr, str(remote_bare))
+        b_mgr.init()
+        # Pull rebases B's branch onto origin/main, which now carries A's commit.
+        pull_b = b_mgr.pull()
+        assert pull_b.success, pull_b.summary
+        assert (b_checkout / "global" / "CLAUDE.md").read_text() == "from machine-a\n"
+
+    def test_concurrent_writes_rebase_conflict_aborts_cleanly(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        # Both machines edit the same file before either has pulled.
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        b_checkout = tmp_path / "machine-b" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        b_config = _config_for(b_checkout, remote_bare, node_id="machine-b")
+        a_mgr = PersonalizationManager(a_config)
+        b_mgr = PersonalizationManager(b_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        _patch_remote_url(b_mgr, str(remote_bare))
+        a_mgr.init()
+        b_mgr.init()
+
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("from-a\n")
+        (b_checkout / "global").mkdir()
+        (b_checkout / "global" / "CLAUDE.md").write_text("from-b\n")
+
+        # A pushes first → wins origin/main.
+        result_a = a_mgr.push()
+        assert result_a.success
+
+        # B pushes — rebase onto origin/main now sees a conflict on
+        # CLAUDE.md. Expect a clean abort with conflict_files reported.
+        result_b = b_mgr.push()
+        assert result_b.success is False
+        assert "conflict" in result_b.summary.lower()
+        assert "global/CLAUDE.md" in result_b.conflict_files
+        # Working tree restored — not in the middle of a rebase.
+        # The file is still there with B's content; rebase aborted.
+        assert (b_checkout / "global" / "CLAUDE.md").read_text() == "from-b\n"
+        # No ``rebase-merge`` directory (which would mean rebase still in progress).
+        assert not (b_checkout / ".git" / "rebase-merge").exists()
+        assert not (b_checkout / ".git" / "rebase-apply").exists()
+
+
+class TestManagerErrors:
+    def test_init_rejected_when_path_exists_and_not_ours(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        checkout = tmp_path / "personalization"
+        checkout.mkdir()
+        (checkout / "stranger").write_text("not a clone")
+
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+        with pytest.raises(PersonalizationError, match="back it up"):
+            mgr.init()
+
+    def test_status_works_before_init(self, tmp_path: Path, remote_bare: Path) -> None:
+        # status should not raise when the checkout doesn't exist yet —
+        # it should print a friendly message that a wired CLI can show.
+        checkout = tmp_path / "personalization"  # not created
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        msg = mgr.status()
+        assert "does not exist" in msg
+
+    def test_push_before_init_errors(self, tmp_path: Path, remote_bare: Path) -> None:
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        with pytest.raises(PersonalizationError, match="no checkout"):
+            mgr.push()

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1027,6 +1027,62 @@ class TestPushDeletionAndContention:
         email = _git("config", "--get", "user.email", cwd=checkout).strip()
         assert email == "ctrlrelay@local"
 
+    def test_push_recovers_when_origin_branch_ahead_of_main(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """A previous invocation may have left
+        ``origin/personalization/<node>`` updated while
+        ``origin/main`` did NOT fast-forward (interrupted, retry
+        budget exhausted, etc.). The next push must rebase locally
+        and force-with-lease the per-machine branch — earlier the
+        first attempt was a plain push that hit non-FF rejection on
+        the per-machine branch and exited before retry-2 engaged
+        force-with-lease. Codex review pass 9 caught this.
+        """
+        # Bring the world into the broken state: A pushes successfully,
+        # then a sidecar advances origin/main, leaving A's local
+        # branch out of date with origin/main but A's branch on origin
+        # still at its old SHA (i.e. origin/personalization/A is
+        # behind both origin/main AND what A's local branch will
+        # become after rebase).
+        a_checkout = tmp_path / "machine-a" / "personalization"
+        a_config = _config_for(a_checkout, remote_bare, node_id="machine-a")
+        a_mgr = PersonalizationManager(a_config)
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("rev1\n")
+        first = a_mgr.push(message="rev1")
+        assert first.success, first.summary
+
+        # Sidecar push to advance origin/main without touching A's
+        # per-machine branch. After this:
+        #   origin/main = rev1 + sidecar
+        #   origin/personalization/machine-a = rev1
+        sidecar = tmp_path / "sidecar"
+        _git("clone", str(remote_bare), str(sidecar), cwd=tmp_path)
+        _git("config", "user.email", "x@x", cwd=sidecar)
+        _git("config", "user.name", "Sidecar", cwd=sidecar)
+        (sidecar / "advance.md").write_text("advance\n")
+        _git("add", "advance.md", cwd=sidecar)
+        _git("commit", "-m", "advance main", cwd=sidecar)
+        _git("push", "origin", "main", cwd=sidecar)
+
+        # Now A wants to make another change. With the bug, the
+        # rebase at the start of push() rewrites A's commit, plain
+        # push to per-machine branch is non-FF and fails on attempt
+        # 1, and the function exits before retry-2 can engage
+        # force-with-lease.
+        (a_checkout / "global" / "CLAUDE.md").write_text("rev2\n")
+        result = a_mgr.push(message="rev2")
+        assert result.success, result.summary
+        # All three commits should now be on origin/main: rev1, the
+        # sidecar advance, and rev2.
+        verify = tmp_path / "verify"
+        _git("clone", str(remote_bare), str(verify), cwd=tmp_path)
+        assert (verify / "advance.md").exists()
+        assert (verify / "global" / "CLAUDE.md").read_text() == "rev2\n"
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -220,6 +220,39 @@ class TestPersonalizationConfig:
         with pytest.raises(ConfigError, match="directory vs file"):
             load_config(path)
 
+    def test_effective_node_id_fallback_validated(self, tmp_path: Path) -> None:
+        """When personalization.node_id is omitted, the top-level
+        node_id is used. If the top-level is not git-branch-safe (e.g.
+        a hostname with spaces), config load must fail upfront rather
+        than letting init/push blow up later.
+        """
+        path = tmp_path / "cfg.yaml"
+        cfg = _base_config_dict({
+            "repo": "owner/repo",
+            "paths": [],
+        })
+        cfg["node_id"] = "Oscar's MacBook"   # spaces and apostrophe
+        path.write_text(yaml.dump(cfg))
+        with pytest.raises(ConfigError, match="not safe"):
+            load_config(path)
+
+    def test_effective_node_id_explicit_overrides_unsafe_fallback(
+        self, tmp_path: Path
+    ) -> None:
+        """An explicit personalization.node_id makes the validation
+        pass even when the top-level is unsafe.
+        """
+        path = tmp_path / "cfg.yaml"
+        cfg = _base_config_dict({
+            "repo": "owner/repo",
+            "node_id": "macbook",
+            "paths": [],
+        })
+        cfg["node_id"] = "Oscar's MacBook"
+        path.write_text(yaml.dump(cfg))
+        config = load_config(path)
+        assert config.personalization_branch() == "personalization/macbook"
+
     def test_main_branch_validates_safe(self, tmp_path: Path) -> None:
         path = tmp_path / "cfg.yaml"
         path.write_text(yaml.dump(_base_config_dict({

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -117,10 +117,14 @@ class TestResolveTemplate:
 
 class TestProjectSlug:
     def test_simple(self) -> None:
-        assert project_slug("AInvirion/ctrlrelay") == "AInvirion-ctrlrelay"
+        assert project_slug("AInvirion/ctrlrelay") == "AInvirion--ctrlrelay"
 
-    def test_idempotent_on_already_flat(self) -> None:
-        assert project_slug("AInvirion-ctrlrelay") == "AInvirion-ctrlrelay"
+    def test_no_collision_between_hyphenated_pairs(self) -> None:
+        # Codex pass 6 finding: single-hyphen flattening collides for
+        # ``a-b/c`` and ``a/b-c``. Double-hyphen separator avoids it.
+        assert project_slug("a-b/c") != project_slug("a/b-c")
+        assert project_slug("a-b/c") == "a-b--c"
+        assert project_slug("a/b-c") == "a--b-c"
 
 
 # ---------- Layer 2: config loading ------------------------------------------
@@ -399,7 +403,9 @@ class TestSymlinkWiring:
         not_cloned = tmp_path / "not_cloned"  # deliberately not created
 
         # Source dir exists in checkout for the cloned repo only.
-        (empty_checkout / "claude-memory" / "owner-cloned").mkdir(parents=True)
+        # ``project_slug("owner/cloned")`` is ``"owner--cloned"`` —
+        # double-hyphen separator (collision-free).
+        (empty_checkout / "claude-memory" / "owner--cloned").mkdir(parents=True)
 
         config = _build_config(
             checkout_path=empty_checkout,
@@ -1012,6 +1018,76 @@ class TestManagerErrors:
         _patch_remote_url(mgr, str(remote_bare))
         with pytest.raises(PersonalizationError, match="back it up"):
             mgr.init()
+
+    def test_init_rejects_prefix_matched_existing_clone(
+        self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """Earlier ``_is_existing_checkout_ours`` used ``in`` against
+        the origin URL — so if config repo was ``acme/dot`` and the
+        existing clone's origin was ``acme/dotfiles``, init would
+        wrongly converge against the foreign clone. Codex pass 6
+        caught this.
+        """
+        base = tmp_path_factory.mktemp("dotfiles")
+        bare = _git_init_bare(base / "dotfiles.git")
+        seed = base / "seed"
+        _git_init_with_initial_commit(seed, remote_url=str(bare))
+
+        # Pre-existing clone of acme/dotfiles at the configured path.
+        checkout = tmp_path / "personalization"
+        _git("clone", str(bare), str(checkout), cwd=tmp_path)
+        # Rewrite origin to the prefix-collision URL so the check has
+        # something to match against (test uses local bare; we
+        # spoof the remote name).
+        _git(
+            "remote", "set-url", "origin",
+            "https://github.com/acme/dotfiles.git",
+            cwd=checkout,
+        )
+
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-x",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                # Config repo is prefix of the existing clone's repo.
+                "repo": "acme/dot",
+                "checkout_path": str(checkout),
+                "paths": [],
+            },
+            "repos": [],
+        })
+        mgr = PersonalizationManager(cfg)
+        with pytest.raises(PersonalizationError, match="not a clone"):
+            mgr.init()
+
+    def test_init_clones_into_empty_directory(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """If checkout_path exists as an empty directory (e.g. created
+        by provisioning), init should clone into it rather than
+        refuse. Codex pass 6 caught this.
+        """
+        checkout = tmp_path / "personalization"
+        checkout.mkdir()  # empty
+        config = _config_for(checkout, remote_bare, node_id="machine-empty-dir")
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+        # Should NOT raise: empty dir is fine for clone target.
+        mgr.init()
+        assert (checkout / ".git").exists()
 
     def test_status_works_before_init(self, tmp_path: Path, remote_bare: Path) -> None:
         # status should not raise when the checkout doesn't exist yet —

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -267,6 +267,47 @@ class TestPersonalizationConfig:
         with pytest.raises(ConfigError):
             load_config(path)
 
+    @pytest.mark.parametrize("bad", [
+        "main:backup",   # colon — refspec separator
+        "foo..bar",      # consecutive dots
+        ".leading-dot",  # leading dot
+        "-leading-dash", # leading dash (also looks like a git option)
+        "has space",     # whitespace
+        "tilde~here",    # tilde — git ref-illegal
+        "caret^here",    # caret — git ref-illegal
+        "with/slash",    # slash inside a single component
+        "",              # empty
+    ])
+    def test_main_branch_rejects_git_unsafe_chars(
+        self, tmp_path: Path, bad: str
+    ) -> None:
+        # Codex pass 7 finding: earlier denylist let things like
+        # ``main:backup`` and ``foo..bar`` through; tighten to an
+        # explicit allow-list matching the documented safe set.
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "main_branch": bad,
+            "paths": [],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
+    @pytest.mark.parametrize("bad", [
+        "host:name", "node..2", ".host", "-host", "name with space",
+    ])
+    def test_personalization_node_id_rejects_git_unsafe_chars(
+        self, tmp_path: Path, bad: str
+    ) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict({
+            "repo": "owner/repo",
+            "node_id": bad,
+            "paths": [],
+        })))
+        with pytest.raises(ConfigError):
+            load_config(path)
+
 
 # ---------- Layer 3: symlink wiring ------------------------------------------
 

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1417,38 +1417,32 @@ class TestManagerErrors:
         with pytest.raises(PersonalizationError, match="not a clone"):
             mgr.init()
 
-    def test_init_resets_origin_when_existing_clone_points_at_foreign_host(
+    def test_init_refuses_existing_clone_pointing_at_foreign_host(
         self,
         tmp_path: Path,
         tmp_path_factory: pytest.TempPathFactory,
     ) -> None:
-        """Codex pass 18: ``_is_existing_checkout_ours`` matches on
-        owner/repo only, so a malicious clone of
-        ``https://evil.example/<owner>/<repo>.git`` would otherwise
-        keep that origin and tunnel personalization data outside the
-        intended remote. Init must reset origin to the canonical
-        ``self.repo_url``.
+        """Codex pass 20 (P1): even after pass-18's origin-URL reset,
+        the foreign checkout's working tree and branch contents would
+        still get wired into ``~/.claude``. Tightening: refuse outright
+        when the existing clone's origin host isn't ``github.com``.
+        Operator must back up + remove before retrying.
         """
-        # Spin up a fake foreign bare repo with the matching tail.
         foreign_base = tmp_path_factory.mktemp("foreign")
         foreign_bare = _git_init_bare(foreign_base / "victim.git")
         seed = foreign_base / "seed"
         _git_init_with_initial_commit(seed, remote_url=str(foreign_bare))
 
-        # Pre-populate checkout_path with a clone of the foreign bare,
-        # but rewrite origin to look like the configured repo's tail
-        # via a github-shaped malicious URL. Then init must redirect.
         checkout = tmp_path / "personalization"
         _git("clone", str(foreign_bare), str(checkout), cwd=tmp_path)
-        # Simulate origin pointing at a non-github host with a
-        # matching tail.
         _git(
             "remote", "set-url", "origin",
             "https://evil.example/test/dotclaude.git",
             cwd=checkout,
         )
 
-        # Spin up the LEGITIMATE bare we'll redirect to.
+        # Bare we'd LIKE init to use (but won't, because the existing
+        # clone is foreign and refused).
         legit_base = tmp_path_factory.mktemp("legit")
         legit_bare = _git_init_bare(legit_base / "legit.git")
         legit_seed = legit_base / "seed"
@@ -1457,16 +1451,15 @@ class TestManagerErrors:
         config = _config_for(checkout, legit_bare, node_id="machine-x")
         mgr = PersonalizationManager(config)
         _patch_remote_url(mgr, str(legit_bare))
-        # init should detect the URL match by tail (acme-style
-        # check) AND reset origin to the canonical URL — verified
-        # below.
-        mgr.init()
+        with pytest.raises(PersonalizationError, match="not a clone"):
+            mgr.init()
+        # Origin was NOT redirected (a no-op refusal): the stale
+        # foreign URL is still in place — the operator's job to
+        # clean up.
         actual_origin = _git(
             "remote", "get-url", "origin", cwd=checkout
         ).strip()
-        assert actual_origin == str(legit_bare)
-        # No stale "evil.example" reference left over.
-        assert "evil.example" not in actual_origin
+        assert actual_origin == "https://evil.example/test/dotclaude.git"
 
     def test_init_clones_into_empty_directory(
         self, tmp_path: Path, remote_bare: Path

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -778,6 +778,55 @@ class TestPushDeletionAndContention:
         assert (c_checkout / "phantom.md").exists()
         assert (c_checkout / "global" / "CLAUDE.md").read_text() == "rev1\n"
 
+    def test_init_bootstraps_empty_repo(
+        self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
+    ) -> None:
+        """A brand-new GitHub-style empty bare repo (no commits) must
+        be initable: clone leaves unborn HEAD, then init seeds main
+        with a README commit, pushes, and proceeds normally.
+        """
+        base = tmp_path_factory.mktemp("empty")
+        bare = _git_init_bare(base / "empty.git")  # bare, no commits
+
+        checkout = tmp_path / "personalization"
+        cfg = Config.model_validate({
+            "version": "1",
+            "node_id": "machine-empty",
+            "timezone": "UTC",
+            "paths": {
+                "state_db": "/tmp/state.db",
+                "worktrees": "/tmp/worktrees",
+                "bare_repos": "/tmp/bare",
+                "contexts": "/tmp/contexts",
+                "skills": "/tmp/skills",
+            },
+            "transport": {
+                "type": "file_mock",
+                "file_mock": {"inbox": "/tmp/in", "outbox": "/tmp/out"},
+            },
+            "dashboard": {"enabled": False},
+            "personalization": {
+                "repo": "test/empty",
+                "checkout_path": str(checkout),
+                "paths": [],
+            },
+            "repos": [],
+        })
+        mgr = PersonalizationManager(cfg)
+        mgr.repo_url = str(bare)
+        summary = mgr.init()
+        assert "personalization/machine-empty" in summary
+        # README seeded and committed on main.
+        assert (checkout / "README.md").exists()
+        # On the per-machine branch, with main reachable from origin.
+        head = _git("rev-parse", "--abbrev-ref", "HEAD", cwd=checkout).strip()
+        assert head == "personalization/machine-empty"
+        # origin has main pushed.
+        remote_main = _git(
+            "ls-remote", str(bare), "main", cwd=checkout
+        ).strip()
+        assert remote_main, "origin/main should exist after bootstrap"
+
     def test_init_works_with_non_default_main_branch(
         self, tmp_path: Path, tmp_path_factory: pytest.TempPathFactory
     ) -> None:


### PR DESCRIPTION
## Summary

Slice 1 of personalization sync: clones a private GitHub repo holding the operator's cross-machine context (Claude/Codex/Hermes config, per-project memory, spec/superpower outputs, workspace planning notes), wires symlinks per ``orchestrator.yaml``, and supports manual push/pull from CLI. Per-machine branches with conflict-safe rebase + force-with-lease prevent concurrent pushes from overwriting each other.

- ``ctrlrelay personalization {init,status,push,pull}`` CLI
- New optional ``personalization:`` section in ``orchestrator.yaml`` with ``paths`` (source/target with ``\${HOME}`` / ``\${PROJECT}`` / ``\${PROJECT_ENCODED}`` / ``\${PROJECT_LOCAL}`` / ``\${PROJECT_PARENT}`` placeholders, ``project_scoped`` flag for per-repo wiring)
- Branch model: persistent regular clone at ``\$HOME/.ctrlrelay/personalization``; per-machine working branch ``personalization/<node_id>`` auto-rebases onto ``main`` on push; FF push of main is retried on rejection (3-attempt cap) and uses ``--force-with-lease`` on the per-node branch when the rebase rewrote history
- Symlink wiring is idempotent: missing → create; correct → no-op; wrong-symlink → replace; real file/dir → refuse with backup-and-remove instruction; source missing → skip (partial repos are fine); ``project_scoped`` paths only wire for repos whose ``local_path`` exists
- ``templates/global-CLAUDE.md.snippet`` establishing the ``<project-parent>/specs/<owner>--<project>/`` filing convention so spec/superpower outputs land where the sync config picks them up
- Allowlist guarantee: commits scoped to configured pathspecs via ``git commit -- <paths>`` plus a pre-stage ``git reset --mixed``; ``GIT_LITERAL_PATHSPECS=1`` defuses pathspec magic; tracked-file deletions are staged

## Hardening

The branch survived ~9 review passes. Real bugs caught and fixed include:
- FF rejection of main left commits orphaned on per-node branch (P1)
- Stale remote-tracking refs let init clobber commits that only existed on origin's per-node branch (P1)
- Partial-repo state where some configured sources are missing blocked the entire push (P1)
- Tracked-file deletions weren't staged — files lived forever on the remote
- Allowlist bypass via pre-staged files outside the allowlist
- Foreign-host clone (``https://evil.example/owner/repo.git``) accepted as ours
- Pathspec magic in source paths (``:(top)``, ``:!``)
- Git ref validation only filtered shell metacharacters, accepted ``main:backup`` / ``foo..bar``
- ``_GitError`` didn't derive from ``PersonalizationError``, so clone failures bypassed CLI handlers and printed tracebacks
- Bootstrap heuristic ran on non-empty repos with a misconfigured ``main_branch``, silently creating parallel branches

## Deferred to Slice 2+

- Daemon scheduler integration (auto-pull on existing repo-pull cron, auto-push on session end)
- Telegram conflict escalation via ``pending_resumes``
- Pre-commit lint warning on memory entries containing ``\$HOME/.ctrlrelay/worktrees/``
- ``.gitattributes`` merge drivers per file type
- Adopt-flow for pre-existing target files (move into checkout + symlink instead of refusing)
- ``flock`` around commit
- Lock-namespace separation from work pipelines
- ``workspaces:`` config block (multi-repo workspace planning paths are fixed-target entries for now)

## Test plan

- [x] 84 personalization-specific tests cover paths/encoding, config validation, symlink wiring (5 cases), push/pull integration with local bare-repo "remote" (happy path + rebase conflict abort + concurrent non-conflicting + simulated FF rejection retry + cross-call divergence + tracked-file deletion + non-default main_branch + empty-repo bootstrap + adopt-existing-per-node-branch + foreign-host refusal + identity-less commit + allowlist bypass + partial-repo + ...), CLI smoke tests for error wrapping
- [x] Full suite: 590 passing, ruff clean
- [ ] Manual test: ``ctrlrelay personalization init`` against an actual private GitHub repo
- [ ] Manual test: cross-machine sync (push from machine A, pull on machine B)