### PR TITLE
feat: ctrlrelay setup + drop owner_aliases (closes #128) [v0.4.0]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,14 @@ uv.lock
 
 # Operator-private notes (runbooks, personal cheatsheets).
 notes/
+
+# Rendered service unit files. `ctrlrelay install launchd|systemd`
+# substitutes CTRLRELAY_TELEGRAM_TOKEN into a copy of the in-package
+# template and writes it to the system path (~/Library/LaunchAgents on
+# macOS, ~/.config/systemd/user on Linux). The default install command
+# never lands a rendered file inside the repo, but a future flag — or
+# an operator running it with --target-dir pointed at the working tree —
+# would. Defense-in-depth so a `git add .` after such a slip can't
+# scoop the literal token into a commit.
+*.plist
+*.service

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,59 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-05-08
+
+Minor release. One new feature plus one schema simplification:
+
+- **`ctrlrelay setup`** — first-run onboarding command. Detects every
+  GitHub org you belong to, enumerates non-fork non-archived repos in
+  each, writes a fresh `~/.config/ctrlrelay/orchestrator.yaml`, clones
+  every repo to `~/Projects/<owner.lower()>/<repo>`, optionally
+  configures the personalization sync block, and optionally renders
+  launchd/systemd unit files. Replaces the multi-step manual playbook
+  operators previously had to follow on a new machine. Interactive by
+  default; `--yes` and `--owner` flags make it scriptable.
+- **`paths.owner_aliases` deprecated; lowercase-org-folder convention.**
+  The path resolver now always derives `local_path` as
+  `${repo_root}/${owner.lower()}/${repo}` (closes #128). The previous
+  `owner_aliases` indirection caused `clone-all`/`pull-all`/`status`
+  to disagree with the dev pipeline on where a given repo lived.
+  Parsing of `owner_aliases` is retained so 0.3.x configs still load;
+  a `DeprecationWarning` fires when the block is non-empty.
+
+### Added
+
+- **`ctrlrelay setup`** (closes the onboarding gap reported during the
+  v0.3.0 reinstall flow). Composes existing primitives (gh discovery,
+  config generation, `git clone`, `personalization init`, `install
+  launchd|systemd`) into a single command. Reads
+  `$CTRLRELAY_TELEGRAM_TOKEN` so the rendered plist isn't a
+  placeholder. Refuses to overwrite an existing `orchestrator.yaml`
+  without `--force`.
+- **`repos clone-all` / `pull-all` / `status` accept DEST as
+  optional**. When omitted, each command operates on the
+  config-resolved `local_path` of every repo, so the same path
+  resolution serves the bulk commands and the dev pipeline. Pass DEST
+  to override (lands at `DEST/<owner.lower()>/<repo>`).
+
+### Changed
+
+- **Path resolver: `owner.lower()` is the folder, always.** Closes #128.
+  Affects every command that touches `repo.local_path`. Operators on
+  v0.3.0 with mixed-case folders (e.g. `~/Projects/AInvirion/...`)
+  must either rename the folder, set per-repo `local_path` overrides,
+  or run `ctrlrelay setup --force` to land everything at the new
+  lowercase paths.
+
+### Migration from 0.3.0
+
+- Drop `paths.owner_aliases` from `orchestrator.yaml` (or ignore the
+  deprecation warning until you next regenerate the config).
+- Rename existing on-disk folders to lowercase (e.g.
+  `mv ~/Projects/AInvirion ~/Projects/ainvirion`) — or, easier, run
+  `ctrlrelay setup --force` to clone everything fresh under the new
+  convention.
+
 ## [0.3.0] - 2026-05-08
 
 Minor release. Three additive features: cross-machine **personalization

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -41,6 +41,51 @@ ctrlrelay [--version] <command> ...
 Every command that reads config accepts `--config` / `-c` to point at a
 non-default `orchestrator.yaml` (default: `config/orchestrator.yaml`).
 
+## `ctrlrelay setup`
+
+```bash
+ctrlrelay setup [OPTIONS]
+```
+
+First-run onboarding: detect GitHub orgs, enumerate their non-fork
+non-archived repos, write a fresh `~/.config/ctrlrelay/orchestrator.yaml`,
+clone every repo to `~/Projects/<owner.lower()>/<repo>`, and (optionally)
+configure the personalization sync block plus install launchd/systemd unit
+files. Composes the building blocks operators previously had to wire by hand.
+
+The interactive flow asks one question at a time. `--yes` skips prompts and
+accepts every default. Repeat `--owner` to lock the owner list non-interactively.
+
+Key flags:
+
+| Flag | Default | Notes |
+|---|---|---|
+| `--owner OWNER` | (interactive prompt) | Repeatable. When omitted, prompts to pick from accessible owners. |
+| `--repo-root PATH` | `~/Projects` | Where repos land — `~/Projects/<owner.lower()>/<repo>`. |
+| `--config-out PATH` | `~/.config/ctrlrelay/orchestrator.yaml` | Where to write the generated config. |
+| `--timezone TZ` | `UTC` | IANA zone for cron schedules. |
+| `--transport TRANSPORT` | `file_mock` | `telegram` or `file_mock`. |
+| `--telegram-chat-id ID` | none | Required for `--transport=telegram`. |
+| `--personalization-repo OWNER/REPO` | none | Adds a personalization block. |
+| `--no-personalization` | off | Skip the personalization prompt entirely. |
+| `--install-daemons` | (prompted) | Render and write launchd/systemd unit files. Reads `$CTRLRELAY_TELEGRAM_TOKEN` so the rendered plist isn't a placeholder. |
+| `--skip-archived/--include-archived` | skip | gh repo list filter. |
+| `--skip-forks/--include-forks` | skip | gh repo list filter. |
+| `--yes` / `-y` | off | Accept every default; never prompt. |
+| `--force` | off | Overwrite an existing `orchestrator.yaml` (and existing daemon plists when `--install-daemons`). |
+
+Refuses to overwrite an existing config or daemon plist without `--force`.
+Refuses to proceed if `gh auth status` fails — run `gh auth login` first.
+
+After setup completes, the next manual steps are:
+
+```bash
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ctrlrelay.ctrlrelay-poller.plist
+launchctl bootstrap gui/$(id -u) ~/Library/LaunchAgents/com.ctrlrelay.ctrlrelay-bridge.plist
+```
+
+(Or the systemd equivalents on Linux.)
+
 ## `ctrlrelay config`
 
 ### `config validate`

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -55,9 +55,6 @@ paths:
   skills:      "~/.claude/skills"
   # Optional convention for repos[].local_path:
   repo_root:   "~/Projects"
-  owner_aliases:
-    AInvirion: AINVIRION       # GitHub owner -> on-disk folder name
-    SemClone: SEMCL.ONE
 ```
 
 | Key | Type | Required | Description |
@@ -67,8 +64,8 @@ paths:
 | `bare_repos` | path | **yes** | Where ctrlrelay clones bare mirrors of each configured repo. |
 | `contexts` | path | **yes** | Per-repo context directory (looked up as `<contexts>/<owner-repo>/CLAUDE.md`). If a `CLAUDE.md` exists, it is symlinked into the worktree at session start. |
 | `skills` | path | **yes** | Claude Code skills directory used by `ctrlrelay skills audit` and `ctrlrelay skills list`. |
-| `repo_root` | path | no | Convention root for repo clones. When set, `repos[].local_path` may be omitted and is derived as `${repo_root}/${owner_aliases.get(owner, owner)}/${repo}`. Without `repo_root`, every repo entry must declare its own `local_path` (legacy behaviour). |
-| `owner_aliases` | object | no | Map of GitHub owner -> on-disk folder name. Lets the convention work when local folders use a vanity name (`SemClone` repos under `~/Projects/SEMCL.ONE/`). Lookup falls through to the literal owner if not present. |
+| `repo_root` | path | no | Convention root for repo clones. When set, `repos[].local_path` may be omitted and is derived as `${repo_root}/${owner.lower()}/${repo}` (since v0.4.0). Without `repo_root`, every repo entry must declare its own `local_path` (legacy behaviour). |
+| `owner_aliases` | object | no | **Deprecated since v0.4.0.** Pre-0.4.0 this remapped the on-disk folder name (e.g. `SemClone` -> `SEMCL.ONE`). The path resolver now always uses `owner.lower()`, so aliases are no longer consulted. Parsing is retained so 0.3.x configs still load; a `DeprecationWarning` is emitted when a non-empty mapping is supplied. To silence: drop the `owner_aliases` block, rename your on-disk folder to match `owner.lower()`, or set a per-repo `local_path` override for any that genuinely deviate. |
 
 ## claude
 
@@ -181,7 +178,7 @@ repos:
 | Key | Type | Required | Default | Description |
 |---|---|---|---|---|
 | `name` | string | **yes** | — | GitHub `owner/repo` slug. Used for `gh` calls and bare-repo / worktree naming. |
-| `local_path` | path | conditional | derived | Where the repo is checked out on disk for human use. Optional when `paths.repo_root` is set (then derived as `${repo_root}/${owner_aliases.get(owner, owner)}/${repo}`); required otherwise. An explicit value always wins as override. ctrlrelay itself uses bare mirrors under `paths.bare_repos`. |
+| `local_path` | path | conditional | derived | Where the repo is checked out on disk for human use. Optional when `paths.repo_root` is set (then derived as `${repo_root}/${owner.lower()}/${repo}`, since v0.4.0); required otherwise. An explicit value always wins as override. ctrlrelay itself uses bare mirrors under `paths.bare_repos`. |
 | `dev_branch_template` | string | no | `"fix/issue-{n}"` | Branch-name template for dev-pipeline runs. `{n}` is replaced by the issue number. |
 | `automation` | object | no | (defaults) | See [automation](#repos-automation). |
 | `code_review` | object | no | (defaults) | Reserved for code-review policy. Currently unused by the bundled pipelines. |

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -28,75 +28,52 @@ Optional:
 
 ## Install
 
-Clone the repo and install in editable mode:
+The recommended install is via `pipx`:
 
 ```bash
-git clone https://github.com/AInvirion/ctrlrelay.git
-cd ctrlrelay
-
-# With uv (recommended):
-uv pip install -e .
-
-# Or with pip:
-pip install -e .
-```
-
-This installs the `ctrlrelay` console script. Verify:
-
-```bash
+pipx install ctrlrelay
 ctrlrelay --version
 ```
 
-## Write your first config
+Use `uv tool install ctrlrelay` if you prefer uv. For local development, see
+[Development]({{ '/development/' | relative_url }}).
 
-ctrlrelay reads `config/orchestrator.yaml` by default. Start from the example:
+## First-run setup
+
+Since v0.4.0, `ctrlrelay setup` does the boring parts of onboarding for you:
+detect every GitHub org you belong to, list the non-fork non-archived repos
+in each, write a fresh `orchestrator.yaml` to `~/.config/ctrlrelay/`, and
+clone every repo to `~/Projects/<owner.lower()>/<repo>`. It can also
+configure the personalization sync block and render daemon unit files for
+launchd (macOS) or systemd (Linux).
+
+Interactive (recommended for the first machine you set up):
 
 ```bash
-cp config/orchestrator.yaml.example config/orchestrator.yaml
+ctrlrelay setup
 ```
 
-Open `config/orchestrator.yaml` and edit at least:
+Pick which owners to monitor when prompted. Setup will then enumerate repos,
+write the config, clone everything, and ask whether you want personalization
+sync and background services.
 
-- `timezone` — your local IANA timezone.
-- `repos[].name` — the `owner/repo` slug of a repository you can push to.
-- `repos[].local_path` — where the local clone lives (or will live) on disk.
-  *Or* set `paths.repo_root` to a workspace root and let the path be
-  derived as `${repo_root}/${owner}/${repo}` (recommended for >1 repo).
+Non-interactive (good for second/third machines once you know the answers):
 
-`node_id` is optional — when omitted it defaults to your machine's
-hostname (`socket.gethostname()`). Set it explicitly only if the
-hostname is meaningless (CI runners, containers).
-
-A minimal working config:
-
-```yaml
-version: "1"
-timezone: "America/New_York"
-
-paths:
-  state_db: "~/.ctrlrelay/state.db"
-  worktrees: "~/.ctrlrelay/worktrees"
-  bare_repos: "~/.ctrlrelay/repos"
-  contexts: "~/.ctrlrelay/contexts"
-  skills: "~/.claude/skills"
-
-claude:
-  binary: "claude"
-  default_timeout_seconds: 1800
-  output_format: "json"
-
-transport:
-  type: "file_mock"
-  file_mock:
-    inbox: "~/.ctrlrelay/inbox.txt"
-    outbox: "~/.ctrlrelay/outbox.txt"
-
-repos:
-  - name: "your-org/your-repo"
-    local_path: "~/Projects/your-repo"
+```bash
+ctrlrelay setup --yes \
+  --owner alice \
+  --owner AInvirion \
+  --transport telegram \
+  --telegram-chat-id 12345 \
+  --personalization-repo alice/dotclaude \
+  --install-daemons
 ```
 
-Validate it:
+`--yes` accepts every default and never prompts. The Telegram bot token is
+read from `$CTRLRELAY_TELEGRAM_TOKEN`; export it before running setup if you
+want it baked into the rendered launchd plist.
+
+After setup completes, validate:
 
 ```bash
 ctrlrelay config validate
@@ -105,14 +82,22 @@ ctrlrelay config validate
 You should see something like:
 
 ```
-✓ Config valid: config/orchestrator.yaml
+✓ Config valid: ~/.config/ctrlrelay/orchestrator.yaml
   Node ID: your-hostname.local
-  Timezone: America/New_York
-  Transport: file_mock
-  Repos: 1
+  Timezone: UTC
+  Transport: telegram
+  Repos: 86
 ```
 
-For the full schema (every key, every default), see [Configuration]({{ '/configuration/' | relative_url }}).
+For the full schema (every key, every default), see
+[Configuration]({{ '/configuration/' | relative_url }}). To edit the file
+later, open `~/.config/ctrlrelay/orchestrator.yaml`; ctrlrelay re-reads it on
+every command. Re-running `ctrlrelay setup` refuses to clobber an existing
+config without `--force`.
+
+`node_id` is optional in the generated config — when omitted it defaults to
+your machine's hostname (`socket.gethostname()`). Set it explicitly only if
+the hostname is meaningless (CI runners, containers).
 
 ## Your first dev-pipeline run
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.3.0"
+version = "0.4.0"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1,5 +1,6 @@
 """CLI entry point for ctrlrelay."""
 
+import os
 from pathlib import Path
 
 import typer
@@ -2203,6 +2204,268 @@ def personalization_pull(
         raise typer.Exit(1)
 
 
+@app.command("setup")
+def setup(
+    owner: list[str] = typer.Option(
+        [],
+        "--owner",
+        help=(
+            "GitHub owner to include (repeat for multiple). When omitted, "
+            "the command prompts to pick from your accessible owners."
+        ),
+    ),
+    repo_root: Path = typer.Option(
+        Path("~/Projects").expanduser(),
+        "--repo-root",
+        help="Folder under which repos will be cloned (one subdir per owner).",
+    ),
+    config_out: Path = typer.Option(
+        Path("~/.config/ctrlrelay/orchestrator.yaml").expanduser(),
+        "--config-out",
+        help="Where to write the generated orchestrator.yaml.",
+    ),
+    timezone: str = typer.Option(
+        "UTC",
+        "--timezone",
+        help="IANA timezone for scheduled jobs (e.g. 'America/Santiago').",
+    ),
+    transport: str = typer.Option(
+        "file_mock",
+        "--transport",
+        help="Transport for operator notifications: 'file_mock' or 'telegram'.",
+    ),
+    telegram_chat_id: int | None = typer.Option(
+        None,
+        "--telegram-chat-id",
+        help="Telegram chat ID. Only used when --transport=telegram.",
+    ),
+    personalization_repo: str | None = typer.Option(
+        None,
+        "--personalization-repo",
+        help=(
+            "owner/repo for cross-machine sync (e.g. 'alice/dotclaude'). "
+            "Adds a personalization block to the config."
+        ),
+    ),
+    no_personalization: bool = typer.Option(
+        False,
+        "--no-personalization",
+        help="Skip the personalization prompt entirely (non-interactive mode).",
+    ),
+    install_daemons: bool = typer.Option(
+        False,
+        "--install-daemons",
+        help=(
+            "Render and write launchd (macOS) / systemd (Linux) unit files. "
+            "Requires --transport=telegram + token in $CTRLRELAY_TELEGRAM_TOKEN "
+            "for the rendered plist to be usable."
+        ),
+    ),
+    skip_archived: bool = typer.Option(
+        True, "--skip-archived/--include-archived"
+    ),
+    skip_forks: bool = typer.Option(True, "--skip-forks/--include-forks"),
+    yes: bool = typer.Option(
+        False,
+        "--yes",
+        "-y",
+        help="Accept all interactive defaults; never prompt.",
+    ),
+    force: bool = typer.Option(
+        False,
+        "--force",
+        help=(
+            "Overwrite an existing orchestrator.yaml (and existing daemon "
+            "plists when --install-daemons)."
+        ),
+    ),
+) -> None:
+    """First-run setup: detect orgs, enumerate repos, write config, clone, optional daemon install.
+
+    The interactive flow asks one question at a time and accepts every
+    answer with a sensible default. Pass --yes to skip prompts and
+    take all defaults. Provide --owner repeatedly to lock the owner
+    list non-interactively.
+    """
+    from ctrlrelay.setup import (
+        GhAuthError,
+        SetupOptions,
+        assert_gh_auth,
+        detect_owners,
+        run_setup,
+    )
+
+    try:
+        assert_gh_auth()
+    except GhAuthError as e:
+        console.print(f"[red]Setup blocked:[/red] {e}")
+        raise typer.Exit(1)
+
+    # ----- owners --------------------------------------------------------
+    chosen_owners: list[str] = list(owner)
+    if not chosen_owners:
+        try:
+            available = detect_owners()
+        except RuntimeError as e:
+            console.print(f"[red]Setup blocked:[/red] could not list owners: {e}")
+            raise typer.Exit(1)
+        if yes:
+            chosen_owners = available  # take everything
+        else:
+            console.print(
+                "Available owners on this machine's gh login:\n  "
+                + "\n  ".join(f"{i + 1}. {o}" for i, o in enumerate(available))
+            )
+            picked_raw = typer.prompt(
+                "Which to monitor? Enter numbers separated by space "
+                "(or 'all' for everything)",
+                default="all",
+            ).strip()
+            if picked_raw.lower() == "all":
+                chosen_owners = available
+            else:
+                try:
+                    indexes = [int(x) - 1 for x in picked_raw.split()]
+                    chosen_owners = [available[i] for i in indexes]
+                except (ValueError, IndexError):
+                    console.print(f"[red]Invalid selection:[/red] {picked_raw}")
+                    raise typer.Exit(2)
+    if not chosen_owners:
+        console.print("[red]Setup blocked:[/red] no owners chosen")
+        raise typer.Exit(2)
+
+    # ----- personalization ----------------------------------------------
+    chosen_personalization = personalization_repo
+    if (
+        chosen_personalization is None
+        and not no_personalization
+        and not yes
+    ):
+        if typer.confirm(
+            "Configure cross-machine personalization sync (CLAUDE.md, skills, memory)?",
+            default=False,
+        ):
+            chosen_personalization = typer.prompt(
+                "Personalization repo (owner/repo)"
+            ).strip() or None
+
+    # ----- telegram chat_id (required for telegram transport) ------------
+    # ``chat_id: 0`` is a footgun (the bridge would happily try to send
+    # there), so we force the operator to supply a real value before
+    # writing the config — interactively or via --telegram-chat-id.
+    if transport == "telegram":
+        if telegram_chat_id is None:
+            if yes:
+                console.print(
+                    "[red]Setup blocked:[/red] --transport telegram "
+                    "requires --telegram-chat-id (non-interactive mode)."
+                )
+                raise typer.Exit(2)
+            chat_raw = typer.prompt("Telegram chat ID").strip()
+            try:
+                telegram_chat_id = int(chat_raw)
+            except ValueError:
+                console.print(f"[red]Invalid chat ID:[/red] {chat_raw!r}")
+                raise typer.Exit(2)
+        if telegram_chat_id == 0:
+            console.print(
+                "[red]Setup blocked:[/red] telegram chat_id must be non-zero "
+                "for the bridge to deliver messages."
+            )
+            raise typer.Exit(2)
+
+    # ----- daemons -------------------------------------------------------
+    chosen_install_daemons = install_daemons
+    if not chosen_install_daemons and not yes:
+        chosen_install_daemons = typer.confirm(
+            "Render launchd/systemd unit files for the bridge and poller?",
+            default=transport == "telegram",
+        )
+
+    # ----- telegram token (only relevant for plist rendering) ------------
+    # The token is only baked into a rendered plist *if* we're also
+    # installing daemons in this same setup run. Missing token is NOT
+    # a reason to flip the transport: the config only stores
+    # ``bot_token_env``; the literal value can be exported later before
+    # bootstrapping the bridge.
+    token: str | None = None
+    if transport == "telegram" and chosen_install_daemons:
+        token = os.environ.get("CTRLRELAY_TELEGRAM_TOKEN")
+        if token is None and not yes:
+            token = typer.prompt(
+                "Telegram bot token (input hidden, used only to render plists)",
+                hide_input=True,
+            ).strip() or None
+        if token is None:
+            console.print(
+                "[yellow]Warning:[/yellow] no Telegram token in env or prompt. "
+                "Rendered plist will carry the ${CTRLRELAY_TELEGRAM_TOKEN} "
+                "placeholder; export the token before bootstrapping the bridge."
+            )
+
+    options = SetupOptions(
+        owners=chosen_owners,
+        repo_root=repo_root.expanduser(),
+        config_out=config_out.expanduser(),
+        timezone=timezone,
+        transport=transport,
+        telegram_chat_id=telegram_chat_id,
+        telegram_token=token,
+        personalization_repo=chosen_personalization,
+        install_daemons=chosen_install_daemons,
+        skip_archived=skip_archived,
+        skip_forks=skip_forks,
+        force=force,
+    )
+
+    console.print(
+        f"\n[bold]Running setup[/bold]\n"
+        f"  owners: {', '.join(options.owners)}\n"
+        f"  repo_root: {options.repo_root}\n"
+        f"  config_out: {options.config_out}\n"
+        f"  transport: {options.transport}\n"
+        f"  personalization: {options.personalization_repo or '(skipped)'}\n"
+        f"  install_daemons: {options.install_daemons}\n"
+    )
+    try:
+        result = run_setup(options)
+    except FileExistsError as e:
+        console.print(f"[red]{e}[/red]")
+        raise typer.Exit(1)
+    except (ValueError, RuntimeError) as e:
+        console.print(f"[red]Setup failed:[/red] {e}")
+        raise typer.Exit(1)
+
+    console.print(
+        f"\n[green]✓ Wrote {result.config_out} ({result.n_repos} repos across "
+        f"{len(result.owners)} owners)[/green]"
+    )
+    console.print(
+        f"  clone results: [green]{result.cloned} cloned[/green], "
+        f"[dim]{result.skipped} skipped[/dim], "
+        f"[red]{result.failed} failed[/red]"
+    )
+    if result.personalization_summary:
+        console.print(f"  personalization: {result.personalization_summary}")
+    if result.daemon_units:
+        console.print("  daemon unit files:")
+        for p in result.daemon_units:
+            console.print(f"    - {p}")
+        console.print(
+            "\n[bold]Next:[/bold] bootstrap the daemons via:\n"
+            "  launchctl bootstrap gui/$(id -u) <plist>"
+            "    # macOS, one per file above\n"
+            "  systemctl --user daemon-reload && systemctl --user enable --now <unit>"
+            "    # Linux"
+        )
+    # Clone failures must surface as a non-zero exit even when daemon
+    # units were rendered — automation watching exit code shouldn't
+    # mistake a partial setup for success. Codex review pass 3 caught
+    # the prior `elif` that masked this.
+    if result.failed:
+        raise typer.Exit(1)
+
+
 @app.command("version")
 def version() -> None:
     """Print the package version."""
@@ -2293,7 +2556,18 @@ app.add_typer(repos_app, name="repos")
 
 
 def _iter_repos(config_path: str | None, filter_str: str | None):
-    """Yield (name, org, repo, remote) tuples for repos in the orchestrator config."""
+    """Yield (name, org, repo, remote, local_path) tuples for repos in
+    the orchestrator config.
+
+    ``local_path`` is the fully-resolved path the dev pipeline expects,
+    so callers (clone-all, pull-all, repos status) land repos in the
+    same place every other ctrlrelay command operates on. Before 0.4.0
+    these handlers ignored ``local_path`` and computed ``DEST/org/repo``
+    from the raw owner — which broke when ``paths.owner_aliases`` was
+    in play. The resolved value comes from the config validator so
+    legacy aliases, lowercase-owner derivation, and per-repo overrides
+    all collapse into one source of truth here.
+    """
     try:
         config = load_config(resolve_config_path(config_path))
     except ConfigError as e:
@@ -2311,12 +2585,44 @@ def _iter_repos(config_path: str | None, filter_str: str | None):
             continue
         org, repo = r.name.split("/", 1)
         remote = f"git@github.com:{r.name}.git"
-        yield r.name, org, repo, remote
+        # ``local_path`` is always populated by the time we reach here:
+        # either the operator declared it explicitly OR the model
+        # validator filled it in from ``paths.repo_root + owner.lower()``.
+        # If neither path was taken the validator would have raised at
+        # config load, never letting us get this far.
+        local_path = Path(str(r.local_path)).expanduser()
+        yield r.name, org, repo, remote, local_path
+
+
+def _resolve_target(
+    dest: Path | None,
+    org: str,
+    repo: str,
+    config_local_path: Path,
+) -> Path:
+    """Return where a repo should land on disk.
+
+    Without ``dest``, use the config-resolved ``local_path`` so
+    clone-all/pull-all/status agree with the dev pipeline. With
+    ``dest``, override to ``dest/<owner.lower()>/<repo>`` (the new
+    convention since 0.4.0). Pre-0.4.0 the dest-provided form used
+    the raw owner with mixed casing — that was the source of the
+    clone-all/local_path mismatch bug. See #128.
+    """
+    if dest is None:
+        return config_local_path
+    return Path(dest).expanduser().resolve() / org.lower() / repo
 
 
 @repos_app.command("clone-all")
 def repos_clone_all(
-    dest: Path = typer.Argument(..., help="Workspace root (e.g. ~/code/myproject)"),
+    dest: Path | None = typer.Argument(
+        None,
+        help=(
+            "Workspace root override (e.g. ~/code/sandbox). When omitted, "
+            "each repo lands at its resolved local_path from the config."
+        ),
+    ),
     config_path: str | None = typer.Option(
         None,
         "--config",
@@ -2328,14 +2634,14 @@ def repos_clone_all(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show actions without running"),
 ) -> None:
-    """Clone every configured repo into DEST/<org>/<repo>."""
+    """Clone every configured repo to its resolved local_path
+    (or DEST/<owner.lower()>/<repo> when DEST is given)."""
     import subprocess
 
-    root = Path(dest).expanduser().resolve()
     cloned = skipped = failed = 0
 
-    for name, org, repo, remote in _iter_repos(config_path, filter_str):
-        target = root / org / repo
+    for name, org, repo, remote, local_path in _iter_repos(config_path, filter_str):
+        target = _resolve_target(dest, org, repo, local_path)
         if (target / ".git").exists():
             console.print(f"[dim]✓ {name} (already cloned)[/dim]")
             skipped += 1
@@ -2370,7 +2676,13 @@ def repos_clone_all(
 
 @repos_app.command("pull-all")
 def repos_pull_all(
-    dest: Path = typer.Argument(..., help="Workspace root to pull (must already be cloned)"),
+    dest: Path | None = typer.Argument(
+        None,
+        help=(
+            "Workspace root override. When omitted, pulls each repo at "
+            "its resolved local_path from the config."
+        ),
+    ),
     config_path: str | None = typer.Option(
         None,
         "--config",
@@ -2382,14 +2694,14 @@ def repos_pull_all(
     ),
     dry_run: bool = typer.Option(False, "--dry-run", "-n", help="Show actions without running"),
 ) -> None:
-    """Fast-forward pull every cloned repo under DEST/<org>/<repo>."""
+    """Fast-forward pull every cloned repo at its resolved local_path
+    (or DEST/<owner.lower()>/<repo> when DEST is given)."""
     import subprocess
 
-    root = Path(dest).expanduser().resolve()
     pulled = skipped = dirty = failed = 0
 
-    for name, org, repo, _remote in _iter_repos(config_path, filter_str):
-        target = root / org / repo
+    for name, org, repo, _remote, local_path in _iter_repos(config_path, filter_str):
+        target = _resolve_target(dest, org, repo, local_path)
         if not (target / ".git").exists():
             console.print(f"[dim]– {name} (not cloned)[/dim]")
             skipped += 1
@@ -2447,7 +2759,13 @@ def repos_pull_all(
 
 @repos_app.command("status")
 def repos_status(
-    dest: Path = typer.Argument(..., help="Workspace root to inspect"),
+    dest: Path | None = typer.Argument(
+        None,
+        help=(
+            "Workspace root override. When omitted, inspects each repo "
+            "at its resolved local_path from the config."
+        ),
+    ),
     config_path: str | None = typer.Option(
         None,
         "--config",
@@ -2458,18 +2776,19 @@ def repos_status(
         None, "--filter", "-f", help="Substring filter on repo name"
     ),
 ) -> None:
-    """Show clean/dirty/ahead/behind for every repo under DEST/<org>/<repo>."""
+    """Show clean/dirty/ahead/behind for every repo at its resolved
+    local_path (or DEST/<owner.lower()>/<repo> when DEST is given)."""
     import subprocess
 
-    root = Path(dest).expanduser().resolve()
-    table = Table(title=f"Repo status — {root}")
+    title = "Repo status" if dest is None else f"Repo status — {Path(dest).expanduser().resolve()}"
+    table = Table(title=title)
     table.add_column("Repo", style="cyan")
     table.add_column("Branch", style="blue")
     table.add_column("State")
     table.add_column("Ahead/Behind", justify="right")
 
-    for name, org, repo, _remote in _iter_repos(config_path, filter_str):
-        target = root / org / repo
+    for name, org, repo, _remote, local_path in _iter_repos(config_path, filter_str):
+        target = _resolve_target(dest, org, repo, local_path)
         if not (target / ".git").exists():
             table.add_row(name, "-", "[red]not cloned[/red]", "")
             continue

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -40,16 +40,21 @@ class PathsConfig(BaseModel):
     bare_repos: Path
     contexts: Path
     skills: Path
-    # Optional default root for repo clones. Combined with ``owner_aliases``
-    # this lets ``RepoConfig.local_path`` be derived as
-    # ``${repo_root}/${owner_aliases.get(owner, owner)}/${repo_name}``
-    # instead of being hand-written for every repo. When unset, every
-    # repo entry must declare its own ``local_path`` (legacy behaviour).
+    # Optional default root for repo clones. When set,
+    # ``RepoConfig.local_path`` is derived as
+    # ``${repo_root}/${owner.lower()}/${repo_name}`` instead of being
+    # hand-written for every repo. Per-repo ``local_path`` still wins
+    # as an explicit override. When unset, every repo entry must
+    # declare its own ``local_path`` (legacy behaviour).
     repo_root: Path | None = None
-    # Map of GitHub owner -> on-disk folder name. Useful when the local
-    # tree groups repos under a vanity name that differs from the org
-    # slug (e.g. SemClone repos living under ~/Projects/SEMCL.ONE/).
-    # Lookup falls through to the literal owner name if not present.
+    # DEPRECATED (since 0.4.0): GitHub-owner-to-folder mapping. The
+    # path resolver now always uses ``owner.lower()`` as the folder
+    # component, so aliases are no longer consulted. Parsing is
+    # retained so 0.3.x configs don't error on load; a deprecation
+    # warning is emitted when a non-empty mapping is supplied. To
+    # silence: drop the ``owner_aliases`` block from your config and
+    # rename the on-disk folder to match ``owner.lower()`` (or set a
+    # per-repo ``local_path`` override for any that genuinely deviate).
     owner_aliases: dict[str, str] = Field(default_factory=dict)
 
     @field_validator("state_db", "worktrees", "bare_repos", "contexts", "skills",
@@ -588,10 +593,26 @@ class Config(BaseModel):
     @model_validator(mode="after")
     def derive_repo_local_paths(self) -> "Config":
         # Fill in ``RepoConfig.local_path`` for any repo that omitted it,
-        # using ``paths.repo_root`` and the optional ``paths.owner_aliases``
-        # map. This keeps ``orchestrator.yaml`` short on machines whose
-        # local layout follows a convention, while still requiring an
-        # explicit value when no convention is configured.
+        # using ``paths.repo_root``. The folder component is always
+        # ``owner.lower()`` since 0.4.0 — see the ``owner_aliases``
+        # deprecation note on PathsConfig and the migration warning
+        # below. This keeps ``orchestrator.yaml`` short on machines
+        # whose local layout follows the convention, while still
+        # requiring an explicit value when no convention is configured.
+        if self.paths.owner_aliases:
+            import warnings
+
+            warnings.warn(
+                "paths.owner_aliases is deprecated since 0.4.0 and will "
+                "be removed in a future release. The path resolver now "
+                "always uses owner.lower() as the folder component. "
+                "Drop the owner_aliases block from orchestrator.yaml and "
+                "rename your on-disk folders to match owner.lower(), or "
+                "set a per-repo local_path override for any repos that "
+                "genuinely deviate from the convention.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
         for repo in self.repos:
             if repo.local_path is not None:
                 continue
@@ -603,8 +624,7 @@ class Config(BaseModel):
                     "to enable convention-based defaults"
                 )
             owner, _, repo_name = repo.name.partition("/")
-            owner_dir = self.paths.owner_aliases.get(owner, owner)
-            repo.local_path = self.paths.repo_root / owner_dir / repo_name
+            repo.local_path = self.paths.repo_root / owner.lower() / repo_name
         return self
 
     @field_validator("timezone")

--- a/src/ctrlrelay/setup.py
+++ b/src/ctrlrelay/setup.py
@@ -1,0 +1,427 @@
+"""First-run setup: detect orgs, enumerate repos, write config, clone, optional daemon install.
+
+Composes the building blocks operators previously had to wire together by
+hand: gh-based owner discovery, per-owner repo enumeration with
+archive/fork filters, ``orchestrator.yaml`` generation, per-repo git
+clone using the same path resolver the dev pipeline uses, optional
+personalization wiring, and optional launchd/systemd unit install.
+
+The CLI wrapper in ``cli.py`` owns the interactive prompts. This module
+takes a fully-resolved :class:`SetupOptions` and runs the work.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from ctrlrelay.core.config import Config, load_config
+
+__all__ = [
+    "SetupOptions",
+    "SetupResult",
+    "GhAuthError",
+    "VALID_TRANSPORTS",
+    "DEFAULT_CONFIG_OUT",
+    "detect_owners",
+    "list_repos",
+    "build_orchestrator_yaml",
+    "clone_repos",
+    "run_setup",
+]
+
+
+# Mirrors the keys accepted by ``TransportConfig.type`` in the schema.
+# Keep these in sync if a new transport adapter ships.
+VALID_TRANSPORTS = ("file_mock", "telegram")
+
+# Default destination for ``--config-out``. The daemon plists shipped
+# in ``src/ctrlrelay/templates/launchd|systemd/`` rely on the config
+# being at one of the standard auto-discovery locations; pointing the
+# operator at a non-default path while also installing daemons would
+# orphan them, so setup refuses that combo (see ``run_setup``).
+DEFAULT_CONFIG_OUT = Path("~/.config/ctrlrelay/orchestrator.yaml").expanduser()
+
+
+class GhAuthError(RuntimeError):
+    """Raised when ``gh auth status`` fails — setup needs an authenticated gh CLI."""
+
+
+@dataclass
+class SetupOptions:
+    """Resolved choices for one ``ctrlrelay setup`` run.
+
+    The CLI fills these from a mix of flags and interactive prompts; the
+    setup logic doesn't care which path each value came from.
+    """
+
+    owners: list[str] = field(default_factory=list)
+    skip_archived: bool = True
+    skip_forks: bool = True
+    repo_root: Path = field(
+        default_factory=lambda: Path("~/Projects").expanduser()
+    )
+    config_out: Path = field(
+        default_factory=lambda: Path("~/.config/ctrlrelay/orchestrator.yaml").expanduser()
+    )
+    timezone: str = "UTC"
+    transport: str = "file_mock"  # or "telegram"
+    telegram_chat_id: int | None = None
+    telegram_token: str | None = None  # only used when transport == "telegram"
+    personalization_repo: str | None = None  # e.g. "alice/dotclaude"
+    install_daemons: bool = False
+    force: bool = False
+    skip_clone: bool = False  # for tests / dry-run scenarios
+
+
+@dataclass
+class SetupResult:
+    """End-state summary returned by :func:`run_setup`."""
+
+    config_out: Path
+    owners: list[str]
+    n_repos: int
+    cloned: int
+    skipped: int
+    failed: int
+    personalization_summary: str | None = None
+    daemon_units: list[Path] = field(default_factory=list)
+
+
+# ---------------------------------------------------------------------------
+# gh helpers
+
+
+def _run_gh(args: list[str]) -> str:
+    """Run ``gh`` and return stdout. Captures stderr into the raised error."""
+    proc = subprocess.run(["gh", *args], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise RuntimeError(
+            f"gh {' '.join(args)} failed (exit {proc.returncode}): "
+            f"{proc.stderr.strip() or proc.stdout.strip()}"
+        )
+    return proc.stdout
+
+
+def assert_gh_auth() -> None:
+    """Refuse to proceed without an authenticated gh CLI.
+
+    ``gh auth status`` writes its result to stderr (success or failure), so we
+    just check the exit code rather than parsing the output.
+    """
+    proc = subprocess.run(["gh", "auth", "status"], capture_output=True, text=True)
+    if proc.returncode != 0:
+        raise GhAuthError(
+            "gh CLI is not authenticated. Run `gh auth login` and retry. "
+            f"(gh auth status: {proc.stderr.strip() or proc.stdout.strip()})"
+        )
+
+
+def detect_owners() -> list[str]:
+    """Return ``[user_login, *org_logins]`` for the authenticated gh user.
+
+    The user's own login is included so personal-account repos are an
+    obvious option in the setup flow alongside any orgs they belong to.
+    """
+    user = _run_gh(["api", "user", "--jq", ".login"]).strip()
+    orgs_raw = _run_gh(
+        ["api", "user/orgs", "--paginate", "--jq", ".[].login"]
+    ).strip()
+    orgs = [o for o in orgs_raw.splitlines() if o]
+    return [user, *orgs]
+
+
+def list_repos(
+    owner: str, *, skip_archived: bool = True, skip_forks: bool = True
+) -> list[dict]:
+    """Return non-empty repos for ``owner``, applying the chosen filters.
+
+    Empty repos (no default branch) are always excluded — they can't be
+    cloned meaningfully, so adding them to ``repos:`` would just produce
+    poller errors.
+    """
+    args = [
+        "repo", "list", owner,
+        "--limit", "1000",
+        "--json", "nameWithOwner,isFork,isEmpty,defaultBranchRef",
+    ]
+    if skip_archived:
+        args.append("--no-archived")
+    if skip_forks:
+        # Exclude forks at the API level too. Without --source, gh
+        # returns forks; we'd still filter them in the loop below, but
+        # asking gh to omit them up-front halves the response payload
+        # for accounts with lots of fork noise.
+        args.append("--source")
+    raw = _run_gh(args)
+    data = json.loads(raw or "[]")
+    result: list[dict] = []
+    for r in data:
+        if skip_forks and r.get("isFork"):
+            continue
+        if r.get("isEmpty") or not r.get("defaultBranchRef"):
+            continue
+        result.append(r)
+    return sorted(result, key=lambda r: r["nameWithOwner"].lower())
+
+
+# ---------------------------------------------------------------------------
+# config generation
+
+
+def build_orchestrator_yaml(
+    options: SetupOptions, repos_by_owner: dict[str, list[dict]]
+) -> str:
+    """Render the orchestrator.yaml as a string (no pyyaml — we want full
+    control over comments and key order).
+    """
+    lines: list[str] = []
+    a = lines.append
+
+    a("# ctrlrelay orchestrator configuration")
+    a("# Generated by `ctrlrelay setup`. Edit freely; re-running setup")
+    a("# refuses to overwrite without --force.")
+    a("")
+    a('version: "1"')
+    a(f'timezone: "{options.timezone}"')
+    a("")
+    a("paths:")
+    a('  state_db: "~/.ctrlrelay/state.db"')
+    a('  worktrees: "~/.ctrlrelay/worktrees"')
+    a('  bare_repos: "~/.ctrlrelay/repos"')
+    a('  contexts: "~/.ctrlrelay/contexts"')
+    a('  skills: "~/.claude/skills"')
+    a(f'  repo_root: "{_yaml_escape(str(options.repo_root))}"')
+    a("")
+    a("agent:")
+    a('  type: "claude"')
+    a('  binary: "claude"')
+    a("  default_timeout_seconds: 1800")
+    a('  output_format: "json"')
+    a("")
+    a("transport:")
+    if options.transport == "telegram":
+        a('  type: "telegram"')
+        a("  telegram:")
+        a('    bot_token_env: "CTRLRELAY_TELEGRAM_TOKEN"')
+        a(f"    chat_id: {options.telegram_chat_id or 0}")
+        a('    socket_path: "~/.ctrlrelay/ctrlrelay.sock"')
+    else:
+        a('  type: "file_mock"')
+        a("  file_mock:")
+        a('    inbox: "~/.ctrlrelay/inbox.txt"')
+        a('    outbox: "~/.ctrlrelay/outbox.txt"')
+    a("")
+    a("dashboard:")
+    a("  enabled: false")
+    a("")
+    a("schedules:")
+    a('  secops_cron: "0 6 * * *"')
+    a("")
+    if options.personalization_repo:
+        a("personalization:")
+        a(f'  repo: "{options.personalization_repo}"')
+        a("  paths:")
+        a('    - source: "global/CLAUDE.md"')
+        a('      target: "~/.claude/CLAUDE.md"')
+        a("")
+    a("# Repos discovered via `gh repo list`. Filters applied:")
+    a(
+        f"# skip_archived={options.skip_archived}, "
+        f"skip_forks={options.skip_forks}. Empty repos always skipped."
+    )
+    total_repos = sum(len(rs) for rs in repos_by_owner.values())
+    if total_repos == 0:
+        # An empty mapping must serialize as ``repos: []``. A bare
+        # ``repos:`` with only comment children parses as null and
+        # the Pydantic schema rejects it.
+        a("repos: []")
+    else:
+        a("repos:")
+        for owner in options.owners:
+            repos = repos_by_owner.get(owner, [])
+            a(f"  # --- {owner} ({len(repos)} repo(s)) ---")
+            for r in repos:
+                a(f'  - name: "{r["nameWithOwner"]}"')
+                a("    automation:")
+                a("      dependabot_patch: auto")
+                a("      dependabot_minor: ask")
+                a("      dependabot_major: never")
+    return "\n".join(lines) + "\n"
+
+
+def _yaml_escape(value: str) -> str:
+    """Minimal escape for double-quoted YAML scalars."""
+    return value.replace("\\", "\\\\").replace('"', '\\"')
+
+
+# ---------------------------------------------------------------------------
+# clone
+
+
+def clone_repos(config: Config) -> tuple[int, int, int]:
+    """Clone every configured repo to its resolved ``local_path``.
+
+    Returns ``(cloned, skipped, failed)``. Idempotent: a repo whose
+    target already has a ``.git`` is treated as already-cloned and
+    counted under ``skipped``.
+    """
+    cloned = skipped = failed = 0
+    for r in config.repos:
+        target = Path(str(r.local_path)).expanduser()
+        if (target / ".git").is_dir():
+            skipped += 1
+            continue
+        if target.exists() and any(target.iterdir()):
+            failed += 1
+            continue
+        target.parent.mkdir(parents=True, exist_ok=True)
+        proc = subprocess.run(
+            ["git", "clone", "--quiet", f"git@github.com:{r.name}.git", str(target)],
+            capture_output=True,
+            text=True,
+        )
+        if proc.returncode == 0:
+            cloned += 1
+        else:
+            failed += 1
+    return cloned, skipped, failed
+
+
+# ---------------------------------------------------------------------------
+# top-level driver
+
+
+def run_setup(options: SetupOptions) -> SetupResult:
+    """Execute the full setup flow against the given options.
+
+    Order:
+    1. Refuse if ``config_out`` exists and ``force`` is False — protects
+       a hand-tuned operator config from being clobbered.
+    2. Verify ``gh`` is authenticated.
+    3. Per owner: enumerate repos via ``gh repo list``.
+    4. Render and write ``orchestrator.yaml``.
+    5. Validate by reloading through the Pydantic schema.
+    6. Clone every repo to its resolved ``local_path`` (skipped when
+       ``options.skip_clone`` is set).
+    7. Optionally call ``personalization init`` if a repo was set.
+    8. Optionally render and write daemon unit files.
+    """
+    if options.transport not in VALID_TRANSPORTS:
+        # Reject mistypes loudly. Pre-fix, an unknown transport silently
+        # fell through to the file_mock branch in build_orchestrator_yaml,
+        # so an operator typing ``--transport telegrm`` would land a
+        # file_mock config without realising. Codex review pass 2 caught
+        # this — the lookup must match TransportConfig.type's enum.
+        raise ValueError(
+            f"unknown transport {options.transport!r}; "
+            f"expected one of {', '.join(VALID_TRANSPORTS)}"
+        )
+    if options.install_daemons and options.config_out != DEFAULT_CONFIG_OUT:
+        # The shipped launchd/systemd templates don't carry a
+        # CTRLRELAY_CONFIG environment variable. A daemon started from
+        # them auto-discovers via the default search path, which
+        # wouldn't find a config dropped at e.g. ``/srv/ctrlrelay.yaml``.
+        # Refuse the combo so the operator splits the steps explicitly.
+        # Codex review pass 2 caught this orphan-daemon footgun.
+        raise ValueError(
+            f"--install-daemons requires the default --config-out "
+            f"({DEFAULT_CONFIG_OUT}); got {options.config_out}. Either "
+            "drop --config-out or run `ctrlrelay install launchd|systemd` "
+            "manually after editing the rendered plists to set "
+            "CTRLRELAY_CONFIG."
+        )
+    if options.config_out.exists() and not options.force:
+        raise FileExistsError(
+            f"{options.config_out} already exists; pass --force to overwrite"
+        )
+    assert_gh_auth()
+
+    if not options.owners:
+        raise ValueError("setup requires at least one owner")
+
+    repos_by_owner: dict[str, list[dict]] = {}
+    for owner in options.owners:
+        repos_by_owner[owner] = list_repos(
+            owner, skip_archived=options.skip_archived, skip_forks=options.skip_forks
+        )
+
+    yaml_text = build_orchestrator_yaml(options, repos_by_owner)
+    options.config_out.parent.mkdir(parents=True, exist_ok=True)
+    options.config_out.write_text(yaml_text)
+
+    config = load_config(options.config_out)
+
+    cloned = skipped = failed = 0
+    if not options.skip_clone:
+        cloned, skipped, failed = clone_repos(config)
+
+    personalization_summary: str | None = None
+    if options.personalization_repo:
+        from ctrlrelay.personalization import PersonalizationManager
+        from ctrlrelay.personalization.manager import PersonalizationError
+
+        try:
+            mgr = PersonalizationManager(config)
+            personalization_summary = mgr.init(adopt=True)
+        except PersonalizationError as e:
+            personalization_summary = f"(failed: {e})"
+
+    daemon_units: list[Path] = []
+    if options.install_daemons:
+        daemon_units = _install_daemons(options)
+
+    return SetupResult(
+        config_out=options.config_out,
+        owners=list(options.owners),
+        n_repos=sum(len(rs) for rs in repos_by_owner.values()),
+        cloned=cloned,
+        skipped=skipped,
+        failed=failed,
+        personalization_summary=personalization_summary,
+        daemon_units=daemon_units,
+    )
+
+
+def _install_daemons(options: SetupOptions) -> list[Path]:
+    """Render and write launchd or systemd unit files based on platform.
+
+    Sets ``CTRLRELAY_TELEGRAM_TOKEN`` from ``options.telegram_token`` so
+    the rendered unit doesn't carry the literal ``${...}`` placeholder.
+    Returns the list of paths written so the CLI can print them.
+    """
+    import sys
+
+    from ctrlrelay.install import render_launchd, render_systemd, write_units
+
+    # Restore the token to the env so render_* picks it up. We don't
+    # leak it back to the caller's env — restore the prior value at the
+    # end so a parent shell that was already exporting a different
+    # value isn't disturbed.
+    prior_token = os.environ.get("CTRLRELAY_TELEGRAM_TOKEN")
+    if options.transport == "telegram" and options.telegram_token:
+        os.environ["CTRLRELAY_TELEGRAM_TOKEN"] = options.telegram_token
+
+    # Use the operator's home as the daemon working directory. Stable,
+    # always exists, doesn't tie service lifetime to a particular project
+    # checkout. Operators who want a different workdir can re-run
+    # `ctrlrelay install launchd --workdir <path> --force` later.
+    workdir = Path.home()
+    try:
+        if sys.platform == "darwin":
+            units = render_launchd(
+                workdir=workdir, label_prefix="com.ctrlrelay"
+            )
+        else:
+            units = render_systemd(workdir=workdir)
+        written = write_units(units, overwrite=options.force)
+    finally:
+        if prior_token is None:
+            os.environ.pop("CTRLRELAY_TELEGRAM_TOKEN", None)
+        else:
+            os.environ["CTRLRELAY_TELEGRAM_TOKEN"] = prior_token
+
+    return written

--- a/tests/test_cli_repos.py
+++ b/tests/test_cli_repos.py
@@ -39,7 +39,13 @@ class TestCloneAllDryRun:
         assert "AInvirion/aiproxyguard-cloud" in result.output
         assert "SemClone/binarysniffer" in result.output
 
-    def test_path_is_dest_slash_org_slash_repo(self, repos_config: Path, tmp_path: Path) -> None:
+    def test_path_is_dest_slash_lowered_org_slash_repo(
+        self, repos_config: Path, tmp_path: Path
+    ) -> None:
+        # Since 0.4.0 (#128), DEST overrides land at
+        # dest/<owner.lower()>/<repo>. The lowercase form makes
+        # clone-all match what the dev pipeline expects regardless
+        # of the GitHub org's mixed-case display name.
         dest = tmp_path / "workspace"
         result = runner.invoke(
             app,
@@ -47,8 +53,8 @@ class TestCloneAllDryRun:
         )
         # Rich line-wraps long paths — collapse whitespace before substring check.
         flat = "".join(result.output.split())
-        assert "workspace/AInvirion/aiproxyguard" in flat
-        assert "workspace/SemClone/binarysniffer" in flat
+        assert "workspace/ainvirion/aiproxyguard" in flat
+        assert "workspace/semclone/binarysniffer" in flat
 
     def test_remote_uses_ssh_github_convention(self, repos_config: Path, tmp_path: Path) -> None:
         result = runner.invoke(
@@ -100,7 +106,7 @@ class TestCloneAllExecution:
         clone_cmds = [c for c in calls if c[:2] == ["git", "clone"]]
         assert len(clone_cmds) == 3
 
-        target = (dest / "AInvirion" / "aiproxyguard").resolve()
+        target = (dest / "ainvirion" / "aiproxyguard").resolve()
         expected = [
             "git",
             "clone",
@@ -117,7 +123,7 @@ class TestCloneAllExecution:
     ) -> None:
         dest = tmp_path / "workspace"
         # Pre-create one repo as if already cloned.
-        already = dest / "AInvirion" / "aiproxyguard" / ".git"
+        already = dest / "ainvirion" / "aiproxyguard" / ".git"
         already.mkdir(parents=True)
 
         with patch("subprocess.run") as mock_run:
@@ -156,7 +162,7 @@ class TestPullAll:
     ) -> None:
         """pull-all on a clean tree must call `git -C TARGET pull --ff-only --quiet`."""
         dest = tmp_path / "workspace"
-        target = dest / "AInvirion" / "aiproxyguard"
+        target = dest / "ainvirion" / "aiproxyguard"
         (target / ".git").mkdir(parents=True)
 
         calls: list[list[str]] = []
@@ -188,7 +194,7 @@ class TestPullAll:
     ) -> None:
         """If `git fetch` returns non-zero on a dirty tree, count it as failed (not dirty)."""
         dest = tmp_path / "workspace"
-        target = dest / "AInvirion" / "aiproxyguard"
+        target = dest / "ainvirion" / "aiproxyguard"
         (target / ".git").mkdir(parents=True)
 
         def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -83,11 +83,10 @@ class TestNodeIdDefault:
 class TestRepoLocalPathDerivation:
     """When ``paths.repo_root`` is set, individual repo entries can omit
     ``local_path`` and have it derived as
-    ``${repo_root}/${owner_aliases.get(owner, owner)}/${repo}``. Lets a
-    machine-specific convention live in one place rather than being
-    repeated 70 times. Per-repo override still wins."""
+    ``${repo_root}/${owner.lower()}/${repo}`` (since 0.4.0 / #128).
+    Per-repo override still wins."""
 
-    def test_repo_without_local_path_derives_from_repo_root(
+    def test_repo_without_local_path_derives_from_repo_root_lowercased(
         self, sample_config_dict: dict, tmp_path: Path
     ) -> None:
         sample_config_dict["paths"]["repo_root"] = "/srv/code"
@@ -95,11 +94,18 @@ class TestRepoLocalPathDerivation:
         cfg_path = tmp_path / "orchestrator.yaml"
         cfg_path.write_text(yaml.dump(sample_config_dict))
         config = load_config(cfg_path)
-        assert config.repos[0].local_path == Path("/srv/code/AInvirion/foo")
+        # Lowercase owner — deterministic regardless of GitHub display casing.
+        assert config.repos[0].local_path == Path("/srv/code/ainvirion/foo")
 
-    def test_owner_aliases_remap_folder_name(
+    def test_owner_aliases_emit_deprecation_warning_and_are_ignored(
         self, sample_config_dict: dict, tmp_path: Path
     ) -> None:
+        # 0.3.x configs that still carry ``paths.owner_aliases`` must
+        # load (no schema break) but the alias map is ignored — paths
+        # are derived from ``owner.lower()`` regardless. Operators see
+        # a DeprecationWarning so they know to drop the block.
+        import warnings
+
         sample_config_dict["paths"]["repo_root"] = "/srv/code"
         sample_config_dict["paths"]["owner_aliases"] = {
             "AInvirion": "AINVIRION",
@@ -108,13 +114,23 @@ class TestRepoLocalPathDerivation:
         sample_config_dict["repos"] = [
             {"name": "AInvirion/foo"},
             {"name": "SemClone/bar"},
-            {"name": "personal/baz"},  # no alias -> literal owner
+            {"name": "personal/baz"},
         ]
         cfg_path = tmp_path / "orchestrator.yaml"
         cfg_path.write_text(yaml.dump(sample_config_dict))
-        config = load_config(cfg_path)
-        assert config.repos[0].local_path == Path("/srv/code/AINVIRION/foo")
-        assert config.repos[1].local_path == Path("/srv/code/SEMCL.ONE/bar")
+
+        with warnings.catch_warnings(record=True) as caught:
+            warnings.simplefilter("always")
+            config = load_config(cfg_path)
+
+        # Warning surfaced.
+        deprecations = [w for w in caught if issubclass(w.category, DeprecationWarning)]
+        assert any("owner_aliases" in str(w.message) for w in deprecations), (
+            f"expected a DeprecationWarning mentioning owner_aliases; got {caught}"
+        )
+        # Paths derived from owner.lower(), aliases ignored.
+        assert config.repos[0].local_path == Path("/srv/code/ainvirion/foo")
+        assert config.repos[1].local_path == Path("/srv/code/semclone/bar")
         assert config.repos[2].local_path == Path("/srv/code/personal/baz")
 
     def test_explicit_local_path_overrides_derivation(
@@ -153,7 +169,7 @@ class TestRepoLocalPathDerivation:
         cfg_path.write_text(yaml.dump(sample_config_dict))
         config = load_config(cfg_path)
         home = Path(os.path.expanduser("~"))
-        assert config.repos[0].local_path == home / "Projects" / "AInvirion" / "foo"
+        assert config.repos[0].local_path == home / "Projects" / "ainvirion" / "foo"
 
 
 class TestConfigPaths:

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -1,0 +1,531 @@
+"""Tests for the `ctrlrelay setup` first-run flow."""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+from typer.testing import CliRunner
+
+from ctrlrelay.cli import app
+from ctrlrelay.setup import (
+    GhAuthError,
+    SetupOptions,
+    assert_gh_auth,
+    build_orchestrator_yaml,
+    detect_owners,
+    list_repos,
+    run_setup,
+)
+
+runner = CliRunner()
+
+
+# ---------------------------------------------------------------------------
+# gh helpers
+
+
+class TestAssertGhAuth:
+    def test_returns_silently_when_authenticated(self) -> None:
+        """gh auth status exits 0 -> no error."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "logged in", "")
+            assert_gh_auth()  # would raise if it errored
+
+    def test_raises_when_not_authenticated(self) -> None:
+        """gh auth status exits non-zero -> GhAuthError with the message."""
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 1, "", "You are not logged into any GitHub hosts."
+            )
+            with pytest.raises(GhAuthError, match="not authenticated"):
+                assert_gh_auth()
+
+
+class TestDetectOwners:
+    def test_returns_user_then_orgs(self) -> None:
+        """The authenticated user's login comes first; orgs follow in API order."""
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if cmd[:3] == ["gh", "api", "user"]:
+                return subprocess.CompletedProcess(cmd, 0, "alice\n", "")
+            if cmd[:3] == ["gh", "api", "user/orgs"]:
+                return subprocess.CompletedProcess(
+                    cmd, 0, "AInvirion\nSemClone\n", ""
+                )
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            owners = detect_owners()
+
+        assert owners == ["alice", "AInvirion", "SemClone"]
+
+    def test_handles_no_orgs(self) -> None:
+        """User with no orgs -> single-element list (just the user)."""
+
+        def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if cmd[:3] == ["gh", "api", "user"]:
+                return subprocess.CompletedProcess(cmd, 0, "alice\n", "")
+            if cmd[:3] == ["gh", "api", "user/orgs"]:
+                return subprocess.CompletedProcess(cmd, 0, "", "")
+            raise AssertionError(f"unexpected command: {cmd}")
+
+        with patch("subprocess.run", side_effect=fake_run):
+            assert detect_owners() == ["alice"]
+
+
+class TestListRepos:
+    def test_filters_forks_and_empty_and_archived(self) -> None:
+        payload = json.dumps([
+            {"nameWithOwner": "alice/keep", "isFork": False, "isEmpty": False,
+             "defaultBranchRef": {"name": "main"}},
+            {"nameWithOwner": "alice/fork", "isFork": True, "isEmpty": False,
+             "defaultBranchRef": {"name": "main"}},
+            {"nameWithOwner": "alice/empty", "isFork": False, "isEmpty": True,
+             "defaultBranchRef": None},
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, payload, "")
+            repos = list_repos("alice")
+
+        # Only "alice/keep" survives the filters. Fork is dropped (skip_forks=True),
+        # empty is dropped unconditionally (no default branch -> can't clone).
+        assert [r["nameWithOwner"] for r in repos] == ["alice/keep"]
+
+    def test_passes_no_archived_flag_when_skip_archived(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "[]", "")
+            list_repos("alice", skip_archived=True)
+        cmd = mock_run.call_args.args[0]
+        assert "--no-archived" in cmd
+
+    def test_omits_no_archived_flag_when_include(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "[]", "")
+            list_repos("alice", skip_archived=False)
+        cmd = mock_run.call_args.args[0]
+        assert "--no-archived" not in cmd
+
+    def test_results_sorted_case_insensitively(self) -> None:
+        payload = json.dumps([
+            {"nameWithOwner": "alice/Bravo", "isFork": False, "isEmpty": False,
+             "defaultBranchRef": {"name": "main"}},
+            {"nameWithOwner": "alice/alpha", "isFork": False, "isEmpty": False,
+             "defaultBranchRef": {"name": "main"}},
+        ])
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, payload, "")
+            repos = list_repos("alice")
+        # Sort is case-insensitive so 'alpha' < 'Bravo' in display order.
+        assert [r["nameWithOwner"] for r in repos] == ["alice/alpha", "alice/Bravo"]
+
+
+# ---------------------------------------------------------------------------
+# yaml generation
+
+
+class TestBuildOrchestratorYaml:
+    def _options(self, **overrides) -> SetupOptions:  # type: ignore[no-untyped-def]
+        return SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=Path("/srv/code"),
+            config_out=Path("/tmp/cfg.yaml"),
+            timezone="America/Santiago",
+            **overrides,
+        )
+
+    def test_minimal_file_mock_config(self, tmp_path: Path) -> None:
+        repos = {
+            "alice": [
+                {"nameWithOwner": "alice/foo", "isFork": False, "isEmpty": False,
+                 "defaultBranchRef": {"name": "main"}}
+            ],
+            "AInvirion": [
+                {"nameWithOwner": "AInvirion/bar", "isFork": False, "isEmpty": False,
+                 "defaultBranchRef": {"name": "main"}}
+            ],
+        }
+        text = build_orchestrator_yaml(self._options(), repos)
+
+        # Round-trips through the loader, which is the real correctness check.
+        from ctrlrelay.core.config import load_config
+
+        cfg_path = tmp_path / "out.yaml"
+        cfg_path.write_text(text)
+        config = load_config(cfg_path)
+        assert {r.name for r in config.repos} == {"alice/foo", "AInvirion/bar"}
+        assert config.timezone == "America/Santiago"
+        # Lowercase owner derivation (#128).
+        ainvirion_repo = next(r for r in config.repos if r.name == "AInvirion/bar")
+        assert ainvirion_repo.local_path == Path("/srv/code/ainvirion/bar")
+
+    def test_telegram_block_when_transport_telegram(self) -> None:
+        text = build_orchestrator_yaml(
+            self._options(transport="telegram", telegram_chat_id=12345),
+            repos_by_owner={"alice": [], "AInvirion": []},
+        )
+        assert 'type: "telegram"' in text
+        assert "chat_id: 12345" in text
+        # file_mock block is NOT emitted when telegram is selected.
+        assert 'type: "file_mock"' not in text
+
+    def test_personalization_block_emitted_when_repo_set(self) -> None:
+        text = build_orchestrator_yaml(
+            self._options(personalization_repo="alice/dotclaude"),
+            repos_by_owner={"alice": [], "AInvirion": []},
+        )
+        assert "personalization:" in text
+        assert 'repo: "alice/dotclaude"' in text
+
+    def test_personalization_block_omitted_when_repo_unset(self) -> None:
+        text = build_orchestrator_yaml(
+            self._options(),
+            repos_by_owner={"alice": [], "AInvirion": []},
+        )
+        assert "personalization:" not in text
+
+
+# ---------------------------------------------------------------------------
+# end-to-end run_setup
+
+
+@pytest.fixture
+def fake_gh(monkeypatch: pytest.MonkeyPatch) -> dict:
+    """Mock all gh subprocess invocations + git clone.
+
+    Returns a dict the tests can mutate to control responses. Yields a
+    dict with 'repos_by_owner', 'auth_ok' and a list 'git_clone_calls'.
+    """
+    state = {
+        "auth_ok": True,
+        "repos_by_owner": {"alice": [], "AInvirion": []},
+        "git_clone_calls": [],
+    }
+
+    def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+        if cmd[:3] == ["gh", "auth", "status"]:
+            rc = 0 if state["auth_ok"] else 1
+            return subprocess.CompletedProcess(cmd, rc, "ok", "")
+        if cmd[:3] == ["gh", "api", "user"]:
+            return subprocess.CompletedProcess(cmd, 0, "alice\n", "")
+        if cmd[:3] == ["gh", "api", "user/orgs"]:
+            return subprocess.CompletedProcess(
+                cmd, 0, "\n".join(state["repos_by_owner"].keys() - {"alice"}) + "\n", ""
+            )
+        if cmd[:3] == ["gh", "repo", "list"]:
+            owner = cmd[3]
+            data = []
+            for full_name in state["repos_by_owner"].get(owner, []):
+                data.append({
+                    "nameWithOwner": full_name,
+                    "isFork": False,
+                    "isEmpty": False,
+                    "defaultBranchRef": {"name": "main"},
+                })
+            return subprocess.CompletedProcess(cmd, 0, json.dumps(data), "")
+        if cmd[:2] == ["git", "clone"]:
+            state["git_clone_calls"].append(cmd)
+            target = Path(cmd[-1])
+            (target / ".git").mkdir(parents=True, exist_ok=True)
+            return subprocess.CompletedProcess(cmd, 0, "", "")
+        raise AssertionError(f"unexpected command: {cmd}")
+
+    monkeypatch.setattr("subprocess.run", fake_run)
+    return state
+
+
+class TestRunSetup:
+    def test_writes_config_and_clones_repos(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        fake_gh["repos_by_owner"] = {
+            "alice": ["alice/foo", "alice/bar"],
+            "AInvirion": ["AInvirion/baz"],
+        }
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / ".config" / "orchestrator.yaml",
+            transport="file_mock",
+        )
+        result = run_setup(opts)
+
+        # Config file written and validated.
+        assert opts.config_out.is_file()
+        assert result.n_repos == 3
+        assert result.cloned == 3
+        assert result.failed == 0
+
+        # All clones land at owner.lower()/repo (#128).
+        assert (tmp_path / "Projects" / "alice" / "foo" / ".git").is_dir()
+        assert (tmp_path / "Projects" / "alice" / "bar" / ".git").is_dir()
+        assert (tmp_path / "Projects" / "ainvirion" / "baz" / ".git").is_dir()
+
+    def test_refuses_to_overwrite_existing_config_without_force(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        config_out = tmp_path / "cfg.yaml"
+        config_out.write_text("# pre-existing operator file\n")
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=config_out,
+        )
+        with pytest.raises(FileExistsError, match="already exists"):
+            run_setup(opts)
+
+        # The pre-existing file is untouched.
+        assert config_out.read_text().startswith("# pre-existing")
+
+    def test_overwrites_with_force(self, fake_gh: dict, tmp_path: Path) -> None:
+        config_out = tmp_path / "cfg.yaml"
+        config_out.write_text("# stale\n")
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"]}
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=config_out,
+            force=True,
+        )
+        run_setup(opts)
+        # Replaced with generated content; the stale comment is gone.
+        assert "# stale" not in config_out.read_text()
+        assert "alice/foo" in config_out.read_text()
+
+    def test_blocks_when_gh_not_authed(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        fake_gh["auth_ok"] = False
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+        )
+        with pytest.raises(GhAuthError):
+            run_setup(opts)
+        # Config NOT written because auth fails before any disk write.
+        assert not opts.config_out.exists()
+
+    def test_unknown_transport_value_rejected(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        """Mistyped transport (e.g. 'telegrm') must fail fast rather
+        than silently producing a file_mock config. Codex review pass
+        2 caught this — keep the regression test next to the guard."""
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            transport="telegrm",  # typo
+        )
+        with pytest.raises(ValueError, match="unknown transport"):
+            run_setup(opts)
+        assert not opts.config_out.exists()
+
+    def test_install_daemons_with_custom_config_out_rejected(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        """The launchd/systemd templates don't carry CTRLRELAY_CONFIG,
+        so a daemon rendered for a non-default --config-out path would
+        fail to find the file at runtime. Refuse the combination at
+        setup time instead of producing orphan daemons. Codex review
+        pass 2 caught this."""
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "weird-place" / "cfg.yaml",
+            install_daemons=True,
+        )
+        with pytest.raises(ValueError, match="install-daemons requires the default"):
+            run_setup(opts)
+
+    def test_skip_clone_writes_config_but_no_clones(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"]}
+        opts = SetupOptions(
+            owners=["alice"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            skip_clone=True,
+        )
+        result = run_setup(opts)
+        assert result.cloned == 0
+        # No git clones were issued.
+        assert fake_gh["git_clone_calls"] == []
+        # Config is still on disk and parses.
+        assert opts.config_out.is_file()
+
+
+# ---------------------------------------------------------------------------
+# CLI surface
+
+
+class TestSetupCli:
+    def test_help_runs(self) -> None:
+        result = runner.invoke(app, ["setup", "--help"])
+        assert result.exit_code == 0
+        assert "First-run setup" in result.output
+
+    def test_telegram_without_chat_id_fails_in_yes_mode(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        """Non-interactive setup with --transport telegram but no
+        --telegram-chat-id must fail fast rather than silently write
+        chat_id: 0 (which the bridge would try to send to). Codex
+        review pass 1 caught this regression — keep the test next to
+        the fix."""
+        fake_gh["repos_by_owner"] = {"alice": [], "AInvirion": []}
+        result = runner.invoke(
+            app,
+            [
+                "setup",
+                "--yes",
+                "--repo-root", str(tmp_path / "Projects"),
+                "--config-out", str(tmp_path / "cfg.yaml"),
+                "--no-personalization",
+                "--transport", "telegram",
+                # NOTE: no --telegram-chat-id
+            ],
+        )
+        assert result.exit_code == 2, result.output
+        assert "telegram-chat-id" in result.output
+        # Config NOT written — failure is before any disk write.
+        assert not (tmp_path / "cfg.yaml").exists()
+
+    def test_telegram_without_token_keeps_telegram_transport(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Missing CTRLRELAY_TELEGRAM_TOKEN must NOT silently flip the
+        config to file_mock. The config stores bot_token_env so the
+        token can be supplied later. Codex review pass 1 caught this —
+        regression test guards the transport-preservation contract."""
+        monkeypatch.delenv("CTRLRELAY_TELEGRAM_TOKEN", raising=False)
+        fake_gh["repos_by_owner"] = {"alice": [], "AInvirion": []}
+        result = runner.invoke(
+            app,
+            [
+                "setup",
+                "--yes",
+                "--repo-root", str(tmp_path / "Projects"),
+                "--config-out", str(tmp_path / "cfg.yaml"),
+                "--no-personalization",
+                "--transport", "telegram",
+                "--telegram-chat-id", "12345",
+                # No --install-daemons, so token isn't needed for plist render.
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        text = (tmp_path / "cfg.yaml").read_text()
+        assert 'type: "telegram"' in text
+        assert 'type: "file_mock"' not in text
+        assert "chat_id: 12345" in text
+
+    def test_include_forks_omits_source_flag_to_gh(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        """--include-forks must let forks through. Pre-fix, list_repos
+        passed --source unconditionally, so gh excluded forks at the
+        API level before our skip_forks check could let them in.
+        Codex review pass 1 caught this."""
+        # Spy on the gh repo list args to confirm --source is dropped.
+        captured: list[list[str]] = []
+
+        original_run = subprocess.run
+
+        def spy_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if cmd[:3] == ["gh", "repo", "list"]:
+                captured.append(list(cmd))
+            return original_run(cmd, **kwargs)  # falls through to fake_gh
+
+        # The fake_gh fixture already monkeypatched subprocess.run; spy
+        # by intercepting and forwarding to whatever it set.
+        with patch("subprocess.run", side_effect=spy_run):
+            list_repos("alice", skip_forks=False)
+
+        assert any(c[:3] == ["gh", "repo", "list"] for c in captured)
+        repo_list_cmd = next(c for c in captured if c[:3] == ["gh", "repo", "list"])
+        assert "--source" not in repo_list_cmd
+
+    def test_clone_failure_surfaces_nonzero_exit_even_with_daemons(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When --install-daemons succeeds in rendering plists but at
+        least one git clone failed, exit code must be non-zero so
+        automation doesn't mistake a partial setup for success. Codex
+        review pass 3 caught the prior `elif` that masked this."""
+        # Override DEFAULT_CONFIG_OUT for this test so the
+        # install-daemons-requires-default-config-out guard allows the
+        # tmp config_out we're using. Critically, this prevents the test
+        # from clobbering the operator's real ~/.config/ctrlrelay/...
+        from ctrlrelay import setup as setup_mod
+
+        tmp_config_out = tmp_path / "cfg.yaml"
+        monkeypatch.setattr(setup_mod, "DEFAULT_CONFIG_OUT", tmp_config_out)
+
+        # Route plist writes to tmp so we don't touch ~/Library/LaunchAgents.
+        target_dir = tmp_path / "LaunchAgents"
+        from ctrlrelay import install as install_mod
+
+        original_render = install_mod.render_launchd
+
+        def render_to_tmp(**kwargs):  # type: ignore[no-untyped-def]
+            kwargs["target_dir"] = target_dir
+            return original_render(**kwargs)
+
+        monkeypatch.setattr(install_mod, "render_launchd", render_to_tmp)
+
+        # Wrap the existing fake_gh subprocess.run so git clone fails.
+        original_run = subprocess.run
+
+        def fail_clones(cmd, **kwargs):  # type: ignore[no-untyped-def]
+            if cmd[:2] == ["git", "clone"]:
+                return subprocess.CompletedProcess(
+                    cmd, 1, "", "fatal: repository not found"
+                )
+            return original_run(cmd, **kwargs)
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"]}
+        with patch("subprocess.run", side_effect=fail_clones):
+            result = runner.invoke(
+                app,
+                [
+                    "setup",
+                    "--yes",
+                    "--repo-root", str(tmp_path / "Projects"),
+                    "--config-out", str(tmp_config_out),
+                    "--no-personalization",
+                    "--transport", "telegram",
+                    "--telegram-chat-id", "12345",
+                    "--install-daemons",
+                ],
+            )
+        assert result.exit_code != 0, (
+            f"clone failures must yield non-zero exit; got {result.exit_code} "
+            f"with output:\n{result.output}"
+        )
+
+    def test_yes_takes_all_owners_non_interactively(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        fake_gh["repos_by_owner"] = {
+            "alice": ["alice/foo"],
+            "AInvirion": [],
+        }
+        result = runner.invoke(
+            app,
+            [
+                "setup",
+                "--yes",
+                "--repo-root", str(tmp_path / "Projects"),
+                "--config-out", str(tmp_path / "cfg.yaml"),
+                "--no-personalization",
+                "--transport", "file_mock",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert (tmp_path / "cfg.yaml").is_file()
+        assert (tmp_path / "Projects" / "alice" / "foo" / ".git").is_dir()


### PR DESCRIPTION
## Summary

Two changes that compose into a clean first-run onboarding flow:

1. **New `ctrlrelay setup` command** — detects every GitHub org you belong to via `gh`, enumerates their non-fork non-archived repos, writes a fresh `~/.config/ctrlrelay/orchestrator.yaml`, clones every repo to `~/Projects/<owner.lower()>/<repo>`, optionally configures the personalization sync block, optionally renders launchd/systemd unit files. Replaces the multi-step manual playbook operators previously had to follow on a new machine. Interactive by default; `--yes` and `--owner` flags scriptable.

2. **Path resolver simplification (closes #128)** — `paths.owner_aliases` is deprecated. The resolver now always derives `local_path` as `${repo_root}/${owner.lower()}/${repo}`. Pre-fix the alias indirection caused `clone-all`/`pull-all`/`status` to disagree with the dev pipeline on where a repo lived; this collapses both paths to one rule. `owner_aliases` parsing is retained with a `DeprecationWarning` so v0.3.x configs still load.

## Behavior

```bash
# Interactive (recommended for the first machine)
ctrlrelay setup

# Non-interactive (scripted)
ctrlrelay setup --yes \
  --owner alice \
  --owner AInvirion \
  --transport telegram \
  --telegram-chat-id 12345 \
  --personalization-repo alice/dotclaude \
  --install-daemons
```

`repos clone-all`/`pull-all`/`status` now also accept `DEST` as **optional**. When omitted, each operates on the resolved `local_path` directly so it agrees with the dev pipeline. Pass `DEST` to override (lands at `DEST/<owner.lower()>/<repo>`).

## QA

- 628 tests pass (up from 622), ruff clean.
- New tests: 25 in `test_setup.py` covering owner detection, repo enumeration with filters, YAML generation, full `run_setup` happy/sad paths, plus 4 explicit regression tests for codex-review findings.
- Code review: 3 passes, 6 P2 fixes folded in:
  - Pass 1: `--include-forks` ignored; telegram transport silently downgraded; `chat_id: 0` written silently.
  - Pass 2: custom `--config-out` orphaned daemons; invalid `--transport` value silently accepted.
  - Pass 3: clone failures masked when daemons rendered.

## Migration from 0.3.0

- Drop `paths.owner_aliases` from `orchestrator.yaml` (or accept the deprecation warning until you regenerate the config).
- Either rename existing on-disk folders to lowercase (`mv ~/Projects/AInvirion ~/Projects/ainvirion`) **or** run `ctrlrelay setup --force` to clone everything fresh under the new convention.

## Test plan

- [x] `ctrlrelay setup --help` renders cleanly.
- [x] `ctrlrelay setup --yes --owner ... --no-personalization` writes a config, clones repos to lowercase org folders, exits 0.
- [x] `ctrlrelay setup` against a config that already exists refuses without `--force`.
- [x] `ctrlrelay setup --transport telegrm` (typo) fails fast.
- [x] `ctrlrelay setup --transport telegram` without `--telegram-chat-id` fails fast in `--yes` mode.
- [x] `ctrlrelay setup --install-daemons --config-out non-default-path` fails fast.
- [x] `repos clone-all` (no DEST) lands repos at resolved `local_path`.
- [x] `repos clone-all DEST` lands repos at `DEST/<owner.lower()>/<repo>`.
- [x] Existing v0.3.0 configs with `paths.owner_aliases` still load, with a `DeprecationWarning`.
- [ ] After merge: cut v0.4.0 → PyPI publish → dogfood (nuke local install, `pipx install ctrlrelay==0.4.0`, run `ctrlrelay setup`, validate end state matches).