### PR TITLE
chore: gitignore rendered launchd/systemd units

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,14 @@ uv.lock
 
 # Operator-private notes (runbooks, personal cheatsheets).
 notes/
+
+# Rendered service unit files. `ctrlrelay install launchd|systemd`
+# substitutes CTRLRELAY_TELEGRAM_TOKEN into a copy of the in-package
+# template and writes it to the system path (~/Library/LaunchAgents on
+# macOS, ~/.config/systemd/user on Linux). The default install command
+# never lands a rendered file inside the repo, but a future flag — or
+# an operator running it with --target-dir pointed at the working tree —
+# would. Defense-in-depth so a `git add .` after such a slip can't
+# scoop the literal token into a commit.
+*.plist
+*.service


### PR DESCRIPTION
## Summary

Defense-in-depth: add `*.plist` and `*.service` to `.gitignore` so a stray `git add .` after a future install command leak can't scoop a rendered unit file (which contains the literal `CTRLRELAY_TELEGRAM_TOKEN` value) into a commit.

## Why

`ctrlrelay install launchd|systemd` substitutes the env var's literal value into a copy of the in-package template and writes the rendered unit to the system path (`~/Library/LaunchAgents` on macOS, `~/.config/systemd/user` on Linux). That's the safe default — the rendered file never enters the repo working tree. But:

- A future flag could land it in the working tree.
- An operator passing `--target-dir` pointed at the repo would land it there directly.
- A debugging script copying a unit file back for inspection would land it there.

Today's `.gitignore` doesn't catch any of those cases. With this PR, even if a rendered plist ends up in the working tree, `git add .` won't track it and the token can't slip into a commit.

## Templates still ship

Templates use the `.template` suffix (`bridge.plist.template`, `bridge.service.template`, `poller.plist.template`, `poller.service.template`), so the new rules don't ignore them.

## Verified

- `git ls-files | grep -E '\.plist$|\.service$'` returns nothing — no currently-tracked unit file is removed by these rules.
- The shipped templates remain tracked (they end in `.template`, not `.plist`/`.service`).

## Test plan

- [ ] CI passes.
- [ ] `git ls-files src/ctrlrelay/templates/` still lists the four `.template` files after this change.