### PR TITLE
fix(setup): drop personalization repo from repos; auto-wire skills [v0.4.1]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.1] - 2026-05-08
+
+Patch release. Two follow-ups against the v0.4.0 setup flow surfaced
+during the dogfood validation:
+
+### Fixed
+
+- **`setup` no longer lists the personalization repo under
+  `repos:`.** When the operator's personalization repo lives under
+  one of the configured owners (e.g. `alice/dotclaude` while `alice`
+  is also an enumerated owner), it was being added to the dev
+  pipeline's monitored set — the poller would have polled it for
+  issues and worktree-cloned it. The repo is the cross-machine sync
+  target, not a project; setup now drops it from the enumerated list
+  before generating the YAML.
+
+### Added
+
+- **Auto-wire detected skills on `setup`.** When the personalization
+  repo already contains `global/skills/<name>/` directories (e.g.
+  from a prior `personalization push` on another machine), setup now
+  pre-clones the repo, scans for skill subdirectories, and adds one
+  `paths:` entry per skill to the generated `personalization.paths`
+  block. Operators don't have to hand-edit the config to wire each
+  skill back on a new machine. Pass `--no-wire-skills` to opt out.
+  Hidden directories and stray top-level files are ignored — only
+  real skill packages count.
+
 ## [0.4.0] - 2026-05-08
 
 Minor release. One new feature plus one schema simplification:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.4.0"
+version = "0.4.1"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -2252,6 +2252,15 @@ def setup(
         "--no-personalization",
         help="Skip the personalization prompt entirely (non-interactive mode).",
     ),
+    wire_skills: bool = typer.Option(
+        True,
+        "--wire-skills/--no-wire-skills",
+        help=(
+            "When the personalization repo already contains "
+            "global/skills/<name>/ directories, add a paths: entry per "
+            "skill so they sync to ~/.claude/skills/<name>/. Default: on."
+        ),
+    ),
     install_daemons: bool = typer.Option(
         False,
         "--install-daemons",
@@ -2412,6 +2421,7 @@ def setup(
         telegram_chat_id=telegram_chat_id,
         telegram_token=token,
         personalization_repo=chosen_personalization,
+        wire_skills=wire_skills,
         install_daemons=chosen_install_daemons,
         skip_archived=skip_archived,
         skip_forks=skip_forks,

--- a/src/ctrlrelay/setup.py
+++ b/src/ctrlrelay/setup.py
@@ -23,11 +23,14 @@ from ctrlrelay.core.config import Config, load_config
 __all__ = [
     "SetupOptions",
     "SetupResult",
+    "PersonalizationPath",
     "GhAuthError",
     "VALID_TRANSPORTS",
     "DEFAULT_CONFIG_OUT",
+    "DEFAULT_PERSONALIZATION_CHECKOUT",
     "detect_owners",
     "list_repos",
+    "detect_personalization_skills",
     "build_orchestrator_yaml",
     "clone_repos",
     "run_setup",
@@ -44,6 +47,11 @@ VALID_TRANSPORTS = ("file_mock", "telegram")
 # operator at a non-default path while also installing daemons would
 # orphan them, so setup refuses that combo (see ``run_setup``).
 DEFAULT_CONFIG_OUT = Path("~/.config/ctrlrelay/orchestrator.yaml").expanduser()
+
+# Mirrors ``Personalization.checkout_path``'s default. Setup pre-clones
+# into this path before generating the YAML so we can scan for skill
+# directories and wire them in the same setup run (see #129 follow-up).
+DEFAULT_PERSONALIZATION_CHECKOUT = Path("~/.ctrlrelay/personalization").expanduser()
 
 
 class GhAuthError(RuntimeError):
@@ -72,9 +80,30 @@ class SetupOptions:
     telegram_chat_id: int | None = None
     telegram_token: str | None = None  # only used when transport == "telegram"
     personalization_repo: str | None = None  # e.g. "alice/dotclaude"
+    # When True (the default) and ``personalization_repo`` is set,
+    # setup pre-clones the personalization repo and scans
+    # ``global/skills/<name>/`` for existing skill directories,
+    # wiring each as its own ``paths:`` entry. Skills already laid
+    # down by the operator on a prior machine then auto-sync to this
+    # one without a hand-edit.
+    wire_skills: bool = True
     install_daemons: bool = False
     force: bool = False
     skip_clone: bool = False  # for tests / dry-run scenarios
+
+
+@dataclass
+class PersonalizationPath:
+    """One source/target pair for the personalization block.
+
+    Setup uses this to assemble the ``personalization.paths`` list:
+    the always-on ``global/CLAUDE.md`` entry plus any auto-detected
+    skills. Kept as a flat dataclass so tests can construct lists
+    without touching the YAML output format.
+    """
+
+    source: str
+    target: str
 
 
 @dataclass
@@ -169,14 +198,117 @@ def list_repos(
 
 
 # ---------------------------------------------------------------------------
+# personalization helpers
+
+
+def _ensure_personalization_clone(
+    repo: str, checkout: Path
+) -> bool:
+    """Make sure ``checkout`` is a clone of ``github.com:<repo>.git``.
+
+    Returns True if the clone is present and matches ``repo`` (existing
+    or freshly created), False if the remote refused (auth error, repo
+    doesn't exist) OR the existing checkout points at a different repo.
+    Errors are swallowed so setup proceeds with the default
+    CLAUDE.md-only personalization paths — a missing or unrelated
+    remote shouldn't abort the whole onboarding flow, but we also must
+    not scan an unrelated working tree's skills and bake them into the
+    new config (codex review pass 2).
+    """
+    if (checkout / ".git").is_dir():
+        return _checkout_matches_repo(checkout, repo)
+    checkout.parent.mkdir(parents=True, exist_ok=True)
+    # Use HTTPS to match ``PersonalizationManager.repo_url`` so the
+    # pre-scan works for operators authenticated to GitHub via gh
+    # tokens / HTTPS without an SSH key on the machine. Codex review
+    # pass 3 caught the SSH/HTTPS mismatch — pre-scan would silently
+    # fail, the manager's own init() would later succeed via HTTPS,
+    # and the auto-wire feature would be bypassed in a common setup.
+    proc = subprocess.run(
+        ["git", "clone", "--quiet", f"https://github.com/{repo}.git", str(checkout)],
+        capture_output=True,
+        text=True,
+    )
+    return proc.returncode == 0
+
+
+def _checkout_matches_repo(checkout: Path, repo: str) -> bool:
+    """Return True iff the existing ``checkout``'s origin remote points
+    at ``github.com:<repo>``.
+
+    Accepts the three URL forms git emits for github.com remotes:
+    ``https://github.com/owner/repo(.git)``,
+    ``git@github.com:owner/repo(.git)``, and
+    ``ssh://git@github.com/owner/repo(.git)``. Comparison is
+    case-insensitive — GitHub repo names are. Any other host or any
+    error reading the remote returns False (treated as "not ours").
+    """
+    proc = subprocess.run(
+        ["git", "-C", str(checkout), "remote", "get-url", "origin"],
+        capture_output=True,
+        text=True,
+    )
+    if proc.returncode != 0:
+        return False
+    url = proc.stdout.strip()
+    expected = repo.lower()
+    # Strip the optional ``.git`` suffix and reduce each accepted URL
+    # form to ``owner/repo`` for the comparison.
+    if url.endswith(".git"):
+        url = url[: -len(".git")]
+    for prefix in (
+        "https://github.com/",
+        "ssh://git@github.com/",
+        "git@github.com:",
+    ):
+        if url.startswith(prefix):
+            return url[len(prefix):].lower() == expected
+    return False
+
+
+def detect_personalization_skills(checkout: Path) -> list[PersonalizationPath]:
+    """Return a sorted list of per-skill ``paths:`` entries derived from
+    ``<checkout>/global/skills/``.
+
+    Each direct subdirectory becomes one entry mapping
+    ``global/skills/<name>/`` -> ``~/.claude/skills/<name>/``. Hidden
+    dirs (``.foo``) and files at the top level are skipped — only
+    actual skill packages count. Returns an empty list when the
+    directory is missing.
+    """
+    skills_dir = checkout / "global" / "skills"
+    if not skills_dir.is_dir():
+        return []
+    paths: list[PersonalizationPath] = []
+    for entry in sorted(skills_dir.iterdir(), key=lambda p: p.name.lower()):
+        if not entry.is_dir() or entry.name.startswith("."):
+            continue
+        paths.append(
+            PersonalizationPath(
+                source=f"global/skills/{entry.name}/",
+                target=f"~/.claude/skills/{entry.name}/",
+            )
+        )
+    return paths
+
+
+# ---------------------------------------------------------------------------
 # config generation
 
 
 def build_orchestrator_yaml(
-    options: SetupOptions, repos_by_owner: dict[str, list[dict]]
+    options: SetupOptions,
+    repos_by_owner: dict[str, list[dict]],
+    personalization_paths: list[PersonalizationPath] | None = None,
 ) -> str:
     """Render the orchestrator.yaml as a string (no pyyaml — we want full
     control over comments and key order).
+
+    ``personalization_paths`` is the full list of ``paths:`` entries to
+    emit under the personalization block. When ``None`` and a
+    personalization repo is configured, defaults to the always-on
+    ``global/CLAUDE.md`` mapping. Pass an explicit list to add detected
+    skills (see :func:`detect_personalization_skills`).
     """
     lines: list[str] = []
     a = lines.append
@@ -222,11 +354,19 @@ def build_orchestrator_yaml(
     a('  secops_cron: "0 6 * * *"')
     a("")
     if options.personalization_repo:
+        if personalization_paths is None:
+            personalization_paths = [
+                PersonalizationPath(
+                    source="global/CLAUDE.md",
+                    target="~/.claude/CLAUDE.md",
+                )
+            ]
         a("personalization:")
         a(f'  repo: "{options.personalization_repo}"')
         a("  paths:")
-        a('    - source: "global/CLAUDE.md"')
-        a('      target: "~/.claude/CLAUDE.md"')
+        for entry in personalization_paths:
+            a(f'    - source: "{_yaml_escape(entry.source)}"')
+            a(f'      target: "{_yaml_escape(entry.target)}"')
         a("")
     a("# Repos discovered via `gh repo list`. Filters applied:")
     a(
@@ -345,11 +485,51 @@ def run_setup(options: SetupOptions) -> SetupResult:
 
     repos_by_owner: dict[str, list[dict]] = {}
     for owner in options.owners:
-        repos_by_owner[owner] = list_repos(
+        repos = list_repos(
             owner, skip_archived=options.skip_archived, skip_forks=options.skip_forks
         )
+        # Drop the personalization repo if it surfaced under one of the
+        # configured owners. It's the cross-machine sync target, not a
+        # project the dev pipeline should monitor for issues — listing
+        # it under ``repos:`` alongside the per-machine personalization
+        # checkout would have ctrlrelay polling and worktree-cloning
+        # the operator's own dotfiles. Comparison is case-insensitive
+        # because GitHub repo names are case-insensitive: ``alice/foo``
+        # and ``Alice/Foo`` resolve to the same repo, so an operator
+        # passing one casing while ``gh repo list`` returned the other
+        # would otherwise dodge the filter (codex review pass 1).
+        if options.personalization_repo:
+            personalization_norm = options.personalization_repo.lower()
+            repos = [
+                r for r in repos
+                if r["nameWithOwner"].lower() != personalization_norm
+            ]
+        repos_by_owner[owner] = repos
 
-    yaml_text = build_orchestrator_yaml(options, repos_by_owner)
+    # Build the personalization paths list BEFORE writing the YAML so
+    # auto-detected skills end up baked into the file the operator
+    # eventually edits. Pre-clone the personalization repo if needed
+    # (it might already exist from a prior setup run on this machine).
+    personalization_paths: list[PersonalizationPath] | None = None
+    if options.personalization_repo:
+        personalization_paths = [
+            PersonalizationPath(
+                source="global/CLAUDE.md",
+                target="~/.claude/CLAUDE.md",
+            )
+        ]
+        if options.wire_skills:
+            cloned_for_scan = _ensure_personalization_clone(
+                options.personalization_repo, DEFAULT_PERSONALIZATION_CHECKOUT
+            )
+            if cloned_for_scan:
+                personalization_paths.extend(
+                    detect_personalization_skills(DEFAULT_PERSONALIZATION_CHECKOUT)
+                )
+
+    yaml_text = build_orchestrator_yaml(
+        options, repos_by_owner, personalization_paths=personalization_paths
+    )
     options.config_out.parent.mkdir(parents=True, exist_ok=True)
     options.config_out.write_text(yaml_text)
 

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -17,11 +17,28 @@ from ctrlrelay.setup import (
     assert_gh_auth,
     build_orchestrator_yaml,
     detect_owners,
+    detect_personalization_skills,
     list_repos,
     run_setup,
 )
 
 runner = CliRunner()
+
+
+def _write_fake_checkout(checkout: Path, origin_url: str) -> None:
+    """Lay down a checkout that ``git remote get-url origin`` would
+    accept, without needing a real ``git init`` (the test fixtures
+    patch ``subprocess.run`` and would intercept real git ops).
+    """
+    git_dir = checkout / ".git"
+    git_dir.mkdir(parents=True, exist_ok=True)
+    (git_dir / "HEAD").write_text("ref: refs/heads/main\n")
+    (git_dir / "config").write_text(
+        "[core]\n"
+        "\trepositoryformatversion = 0\n"
+        f'[remote "origin"]\n'
+        f"\turl = {origin_url}\n"
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -231,6 +248,28 @@ def fake_gh(monkeypatch: pytest.MonkeyPatch) -> dict:
             target = Path(cmd[-1])
             (target / ".git").mkdir(parents=True, exist_ok=True)
             return subprocess.CompletedProcess(cmd, 0, "", "")
+        # git -C <checkout> remote get-url origin — used by the
+        # personalization-checkout origin verification.
+        if (
+            len(cmd) >= 6
+            and cmd[0] == "git"
+            and cmd[1] == "-C"
+            and cmd[3:6] == ["remote", "get-url", "origin"]
+        ):
+            checkout = Path(cmd[2])
+            cfg = checkout / ".git" / "config"
+            if cfg.is_file():
+                # Pull `url = ...` out of the [remote "origin"] block.
+                in_origin = False
+                for line in cfg.read_text().splitlines():
+                    s = line.strip()
+                    if s.startswith("["):
+                        in_origin = s == '[remote "origin"]'
+                        continue
+                    if in_origin and s.startswith("url"):
+                        url = s.split("=", 1)[1].strip()
+                        return subprocess.CompletedProcess(cmd, 0, url + "\n", "")
+            return subprocess.CompletedProcess(cmd, 1, "", "no origin")
         raise AssertionError(f"unexpected command: {cmd}")
 
     monkeypatch.setattr("subprocess.run", fake_run)
@@ -358,6 +397,247 @@ class TestRunSetup:
         assert fake_gh["git_clone_calls"] == []
         # Config is still on disk and parses.
         assert opts.config_out.is_file()
+
+
+# ---------------------------------------------------------------------------
+# personalization follow-ups: filter the personalization repo, auto-wire skills
+
+
+class TestDetectPersonalizationSkills:
+    def test_returns_sorted_subdirs_only(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "global" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "Bravo").mkdir()
+        (skills_dir / "alpha").mkdir()
+        (skills_dir / "charlie").mkdir()
+        # A stray file at the top level — must be ignored.
+        (skills_dir / "README.md").write_text("not a skill\n")
+        # A hidden dir — must be ignored.
+        (skills_dir / ".hidden").mkdir()
+
+        paths = detect_personalization_skills(tmp_path)
+        names = [p.source.removeprefix("global/skills/").removesuffix("/") for p in paths]
+        # Case-insensitive sort: 'alpha', 'Bravo', 'charlie'.
+        assert names == ["alpha", "Bravo", "charlie"]
+
+    def test_returns_empty_when_skills_dir_missing(self, tmp_path: Path) -> None:
+        # Personalization repo without a global/skills/ tree at all.
+        assert detect_personalization_skills(tmp_path) == []
+
+    def test_target_uses_tilde_home_for_portability(self, tmp_path: Path) -> None:
+        skills_dir = tmp_path / "global" / "skills"
+        skills_dir.mkdir(parents=True)
+        (skills_dir / "gh-secops").mkdir()
+        paths = detect_personalization_skills(tmp_path)
+        # Target must use ``~/.claude/...`` rather than an absolute home
+        # path so the same config works across machines with different
+        # operator home directories.
+        assert paths[0].target == "~/.claude/skills/gh-secops/"
+
+
+class TestPersonalizationRepoFilteredOutOfRepos:
+    def test_personalization_repo_not_listed_under_owner(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When the personalization repo lives under one of the
+        configured owners (e.g. ``alice/dotclaude`` while ``alice`` is
+        also an enumerated owner), it must not appear in the ``repos:``
+        block — it's the sync target, not a project to monitor."""
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        # Don't try to clone the personalization repo for skill scan
+        # or actually run init in this test — we're focused on the
+        # repos: filter.
+        monkeypatch.setattr(
+            setup_mod, "_ensure_personalization_clone", lambda repo, checkout: False
+        )
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+        fake_gh["repos_by_owner"] = {
+            "alice": ["alice/foo", "alice/dotclaude", "alice/bar"],
+            "AInvirion": ["AInvirion/baz"],
+        }
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=False,  # skip scan in this test
+        )
+        result = run_setup(opts)
+        # 3 repos remain (alice/foo, alice/bar, AInvirion/baz). The
+        # personalization repo is excluded but other alice repos pass.
+        assert result.n_repos == 3
+        text = opts.config_out.read_text()
+        assert "alice/foo" in text
+        assert "alice/bar" in text
+        assert "AInvirion/baz" in text
+        assert 'name: "alice/dotclaude"' not in text
+
+
+    def test_personalization_repo_filter_is_case_insensitive(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """GitHub repo names are case-insensitive (``alice/dotclaude``
+        and ``Alice/DotClaude`` resolve to the same repo). The filter
+        must match regardless of casing — codex review pass 1 caught
+        the case where ``gh repo list`` returns the canonical casing
+        but the operator's --personalization-repo arg differs."""
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        monkeypatch.setattr(
+            setup_mod, "_ensure_personalization_clone", lambda repo, checkout: False
+        )
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+        # gh returns the canonical casing; operator typed lowercase.
+        fake_gh["repos_by_owner"] = {
+            "alice": ["alice/foo", "Alice/DotClaude"],
+            "AInvirion": [],
+        }
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",  # lowercase
+            wire_skills=False,
+        )
+        result = run_setup(opts)
+        # Only alice/foo remains — the canonical-cased dotclaude was filtered.
+        assert result.n_repos == 1
+        text = opts.config_out.read_text()
+        assert "alice/foo" in text
+        assert "DotClaude" not in text
+        assert "dotclaude" not in text.replace(opts.personalization_repo or "", "")
+
+
+class TestSkillAutoWiringInRunSetup:
+    def test_detected_skills_appear_in_personalization_paths(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """End-to-end: when --wire-skills is on (default) and the
+        personalization checkout has skill subdirs, run_setup adds
+        per-skill paths: entries to the generated YAML."""
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        # Stand up a fake personalization checkout with two skills.
+        fake_checkout = tmp_path / "personalization-checkout"
+        skills = fake_checkout / "global" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "gh-secops").mkdir()
+        (skills / "codex-review-loop").mkdir()
+        # Origin must match `personalization_repo` for the existence
+        # check to accept this checkout (codex review pass 2 added the
+        # check; without an origin, scan would be skipped).
+        _write_fake_checkout(fake_checkout, "git@github.com:alice/dotclaude.git")
+
+        # Point setup at the fake checkout instead of ~/.ctrlrelay/...
+        monkeypatch.setattr(
+            setup_mod, "DEFAULT_PERSONALIZATION_CHECKOUT", fake_checkout
+        )
+        # Don't run real PersonalizationManager.init — that would issue
+        # additional git commands the fake_gh fixture doesn't mock.
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=True,
+        )
+        run_setup(opts)
+        text = opts.config_out.read_text()
+        # CLAUDE.md still there; skills appended in detect order.
+        assert 'source: "global/CLAUDE.md"' in text
+        assert 'source: "global/skills/codex-review-loop/"' in text
+        assert 'source: "global/skills/gh-secops/"' in text
+        assert 'target: "~/.claude/skills/codex-review-loop/"' in text
+
+    def test_existing_checkout_with_different_origin_is_not_scanned(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """If ~/.ctrlrelay/personalization already holds a clone of a
+        DIFFERENT repo than what setup is configuring, the helper must
+        treat it as unusable and skip the skill scan. Otherwise we'd
+        bake the unrelated repo's skill names into the new config and
+        PersonalizationManager.init would later refuse the checkout.
+        Codex review pass 2 caught this."""
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        # Stand up a fake checkout whose origin is for "other/unrelated",
+        # but configure setup with personalization-repo "alice/dotclaude".
+        fake_checkout = tmp_path / "stale-checkout"
+        skills = fake_checkout / "global" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "should-not-leak").mkdir()
+        _write_fake_checkout(fake_checkout, "git@github.com:other/unrelated.git")
+
+        monkeypatch.setattr(
+            setup_mod, "DEFAULT_PERSONALIZATION_CHECKOUT", fake_checkout
+        )
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=True,
+        )
+        run_setup(opts)
+        text = opts.config_out.read_text()
+        # CLAUDE.md is the only paths: entry. The unrelated checkout's
+        # skill name does NOT leak into the generated config.
+        assert 'source: "global/CLAUDE.md"' in text
+        assert "should-not-leak" not in text
+        assert "global/skills/" not in text
+
+    def test_no_wire_skills_emits_only_default_path(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """``--no-wire-skills`` must NOT scan or add per-skill
+        entries even if the personalization checkout has skill dirs."""
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        fake_checkout = tmp_path / "personalization-checkout"
+        skills = fake_checkout / "global" / "skills"
+        skills.mkdir(parents=True)
+        (skills / "gh-secops").mkdir()
+        (fake_checkout / ".git").mkdir()
+        monkeypatch.setattr(
+            setup_mod, "DEFAULT_PERSONALIZATION_CHECKOUT", fake_checkout
+        )
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=False,
+        )
+        run_setup(opts)
+        text = opts.config_out.read_text()
+        assert 'source: "global/CLAUDE.md"' in text
+        # No per-skill entries written when wire-skills is off.
+        assert "global/skills/" not in text
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Two follow-ups against the v0.4.0 setup flow surfaced during dogfood validation.

1. **Filter the personalization repo out of `repos:`.** When the operator's personalization repo lives under one of the configured owners (e.g. `alice/dotclaude` while `alice` is enumerated), it was being added to the dev-pipeline's monitored set — the poller would have polled it for issues and worktree-cloned it. Setup now drops it from the enumerated list before generating the YAML. Comparison is case-insensitive (GitHub repo names are).

2. **Auto-wire detected skills.** When the personalization repo already contains `global/skills/<name>/` directories (from a prior `personalization push` on another machine), setup pre-clones the repo, scans for skills, and adds one `paths:` entry per skill. Operators don't have to hand-edit the config to wire each skill back on a new machine. Pass `--no-wire-skills` to opt out.

## Behavior

```bash
# Default: skills auto-wired
ctrlrelay setup --yes \
  --owner alice \
  --personalization-repo alice/dotclaude

# Opt out of skill scan (pre-fix behavior)
ctrlrelay setup --yes \
  --owner alice \
  --personalization-repo alice/dotclaude \
  --no-wire-skills
```

## QA

- 636 tests pass (up from 634), ruff clean.
- New tests cover: `detect_personalization_skills` (sorted, hidden-aware, missing-dir-tolerant), repo filter (basic + case-insensitive), full `run_setup` skill auto-wiring on/off, wrong-origin checkout safely ignored.
- Codex review: 3 passes, 3 P2 fixes folded in:
  - Pass 1: case-sensitive comparison missed canonical-vs-lowercase repo names.
  - Pass 2: existing checkout for a *different* repo was scanned anyway, leaking unrelated skill names into the new config.
  - Pass 3: pre-scan cloned via SSH but `PersonalizationManager` uses HTTPS — operators with gh-token/HTTPS auth (no SSH key) saw the auto-wire silently skip.

## Test plan

- [x] `ctrlrelay setup --yes --personalization-repo OWNER/dotclaude` excludes that repo from `repos:` even if it's listed under one of the enumerated owners.
- [x] Skill subdirs in `~/.ctrlrelay/personalization/global/skills/` produce per-skill `paths:` entries.
- [x] `--no-wire-skills` falls back to the CLAUDE.md-only personalization paths.
- [x] An existing `~/.ctrlrelay/personalization/` checkout pointing at an *unrelated* repo is treated as not-ours and the scan skipped.
- [x] HTTPS pre-scan succeeds in CI (no SSH agent in the test env).
- [ ] After merge: cut v0.4.1 → PyPI publish.