### PR TITLE
feat(personalization): adopt-flow on init + auto-pull on cron (slice 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,6 @@ repos.manifest
 
 # Lock file — not committed per AInvirion Python-SDK convention.
 uv.lock
+
+# Operator-private notes (runbooks, personal cheatsheets).
+notes/

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -51,6 +51,12 @@ dashboard:
 # set above. Change `secops_cron` to e.g. "0 6 * * 1" for weekly (Mondays).
 schedules:
   secops_cron: "0 6 * * *"
+  # Optional. When personalization is configured AND this is set, the
+  # poller daemon runs `ctrlrelay personalization pull` on this cron
+  # so machines converge without manual sync. Skip-on-dirty: never
+  # rebases under uncommitted operator edits. Defaults to None
+  # (manual sync only).
+  # personalization_cron: "*/15 * * * *"
 
 # Optional: cross-machine personalization sync.
 #

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1777,6 +1777,52 @@ def poller_start(
                         pass
 
         async def _main() -> None:
+            async def _run_scheduled_personalization_pull() -> None:
+                """Cron-driven auto-pull of the personalization repo.
+
+                Runs at ``schedules.personalization_cron``. Skips when
+                the working tree is dirty so unsaved operator edits
+                aren't disturbed by the rebase. Conflicts during the
+                rebase abort and are logged; operator must intervene
+                via ``ctrlrelay personalization pull`` to surface the
+                conflict files. Auto-push is intentionally NOT done
+                here — a daemon committing on the operator's behalf
+                without explicit intent is the kind of thing that
+                surprises people; commits stay manual.
+
+                ``auto_pull`` runs synchronous ``git fetch``/``rebase``
+                subprocesses; dispatch to a worker thread so a slow
+                or stuck remote can't stall the poller's event loop
+                (Telegram dispatch, pending-resume sweeper, secops
+                cron). Codex pass 3 caught this.
+                """
+                if config.personalization is None:
+                    return
+                import asyncio
+
+                from ctrlrelay.personalization import PersonalizationManager
+                from ctrlrelay.personalization.manager import (
+                    PersonalizationError,
+                )
+
+                try:
+                    mgr = PersonalizationManager(config)
+                    result = await asyncio.to_thread(mgr.auto_pull)
+                except PersonalizationError as e:
+                    console.print(
+                        f"[yellow]Auto-pull failed: {e}[/yellow]"
+                    )
+                    return
+                if result.success:
+                    console.print(f"[dim]Auto-pull: {result.summary}[/dim]")
+                else:
+                    console.print(
+                        f"[yellow]Auto-pull: {result.summary}[/yellow]"
+                    )
+                    if result.conflict_files:
+                        for f in result.conflict_files:
+                            console.print(f"[yellow]  conflict: {f}[/yellow]")
+
             # Register + start the scheduler FIRST, before any potentially
             # slow startup work. Otherwise a 6am fire that lands during
             # seed_current's per-repo GitHub calls would be lost —
@@ -1797,11 +1843,31 @@ def poller_start(
                 cron_expr="* * * * *",
                 func=_run_pending_resume_sweeper,
             )
+            # Register the personalization auto-pull only when the
+            # operator has both configured the personalization block
+            # AND set a cron expression. Either alone is intentional
+            # (config without cron = manual sync only; cron without
+            # config = invalid in load_config).
+            personalization_cron_summary = ""
+            if (
+                config.personalization is not None
+                and config.schedules.personalization_cron is not None
+            ):
+                scheduler.add_cron_job(
+                    name="personalization_auto_pull",
+                    cron_expr=config.schedules.personalization_cron,
+                    func=_run_scheduled_personalization_pull,
+                )
+                personalization_cron_summary = (
+                    f" | personalization_auto_pull cron="
+                    f"{config.schedules.personalization_cron}"
+                )
             scheduler.start()
             console.print(
                 f"[dim]Scheduler: secops cron={config.schedules.secops_cron} "
                 f"tz={config.timezone} | "
-                f"pending_resume_sweeper=every 1m[/dim]"
+                f"pending_resume_sweeper=every 1m"
+                f"{personalization_cron_summary}[/dim]"
             )
 
             # Now the slow startup: first-run seeding (one gh call per
@@ -2031,6 +2097,16 @@ def personalization_init(
         "-c",
         help="Path to orchestrator.yaml (default: auto-discover; see $CTRLRELAY_CONFIG).",
     ),
+    no_adopt: bool = typer.Option(
+        False,
+        "--no-adopt",
+        help=(
+            "Refuse to adopt pre-existing real files at target paths. "
+            "Default: adopt (move target into checkout, then symlink). "
+            "Use --no-adopt for the conservative Slice 1 behavior of "
+            "skipping such targets with a back-up-and-remove instruction."
+        ),
+    ),
 ) -> None:
     """Clone the personalization repo and wire symlinks.
 
@@ -2041,7 +2117,7 @@ def personalization_init(
 
     mgr = _make_personalization_manager(config_path)
     try:
-        summary = mgr.init()
+        summary = mgr.init(adopt=not no_adopt)
     except PersonalizationError as e:
         console.print(f"[red]Init failed:[/red] {e}")
         raise typer.Exit(1)

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -443,26 +443,43 @@ class SchedulesConfig(BaseModel):
     evaluated in the top-level ``timezone``. Each schedule is validated at
     config load time so an unparseable expression fails fast rather than
     silently disabling the job.
+
+    ``personalization_cron`` is optional: when ``None`` (the default), no
+    auto-pull job is registered. Set it to e.g. ``"*/15 * * * *"`` to
+    have the daemon pull the personalization repo every 15 minutes so
+    machines converge without manual ``ctrlrelay personalization pull``.
+    Skip-on-dirty: auto-pull never rebases under uncommitted operator
+    edits.
     """
 
     secops_cron: str = "0 6 * * *"
+    personalization_cron: str | None = None
 
     @field_validator("secops_cron")
     @classmethod
-    def validate_cron(cls, v: str) -> str:
-        from ctrlrelay.core.scheduler import _build_vixie_trigger
+    def validate_secops_cron(cls, v: str) -> str:
+        return _validate_cron_expression(v, "secops_cron")
 
-        try:
-            # Build through the same helper the scheduler uses so
-            # (a) DOW normalization and (b) Vixie DOM/DOW-OR splitting
-            # are both exercised at load time. Bad expressions surface
-            # synchronously instead of at daemon start.
-            _build_vixie_trigger(v, timezone=None)
-        except Exception as e:
-            raise ValueError(
-                f"invalid cron expression {v!r}: {e}"
-            ) from e
-        return v
+    @field_validator("personalization_cron")
+    @classmethod
+    def validate_personalization_cron(cls, v: str | None) -> str | None:
+        if v is None:
+            return None
+        return _validate_cron_expression(v, "personalization_cron")
+
+
+def _validate_cron_expression(v: str, field: str) -> str:
+    from ctrlrelay.core.scheduler import _build_vixie_trigger
+
+    try:
+        # Build through the same helper the scheduler uses so
+        # (a) DOW normalization and (b) Vixie DOM/DOW-OR splitting
+        # are both exercised at load time. Bad expressions surface
+        # synchronously instead of at daemon start.
+        _build_vixie_trigger(v, timezone=None)
+    except Exception as e:
+        raise ValueError(f"invalid cron expression for {field} {v!r}: {e}") from e
+    return v
 
 
 class Config(BaseModel):

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -40,6 +40,7 @@ from __future__ import annotations
 
 import os
 import re
+import shutil
 import subprocess
 from collections.abc import Iterable
 from dataclasses import dataclass
@@ -123,12 +124,19 @@ class PersonalizationManager:
 
     # ----- top-level commands ------------------------------------------------
 
-    def init(self) -> str:
+    def init(self, *, adopt: bool = True) -> str:
         """Clone the personalization repo into ``checkout_path`` and
         wire symlinks. Refuses to overwrite an existing non-empty
         directory; if the checkout already looks like a clone of the
         right repo, falls through to ``wire_symlinks`` so a re-run is
         idempotent.
+
+        ``adopt=True`` (the default since Slice 2) moves pre-existing
+        real files/dirs at target paths into the personalization
+        checkout and wires the symlink, eliminating the manual
+        adoption dance Slice 1 required. ``adopt=False`` preserves
+        the conservative Slice 1 behavior of skipping such targets
+        with a "back up and remove" instruction.
 
         Returns a human-readable summary.
         """
@@ -156,14 +164,14 @@ class PersonalizationManager:
                 # caught this).
                 self._bootstrap_main_if_empty()
                 self._ensure_working_branch()
-                results = self.wire_symlinks()
+                results = self.wire_symlinks(adopt=adopt)
                 return self._format_init_summary(results, cloned=False)
 
         self.checkout_path.parent.mkdir(parents=True, exist_ok=True)
         self._git_global("clone", self.repo_url, str(self.checkout_path))
         self._bootstrap_main_if_empty()
         self._ensure_working_branch()
-        results = self.wire_symlinks()
+        results = self.wire_symlinks(adopt=adopt)
         return self._format_init_summary(results, cloned=True)
 
     def _bootstrap_main_if_empty(self) -> None:
@@ -331,17 +339,19 @@ class PersonalizationManager:
 
         return "\n".join(lines)
 
-    def wire_symlinks(self) -> list[SymlinkResult]:
+    def wire_symlinks(self, *, adopt: bool = True) -> list[SymlinkResult]:
         """Apply the ``paths`` config to the filesystem. Idempotent.
 
         For each plan: create missing symlinks, replace pointing-
-        elsewhere symlinks, refuse to clobber a real file/dir, skip
-        entries whose source doesn't exist in the checkout yet (so a
-        partially-populated personalization repo is OK).
+        elsewhere symlinks, skip entries whose source doesn't exist
+        in the checkout yet, and (when ``adopt=True``, the default)
+        adopt pre-existing target files/dirs by moving them into the
+        checkout. ``adopt=False`` reverts to Slice 1 behavior:
+        refuse to clobber a real file/dir at the target.
         """
         results: list[SymlinkResult] = []
         for plan in self._plan_symlinks():
-            results.append(self._apply_symlink(plan))
+            results.append(self._apply_symlink(plan, adopt=adopt))
         return results
 
     # Bounded retries for the rebase + branch-push + FF-push cycle on
@@ -513,11 +523,18 @@ class PersonalizationManager:
             ),
         )
 
-    def pull(self) -> PullResult:
+    def pull(self, *, adopt: bool = True) -> PullResult:
         """Fetch and rebase the per-machine branch onto ``origin/<main>``.
         FF-update local main if possible. Re-wire symlinks at the end
         because the config-as-code shipped in the personalization repo
         may have changed.
+
+        ``adopt`` is forwarded to :meth:`wire_symlinks`. The interactive
+        ``ctrlrelay personalization pull`` defaults to ``True`` (matches
+        ``init`` semantics: pre-existing real targets are moved into the
+        synced repo). The daemon-scheduled :meth:`auto_pull` passes
+        ``False`` so a background sync never silently moves operator
+        files.
         """
         self._require_checkout()
         self._ensure_working_branch()
@@ -554,7 +571,7 @@ class PersonalizationManager:
             check=False,
         )
         # Re-wire (config may have changed; harmless if not).
-        self.wire_symlinks()
+        self.wire_symlinks(adopt=adopt)
 
         ff_note = "" if ff.returncode == 0 else (
             f" (local {self.main_branch} not fast-forwarded — diverged "
@@ -567,6 +584,43 @@ class PersonalizationManager:
                 f"origin/{self.main_branch}{ff_note}"
             ),
         )
+
+    def auto_pull(self) -> PullResult:
+        """Pull variant for the daemon scheduler.
+
+        Differs from ``pull`` in two ways:
+
+        1. Refuses to run when the working tree is dirty. The
+           operator may be mid-edit (writes go straight to the
+           personalization repo via the symlinks); rebasing under
+           them would lose the unsaved work, fail the rebase, or
+           both. Skip-on-dirty is the safe default.
+        2. Refuses if no checkout exists yet, returning a benign
+           summary instead of raising — the daemon shouldn't crash
+           because an operator hasn't run ``init`` on this machine.
+
+        Conflicts during rebase still abort (same as ``pull``); the
+        daemon log records the conflict files. The re-wire phase runs
+        with ``adopt=False`` — a background sync must never silently
+        move operator files. Adoption stays an explicit init-time act.
+        """
+        if not (self.checkout_path / ".git").exists():
+            return PullResult(
+                success=True,
+                summary="auto-pull skipped: no checkout (run init first)",
+            )
+        # ``status --porcelain`` outputs nothing for a clean working
+        # tree; non-empty means there are uncommitted changes.
+        porcelain = self._git("status", "--porcelain").strip()
+        if porcelain:
+            return PullResult(
+                success=True,
+                summary=(
+                    "auto-pull skipped: working tree dirty "
+                    f"({len(porcelain.splitlines())} entries)"
+                ),
+            )
+        return self.pull(adopt=False)
 
     # ----- internals: symlink planning + apply -------------------------------
 
@@ -626,18 +680,81 @@ class PersonalizationManager:
                 repo_name=repo.name,
             )
 
-    def _apply_symlink(self, plan: SymlinkPlan) -> SymlinkResult:
-        if not plan.source.exists():
-            # Tolerated: the user may not have populated this entry on
-            # any machine yet. Skip without failing so wire-symlinks is
-            # safe to run on a partial repo.
+    def _apply_symlink(
+        self, plan: SymlinkPlan, *, adopt: bool = True
+    ) -> SymlinkResult:
+        """Apply one symlink wiring decision.
+
+        With ``adopt=True`` (Slice 2 default), a target that is a real
+        file/dir AND a missing source triggers ADOPTION: the target is
+        moved into the checkout at the source location, then the
+        symlink is created. This eliminates the manual "move then
+        re-init" dance Slice 1 required.
+
+        Adoption is intentionally narrow: it only fires when the
+        source is missing. If BOTH source and target exist as real
+        content the manager refuses (``skipped-conflict-both-exist``)
+        — that needs operator judgment to reconcile.
+        """
+        source_exists = plan.source.exists()
+        target_is_real = plan.target.exists() and not plan.target.is_symlink()
+
+        if source_exists and target_is_real:
+            # Both populated — operator must reconcile manually.
+            return SymlinkResult(
+                plan=plan,
+                action="skipped-conflict-both-exist",
+                detail=(
+                    "both the personalization repo's source and the on-disk "
+                    "target have content; reconcile manually (move one into "
+                    "the other or delete one) before re-running init"
+                ),
+            )
+
+        if not source_exists and target_is_real:
+            if not adopt:
+                return SymlinkResult(
+                    plan=plan,
+                    action="skipped-real-file-at-target",
+                    detail=(
+                        "adopt disabled (--no-adopt or wire(adopt=False)); "
+                        "back up and remove the existing path before retrying"
+                    ),
+                )
+            # Type sanity: refuse if target's on-disk shape doesn't
+            # match config's trailing-slash declaration. Better to
+            # surface the mismatch than to move a file into a slot
+            # the config says is a directory.
+            actual_is_dir = plan.target.is_dir()
+            if plan.is_dir != actual_is_dir:
+                expected = "directory" if plan.is_dir else "file"
+                actual = "directory" if actual_is_dir else "file"
+                return SymlinkResult(
+                    plan=plan,
+                    action="skipped-target-type-mismatch",
+                    detail=(
+                        f"config declares {expected} (trailing slash) but "
+                        f"on-disk target {plan.target} is a {actual}; "
+                        "fix the config or the target before retrying"
+                    ),
+                )
+            # Adopt: move target into source location, then continue
+            # the wire path as if source had been there all along.
+            plan.source.parent.mkdir(parents=True, exist_ok=True)
+            shutil.move(str(plan.target), str(plan.source))
+            source_exists = True
+            target_is_real = False
+            adopted = True
+        else:
+            adopted = False
+
+        if not source_exists:
+            # Source missing AND no real-file target to adopt. Common
+            # for partial-repo state where another machine hasn't
+            # populated this entry yet. Skip without failing.
             return SymlinkResult(plan=plan, action="skipped-source-missing")
 
-        # Source's actual on-disk type must match what the config says
-        # (trailing slash → dir, no slash → file). A directory entry
-        # accidentally present as a regular file (or vice versa)
-        # would otherwise wire a symlink that breaks downstream
-        # consumers (Codex pass 15). Refuse loudly with a hint.
+        # Source-side type check (existing Slice 1 invariant).
         actual_is_dir = plan.source.is_dir()
         if plan.is_dir != actual_is_dir:
             expected = "directory" if plan.is_dir else "file"
@@ -651,14 +768,12 @@ class PersonalizationManager:
                 ),
             )
 
-        # Ensure parent dir of target exists.
         plan.target.parent.mkdir(parents=True, exist_ok=True)
 
         if plan.target.is_symlink():
             current = plan.target.readlink()
             if current == plan.source or self._same_resolved(current, plan.source):
                 return SymlinkResult(plan=plan, action="already-correct")
-            # Wrong symlink — replace.
             plan.target.unlink()
             plan.target.symlink_to(plan.source)
             return SymlinkResult(
@@ -667,17 +782,11 @@ class PersonalizationManager:
                 detail=f"was -> {current}",
             )
 
-        if plan.target.exists():
-            # Real file or directory at the target. Refuse — the user
-            # must back up and remove. Adopt-flow comes in Slice 2.
-            return SymlinkResult(
-                plan=plan,
-                action="skipped-real-file-at-target",
-                detail="back up and remove the existing path before retrying",
-            )
-
         plan.target.symlink_to(plan.source)
-        return SymlinkResult(plan=plan, action="created")
+        return SymlinkResult(
+            plan=plan,
+            action="adopted" if adopted else "created",
+        )
 
     def _inspect_symlink(self, plan: SymlinkPlan) -> str:
         """Read-only counterpart to ``_apply_symlink`` for ``status``."""

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -743,7 +743,6 @@ class PersonalizationManager:
             plan.source.parent.mkdir(parents=True, exist_ok=True)
             shutil.move(str(plan.target), str(plan.source))
             source_exists = True
-            target_is_real = False
             adopted = True
         else:
             adopted = False

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -482,9 +482,13 @@ class TestSymlinkWiring:
         assert results[0].action == "replaced-stale-symlink"
         assert target.readlink() == empty_checkout / "global" / "CLAUDE.md"
 
-    def test_refuses_real_file_at_target(
+    def test_refuses_when_both_source_and_target_are_real_content(
         self, tmp_path: Path, empty_checkout: Path
     ) -> None:
+        """Slice 2 distinguishes adoption-eligible (only target has
+        content) from un-resolvable (both sides do). This case is
+        the latter: refuse with ``skipped-conflict-both-exist``.
+        """
         (empty_checkout / "global").mkdir()
         (empty_checkout / "global" / "CLAUDE.md").write_text("from-checkout")
         target = tmp_path / "home" / ".claude" / "CLAUDE.md"
@@ -496,7 +500,7 @@ class TestSymlinkWiring:
             paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
         )
         results = PersonalizationManager(config).wire_symlinks()
-        assert results[0].action == "skipped-real-file-at-target"
+        assert results[0].action == "skipped-conflict-both-exist"
         assert target.is_symlink() is False
         assert target.read_text() == "real file, do not clobber"
 
@@ -539,6 +543,133 @@ class TestSymlinkWiring:
         results = PersonalizationManager(config).wire_symlinks()
         assert results[0].action == "skipped-source-type-mismatch"
         assert not target.exists()
+
+    def test_adopt_moves_real_file_into_checkout_and_wires(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """Slice 2: when the source is missing in the checkout AND the
+        target is a real file, adopt-flow moves the target into the
+        source location and creates the symlink. Eliminates the
+        manual "move then re-init" dance Slice 1 required.
+        """
+        # Pre-existing real file at the target.
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "CLAUDE.md"
+        target.write_text("real content from before adopt\n")
+
+        # Source not yet in checkout.
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+
+        assert len(results) == 1
+        assert results[0].action == "adopted"
+        # Target is now a symlink into the checkout.
+        assert target.is_symlink()
+        assert target.readlink() == empty_checkout / "global" / "CLAUDE.md"
+        # Content survived the move (still readable through the symlink).
+        assert target.read_text() == "real content from before adopt\n"
+        # And lives at the source path inside the checkout.
+        assert (empty_checkout / "global" / "CLAUDE.md").read_text() == (
+            "real content from before adopt\n"
+        )
+
+    def test_adopt_moves_directory(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """Adoption works for directory targets too, not just files."""
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        skills = target_dir / "skills"
+        skills.mkdir()
+        (skills / "skill1.md").write_text("a skill\n")
+        (skills / "skill2.md").write_text("another\n")
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/skills/", "target": str(skills) + "/"}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "adopted"
+        assert skills.is_symlink()
+        # Both files are now readable through the symlink and live in
+        # the checkout.
+        assert (empty_checkout / "global" / "skills" / "skill1.md").read_text() == "a skill\n"
+        assert (skills / "skill2.md").read_text() == "another\n"
+
+    def test_no_adopt_preserves_slice1_behavior(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """``adopt=False`` reverts to the conservative Slice 1 path:
+        refuse to touch the real file, instruct backup-and-remove.
+        """
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "CLAUDE.md"
+        target.write_text("don't touch me\n")
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks(adopt=False)
+        assert results[0].action == "skipped-real-file-at-target"
+        assert not target.is_symlink()
+        assert target.read_text() == "don't touch me\n"
+        # Source NOT created in checkout.
+        assert not (empty_checkout / "global" / "CLAUDE.md").exists()
+
+    def test_adopt_refuses_when_both_source_and_target_have_content(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """If BOTH the checkout source AND the on-disk target have
+        real content, adopt can't pick a winner — refuse and ask the
+        operator to reconcile manually.
+        """
+        # Source already populated in checkout.
+        (empty_checkout / "global").mkdir()
+        (empty_checkout / "global" / "CLAUDE.md").write_text("from-repo\n")
+
+        # Target also has content, NOT a symlink.
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "CLAUDE.md"
+        target.write_text("from-disk\n")
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "skipped-conflict-both-exist"
+        # Neither side touched.
+        assert target.read_text() == "from-disk\n"
+        assert (empty_checkout / "global" / "CLAUDE.md").read_text() == "from-repo\n"
+
+    def test_adopt_refuses_when_target_type_doesnt_match_config(
+        self, tmp_path: Path, empty_checkout: Path
+    ) -> None:
+        """Config says directory (trailing slash) but target on disk
+        is a regular file: refuse rather than silently move a file
+        into a slot the config thinks is a directory.
+        """
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        # Target is a FILE, but config will say DIRECTORY.
+        target = target_dir / "skills"
+        target.write_text("oops, not a dir\n")
+
+        config = _build_config(
+            checkout_path=empty_checkout,
+            paths=[{"source": "global/skills/", "target": str(target) + "/"}],
+        )
+        results = PersonalizationManager(config).wire_symlinks()
+        assert results[0].action == "skipped-target-type-mismatch"
+        # Target unchanged.
+        assert target.read_text() == "oops, not a dir\n"
 
     def test_skips_missing_source(
         self, tmp_path: Path, empty_checkout: Path
@@ -638,10 +769,25 @@ def remote_bare(tmp_path_factory: pytest.TempPathFactory) -> Path:
     return bare
 
 
-def _config_for(checkout: Path, remote_bare: Path, *, node_id: str) -> Config:
+def _config_for(
+    checkout: Path,
+    remote_bare: Path,
+    *,
+    node_id: str,
+    paths: list[dict] | None = None,
+) -> Config:
     """Build a Config whose personalization repo URL points at the
     local bare repo (so tests don't hit the network).
     """
+    if paths is None:
+        paths = [
+            {
+                "source": "global/CLAUDE.md",
+                "target": str(
+                    checkout.parent / "fake-home/.claude/CLAUDE.md"
+                ),
+            },
+        ]
     cfg = Config.model_validate({
         "version": "1",
         "node_id": node_id,
@@ -661,14 +807,7 @@ def _config_for(checkout: Path, remote_bare: Path, *, node_id: str) -> Config:
         "personalization": {
             "repo": "test/dotclaude",   # passes the regex; URL is overridden below
             "checkout_path": str(checkout),
-            "paths": [
-                {
-                    "source": "global/CLAUDE.md",
-                    "target": str(
-                        checkout.parent / "fake-home/.claude/CLAUDE.md"
-                    ),
-                },
-            ],
+            "paths": paths,
         },
         "repos": [],
     })
@@ -1347,6 +1486,134 @@ class TestPushDeletionAndContention:
         assert head == "personalization/machine-x"
         # ...and reachable from develop's content (the marker file).
         assert (checkout / "develop-marker.md").exists()
+
+
+class TestAutoPull:
+    """Slice 2 daemon-friendly pull variant — skips on dirty working
+    tree so the operator's unsaved edits aren't disturbed by a rebase.
+    """
+
+    def test_auto_pull_runs_when_clean(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        # Set up: A pushes a commit, B inits and is clean.
+        a_checkout = tmp_path / "a" / "personalization"
+        b_checkout = tmp_path / "b" / "personalization"
+        a_mgr = PersonalizationManager(_config_for(a_checkout, remote_bare, node_id="a"))
+        b_mgr = PersonalizationManager(_config_for(b_checkout, remote_bare, node_id="b"))
+        _patch_remote_url(a_mgr, str(remote_bare))
+        _patch_remote_url(b_mgr, str(remote_bare))
+        a_mgr.init()
+        b_mgr.init()
+
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("from-a\n")
+        a_mgr.push(message="from-a")
+
+        # B's working tree is clean — auto_pull should proceed.
+        result = b_mgr.auto_pull()
+        assert result.success
+        assert "skipped" not in result.summary.lower()
+        assert (b_checkout / "global" / "CLAUDE.md").read_text() == "from-a\n"
+
+    def test_auto_pull_skips_on_dirty_tree(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        a_checkout = tmp_path / "a" / "personalization"
+        a_mgr = PersonalizationManager(_config_for(a_checkout, remote_bare, node_id="a"))
+        _patch_remote_url(a_mgr, str(remote_bare))
+        a_mgr.init()
+
+        # Local edit, uncommitted.
+        (a_checkout / "global").mkdir()
+        (a_checkout / "global" / "CLAUDE.md").write_text("uncommitted edit\n")
+
+        # Auto-pull MUST skip — rebase under operator edits is the
+        # behavior we're explicitly trying to avoid.
+        result = a_mgr.auto_pull()
+        assert result.success
+        assert "skipped" in result.summary.lower()
+        # Edit preserved.
+        assert (
+            a_checkout / "global" / "CLAUDE.md"
+        ).read_text() == "uncommitted edit\n"
+
+    def test_auto_pull_no_checkout_returns_benign(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """Daemon shouldn't crash because the operator hasn't run
+        init on this machine yet."""
+        checkout = tmp_path / "personalization"  # not created
+        config = _config_for(checkout, remote_bare, node_id="machine-x")
+        mgr = PersonalizationManager(config)
+        result = mgr.auto_pull()
+        assert result.success
+        assert "no checkout" in result.summary.lower()
+
+    def test_auto_pull_does_not_adopt_real_target(
+        self, tmp_path: Path, remote_bare: Path
+    ) -> None:
+        """Daemon-driven auto-pull MUST NOT silently move operator
+        files. ``pull()`` re-wires symlinks at the end and now defaults
+        to ``adopt=True``; ``auto_pull()`` must thread ``adopt=False``
+        so a background sync never absorbs a real file into the
+        checkout. Codex review pass 1 caught this regression — keep
+        the regression test next to it.
+        """
+        checkout = tmp_path / "personalization"
+        target_dir = tmp_path / "home" / ".claude"
+        target_dir.mkdir(parents=True)
+        target = target_dir / "CLAUDE.md"
+        target.write_text("operator-local content\n")
+
+        config = _config_for(
+            checkout,
+            remote_bare,
+            node_id="machine-x",
+            paths=[{"source": "global/CLAUDE.md", "target": str(target)}],
+        )
+        mgr = PersonalizationManager(config)
+        _patch_remote_url(mgr, str(remote_bare))
+        mgr.init(adopt=False)
+        # No untracked files (init with adopt=False didn't move target).
+        assert mgr._git("status", "--porcelain").strip() == ""
+
+        result = mgr.auto_pull()
+        assert result.success
+        # Target file untouched — still a real file, not a symlink.
+        assert target.is_file()
+        assert not target.is_symlink()
+        assert target.read_text() == "operator-local content\n"
+        # Source NOT created in the checkout by auto_pull.
+        assert not (checkout / "global" / "CLAUDE.md").exists()
+
+
+class TestPersonalizationCronConfig:
+    """Slice 2 added the optional ``schedules.personalization_cron``
+    field. Validate parsing + cron-expression validation.
+    """
+
+    def test_personalization_cron_optional(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        path.write_text(yaml.dump(_base_config_dict()))
+        config = load_config(path)
+        assert config.schedules.personalization_cron is None
+
+    def test_personalization_cron_loaded(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        cfg = _base_config_dict()
+        cfg["schedules"] = {"personalization_cron": "*/15 * * * *"}
+        path.write_text(yaml.dump(cfg))
+        config = load_config(path)
+        assert config.schedules.personalization_cron == "*/15 * * * *"
+
+    def test_personalization_cron_invalid_rejected(self, tmp_path: Path) -> None:
+        path = tmp_path / "cfg.yaml"
+        cfg = _base_config_dict()
+        cfg["schedules"] = {"personalization_cron": "not a cron expression"}
+        path.write_text(yaml.dump(cfg))
+        with pytest.raises(ConfigError):
+            load_config(path)
 
 
 class TestManagerErrors:


### PR DESCRIPTION
## Summary

- **Adopt-flow on init**: `personalization init` now moves pre-existing real targets (e.g. `~/.claude/CLAUDE.md` that predates the sync setup) into the synced repo and lays a symlink in their place. `--no-adopt` opts out, preserving slice-1 "back up and remove first" behavior. Both-real-content collisions still surface as `skipped-conflict-both-exist` so divergence is never silently resolved.
- **Auto-pull on cron**: new optional `schedules.personalization_cron` registers an APScheduler job that runs `personalization pull` on the poller daemon. Skip-on-dirty: never rebases under uncommitted operator edits. Benign no-op when no checkout exists. Auto-push intentionally omitted — daemon never commits on the operator's behalf. `pull(adopt=False)` is threaded through so background sync never silently moves files; adoption stays init-only.
- Cron field reuses `_build_vixie_trigger` so malformed expressions fail fast at config load, identically to `secops_cron`.
- Auto-pull dispatched via `asyncio.to_thread` so synchronous git fetch/rebase can't stall the poller's event loop.

Closes the slice-2 scope from #123 (manual `init/status/push/pull` shipped there).

## QA

- 96 personalization tests, 602 total. ruff clean.
- Codex review: 3 passes, 2 P2 fixes folded in (adopt leak in `pull()` re-wire; sync git blocking event loop).

## Test plan

- [ ] `ctrlrelay personalization init` against an existing `~/.claude/CLAUDE.md` adopts it; file content preserved, target is now a symlink, source committed inside the personalization repo.
- [ ] `ctrlrelay personalization init --no-adopt` against the same setup refuses with `skipped-target-exists`.
- [ ] Set `schedules.personalization_cron: "*/5 * * * *"` and confirm poller logs `personalization_auto_pull cron=*/5 * * * *` at startup.
- [ ] Verify auto-pull skips when `~/.ctrlrelay/personalization` has uncommitted edits.
- [ ] Verify slow `git fetch` does not stall the secops sweep or pending-resume sweeper.