### PR TITLE
fix(secops): dispatch BLOCKED questions to operator via transport.ask

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -593,6 +593,29 @@ def run_secops(
     console.print(f"Running secops on {len(repos)} repo(s)...")
 
     async def _run():
+        # Build a transport so secops blocked questions reach Telegram.
+        # Without this, agents that end BLOCKED_NEEDS_INPUT silently land
+        # in the DB+pending_resumes and the operator never sees the
+        # question (mirror of the wiring in the scheduled path).
+        transport = None
+        if (
+            config.transport.type.value == "telegram"
+            and config.transport.telegram
+        ):
+            from ctrlrelay.transports import SocketTransport
+            sock = config.transport.telegram.socket_path.expanduser().resolve()
+            if sock.exists():
+                try:
+                    candidate = SocketTransport(sock)
+                    await candidate.connect()
+                    transport = candidate
+                except Exception as e:
+                    console.print(
+                        f"[yellow]Bridge transport connect failed ({e}) — "
+                        f"running without notifications. Blocked sessions "
+                        f"will land in pending_resumes for later resume.[/yellow]"
+                    )
+
         return await run_secops_all(
             repos=repos,
             dispatcher=dispatcher,
@@ -600,7 +623,7 @@ def run_secops(
             worktree=worktree,
             dashboard=dashboard,
             state_db=db,
-            transport=None,
+            transport=transport,
             contexts_dir=config.paths.contexts,
         )
 

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -21,6 +21,8 @@ from ctrlrelay.transports.base import Transport
 
 _logger = get_logger("pipeline.secops")
 
+DEFAULT_MAX_BLOCKED_ROUNDS = 5
+
 
 def _question_for_persist(session_id: str, result: PipelineResult) -> str:
     """Return a non-empty question string for pending_resumes storage.
@@ -258,6 +260,7 @@ async def run_secops_all(
     state_db: StateDB,
     transport: Transport | None,
     contexts_dir: Path,
+    max_blocked_rounds: int = DEFAULT_MAX_BLOCKED_ROUNDS,
 ) -> list[PipelineResult]:
     """Run secops pipeline on all configured repos."""
     results = []
@@ -315,6 +318,51 @@ async def run_secops_all(
             session_row_inserted = True
 
             result = await pipeline.run(ctx)
+
+            # BLOCKED loop: when the agent ends BLOCKED_NEEDS_INPUT, push
+            # the question to the operator via the configured transport
+            # (Telegram), wait for an answer, and resume. Mirrors the
+            # dev/task pipelines — without this, secops blocked sessions
+            # silently land as "blocked" in the DB without ever reaching
+            # the operator. transport.ask() failure preserves blocked=True
+            # so the persistence-on-blocked branch below still fires and
+            # writes a pending_resumes row that a later out-of-band reply
+            # could resume via the sweeper.
+            rounds = 0
+            while (
+                result.blocked
+                and transport is not None
+                and rounds < max_blocked_rounds
+            ):
+                question = _question_for_persist(session_id, result)
+                try:
+                    answer = await transport.ask(
+                        question,
+                        session_id=session_id,
+                        repo=repo,
+                    )
+                except Exception as e:
+                    log_event(
+                        _logger,
+                        "secops.transport.ask_failed",
+                        session_id=session_id,
+                        repo=repo,
+                        error_type=type(e).__name__,
+                        error=str(e)[:200],
+                    )
+                    result = PipelineResult(
+                        success=False,
+                        blocked=True,
+                        session_id=session_id,
+                        summary=f"Blocked session deferred (transport): {e}",
+                        error=str(e),
+                        question=question,
+                        outputs=result.outputs,
+                    )
+                    break
+                rounds += 1
+                result = await pipeline.resume(ctx, answer)
+
             results.append(result)
 
             status = "done" if result.success else ("blocked" if result.blocked else "failed")

--- a/src/ctrlrelay/transports/socket_client.py
+++ b/src/ctrlrelay/transports/socket_client.py
@@ -55,6 +55,17 @@ class SocketTransport:
                 try:
                     msg = parse_message(line.decode())
                     if msg.request_id and msg.request_id in self._pending:
+                        # The bridge sends two messages back for an ASK:
+                        # an intermediate ACK(status="pending") immediately
+                        # after queuing for Telegram, then an ANSWER (or
+                        # ERROR) once the operator replies. Resolving the
+                        # future on the first ACK collapses the wait
+                        # prematurely — caller sees "Unexpected response:
+                        # BridgeOp.ACK" and throws. Skip those to keep
+                        # waiting. Terminal ACKs (status="sent" from SEND)
+                        # remain the final response and resolve normally.
+                        if msg.op == BridgeOp.ACK and msg.status == "pending":
+                            continue
                         self._pending[msg.request_id].set_result(msg)
                 except ProtocolError:
                     pass

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -299,6 +299,139 @@ class TestSecopsPromptOperatorConfigPRs:
         assert "begins with `-`" in prompt or "lines beginning with `-`" in prompt.lower()
 
 
+class TestSecopsBlockedDispatch:
+    """Regression for the silent-blocked-secops bug: when an agent ends
+    BLOCKED_NEEDS_INPUT, the orchestrator must call transport.ask() to
+    deliver the question to the operator (mirroring dev/task pipelines).
+    Without this, blocked secops sessions land in the DB with status
+    'blocked' but the question never reaches Telegram."""
+
+    @pytest.mark.asyncio
+    async def test_blocked_secops_dispatches_question_via_transport(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        # First spawn returns BLOCKED with a question; the resume call
+        # returns DONE so the session unblocks.
+        blocked_state = MagicMock()
+        blocked_state.status = CheckpointStatus.BLOCKED_NEEDS_INPUT
+        blocked_state.question = "Merge PR #42 (major version bump)?"
+        blocked_state.summary = None
+        blocked_state.outputs = {}
+        blocked_state.error = None
+
+        done_state = MagicMock()
+        done_state.status = CheckpointStatus.DONE
+        done_state.summary = "Merged PR #42"
+        done_state.outputs = {"merged_prs": [42]}
+        done_state.error = None
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.side_effect = [
+            SessionResult(session_id="sess", exit_code=0, state=blocked_state),
+            SessionResult(session_id="sess", exit_code=0, state=done_state),
+        ]
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.get_agent_session_id.return_value = "sess"
+
+        mock_transport = AsyncMock()
+        mock_transport.ask.return_value = "yes, merge it"
+
+        repo = MagicMock()
+        repo.name = "owner/repo"
+
+        results = await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=mock_transport,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert len(results) == 1
+        assert results[0].success
+        # transport.ask MUST be called with the agent's question — that's
+        # the whole point of the fix.
+        mock_transport.ask.assert_called_once()
+        call_args = mock_transport.ask.call_args
+        assert "Merge PR #42" in call_args.args[0]
+        assert call_args.kwargs.get("session_id", "").startswith("secops-")
+        assert call_args.kwargs.get("repo") == "owner/repo"
+        # Final state should be 'done' since the resume succeeded.
+        statuses = [
+            c.args[1][0] for c in mock_db.execute.call_args_list
+            if c.args and "UPDATE sessions" in c.args[0]
+        ]
+        assert "done" in statuses
+
+    @pytest.mark.asyncio
+    async def test_transport_ask_failure_preserves_blocked_for_pending_resume(
+        self, tmp_path: Path
+    ) -> None:
+        """When transport.ask() raises (bridge down, timeout), the session
+        must stay blocked so the existing pending_resumes persistence
+        branch fires — letting an out-of-band Telegram reply still resume
+        the session via the sweeper."""
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        blocked_state = MagicMock()
+        blocked_state.status = CheckpointStatus.BLOCKED_NEEDS_INPUT
+        blocked_state.question = "Need decision"
+        blocked_state.summary = None
+        blocked_state.outputs = {}
+        blocked_state.error = None
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="sess", exit_code=0, state=blocked_state,
+        )
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+
+        mock_transport = AsyncMock()
+        mock_transport.ask.side_effect = RuntimeError("bridge unavailable")
+
+        repo = MagicMock()
+        repo.name = "owner/repo"
+
+        results = await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=mock_transport,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert len(results) == 1
+        assert results[0].blocked
+        # Pending resume row should still get inserted so a later reply
+        # can route through the sweeper.
+        mock_db.add_pending_resume.assert_called_once()
+        assert "Need decision" in mock_db.add_pending_resume.call_args.kwargs["question"]
+
+
 class TestSecopsCleanupLogging:
     """Regression for codex round-4 [P3]: worktree cleanup failures must
     not be silently swallowed. Log them via the obs stream so operators

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -142,7 +142,6 @@ class TestSocketTransportAckThenAnswer:
     ) -> None:
         import asyncio
         import json
-        import os
         import tempfile
         import uuid
         from pathlib import Path

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -127,6 +127,104 @@ class TestSocketTransport:
         assert isinstance(transport, Transport)
 
 
+class TestSocketTransportAckThenAnswer:
+    """Regression for bug #3: bridge sends back ACK(status=pending) for an
+    ASK as soon as the question is queued for Telegram, then later sends
+    ANSWER once the operator replies. The receive loop must skip the
+    intermediate ACK and only resolve the future on ANSWER/ERROR/terminal-ACK,
+    or transport.ask() raises TransportError("Unexpected response: BridgeOp.ACK")
+    and every blocked secops session falls through to pending_resumes
+    instead of reaching the operator on Telegram."""
+
+    @pytest.mark.asyncio
+    async def test_ask_waits_past_intermediate_ack_and_returns_answer(
+        self,
+    ) -> None:
+        import asyncio
+        import json
+        import os
+        import tempfile
+        import uuid
+        from pathlib import Path
+
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        # Use /tmp directly — macOS sun_path limit is ~104 chars and pytest's
+        # tmp_path lives under /var/folders/... which often blows past it.
+        sock_path = Path(tempfile.gettempdir()) / f"ctrlrelay-{uuid.uuid4().hex[:8]}.sock"
+
+        async def fake_bridge(reader, writer):
+            line = await reader.readline()
+            msg = json.loads(line.decode())
+            assert msg["op"] == "ask"
+            request_id = msg["request_id"]
+            ack = json.dumps({
+                "op": "ack",
+                "request_id": request_id,
+                "status": "pending",
+            }) + "\n"
+            writer.write(ack.encode())
+            await writer.drain()
+            await asyncio.sleep(0.05)
+            answer = json.dumps({
+                "op": "answer",
+                "request_id": request_id,
+                "answer": "operator said yes",
+            }) + "\n"
+            writer.write(answer.encode())
+            await writer.drain()
+
+        server = await asyncio.start_unix_server(fake_bridge, path=str(sock_path))
+        try:
+            transport = SocketTransport(sock_path)
+            await transport.connect()
+            answer = await transport.ask(
+                "Merge PR?", timeout=5, session_id="s1", repo="o/r",
+            )
+            assert answer == "operator said yes"
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    @pytest.mark.asyncio
+    async def test_send_terminal_ack_still_resolves(self) -> None:
+        """SEND ACK(status="sent") is the terminal response — must still
+        resolve normally; only ACK(status="pending") is intermediate."""
+        import asyncio
+        import json
+        import tempfile
+        import uuid
+        from pathlib import Path
+
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        sock_path = Path(tempfile.gettempdir()) / f"ctrlrelay-{uuid.uuid4().hex[:8]}.sock"
+
+        async def fake_bridge(reader, writer):
+            line = await reader.readline()
+            msg = json.loads(line.decode())
+            assert msg["op"] == "send"
+            request_id = msg["request_id"]
+            ack = json.dumps({
+                "op": "ack",
+                "request_id": request_id,
+                "status": "sent",
+            }) + "\n"
+            writer.write(ack.encode())
+            await writer.drain()
+
+        server = await asyncio.start_unix_server(fake_bridge, path=str(sock_path))
+        try:
+            transport = SocketTransport(sock_path)
+            await transport.connect()
+            await transport.send("hello")  # Should return without error.
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+
+
 class TestTransportError:
     def test_error_exists(self) -> None:
         """TransportError should be defined."""


### PR DESCRIPTION
## Summary

The secops pipeline silently dropped agent questions when a session ended `BLOCKED_NEEDS_INPUT`. The DB row was marked `status='blocked'` and a `pending_resumes` entry was inserted, but `run_secops_all` never called `transport.ask()` — so no Telegram message ever reached the operator.

The dev (`dev.py:761`, `1182`) and task (`task.py:339`, `596`) pipelines have the dispatch loop. Secops did not. This PR mirrors the dev/task pattern.

## Real-world impact

In an 86-repo manual secops sweep, **21 sessions ended `BLOCKED`** with substantive questions — Dependabot major-version-bump approvals, decisions about alerts on intentionally-vulnerable demo repos, ecosystem-add proposals for `dependabot.yml`, etc. Zero of those questions reached Telegram. The operator had no idea agents were waiting.

## Fix

After `pipeline.run(ctx)` returns a blocked result, loop:
1. Call `transport.ask(question, session_id, repo)` to deliver to Telegram and await the reply.
2. Feed the answer to `pipeline.resume(ctx, answer)`.
3. Repeat up to `DEFAULT_MAX_BLOCKED_ROUNDS=5` times if the resumed session re-blocks.
4. On `transport.ask()` exception (bridge down, timeout) preserve `blocked=True` so the existing persistence branch still writes a `pending_resumes` row, letting an out-of-band reply route through the sweeper.

Same shape as `task.py`'s blocked loop, minus the `issue_number` argument since secops is repo-level.

## Test plan

- [x] New: `test_blocked_secops_dispatches_question_via_transport` — agent blocks, `transport.ask` is called with the question, answer feeds back via `resume`, final status is `done`.
- [x] New: `test_transport_ask_failure_preserves_blocked_for_pending_resume` — when `transport.ask` raises, session stays blocked and `state_db.add_pending_resume` is still called so the sweeper can pick up a later reply.
- [x] All existing 12 tests in `tests/test_secops_pipeline.py` pass.
- [x] Manually reproduced: pre-fix, 86-repo sweep produced 0 Telegram messages from 21 blocked sessions. Post-fix re-run in flight at the time of writing.