### PR TITLE
chore(secops): auto-merge operator-authored .github/dependabot.yml PRs

### DIFF
--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -131,13 +131,28 @@ class SecopsPipeline:
 
 1. Check Dependabot alerts:
    `gh api repos/{repo}/dependabot/alerts --jq '.[] | select(.state=="open")'`
-2. Check security PRs:
+2. Check Dependabot-authored security PRs:
    `gh pr list --repo {repo} --author "app/dependabot" --json number,title`
-3. For each alert or PR:
-   - Review the severity and impact
-   - If patch/minor update with passing CI, merge the PR
-   - If major or unclear, signal BLOCKED to ask for guidance
-4. Summarize actions taken
+3. Check operator-authored config-only PRs that enable Dependabot itself.
+   These are prerequisites for future Dependabot work — they sit waiting
+   on the operator's own approval and block the security pipeline if
+   left open:
+   `gh pr list --repo {repo} --state open --json number,title,author,files \\
+     --jq '.[] | select(.author.login != "app/dependabot")'`
+   For each, inspect files via: `gh pr view <NUM> --repo {repo} --json files`
+4. For each alert or PR:
+   - **Dependabot PRs**: if patch/minor update with passing CI, merge.
+     If major or unclear, signal BLOCKED to ask for guidance.
+   - **Operator-authored PR touching ONLY `.github/dependabot.yml`**
+     (additive ecosystem entries, no other files changed): treat as
+     auto-merge eligible. These are the "enable Dependabot" prerequisites
+     the operator opened — a conservative review policy would otherwise
+     leave them stranded indefinitely. Merge with squash, delete the branch.
+   - **Any other operator-authored PR** (touches code, tests, configs other
+     than dependabot.yml): signal BLOCKED with a one-line summary so the
+     operator decides — never auto-merge code changes the operator
+     authored.
+5. Summarize actions taken
 
 ## Signaling Completion
 

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -147,14 +147,27 @@ class SecopsPipeline:
    - **Dependabot PRs**: if patch/minor update with passing CI, merge.
      If major or unclear, signal BLOCKED to ask for guidance.
    - **PR authored by `$OPERATOR` touching ONLY `.github/dependabot.yml`**
-     (additive ecosystem entries, no other files changed): auto-merge
-     eligible. These are the "enable Dependabot" prerequisites the
-     operator opened. Merge with squash, delete the branch.
-     **CRITICAL**: this carve-out applies only when `author.login`
-     exactly equals `$OPERATOR`. Do NOT auto-merge a dependabot.yml-only
-     PR from any other login — collaborators, GitHub apps, or external
-     contributors can craft such a PR to slip past review. Those go
-     to BLOCKED with a one-line summary instead.
+     (additive ecosystem entries, no other files changed): MAYBE
+     auto-merge — but only after diff validation. These are the
+     "enable Dependabot" prerequisites the operator opened.
+
+     Required validation BEFORE merging:
+     a. **Author check**: confirm `author.login` exactly equals
+        `$OPERATOR`. Collaborators, GitHub apps, or external
+        contributors can craft a `dependabot.yml`-only PR to slip
+        past review — those go to BLOCKED, not auto-merge.
+     b. **Diff check**: pull the diff and confirm it is PURELY
+        ADDITIVE — no `-` lines (deletions or modifications of
+        existing stanzas), only `+` lines that introduce new
+        `package-ecosystem` blocks. Run:
+        `gh pr diff <NUM> --repo {repo}`
+        If any line in the diff begins with `-` (other than `---`
+        file headers), the PR modifies or removes existing config:
+        signal BLOCKED with a one-line summary like "operator
+        dependabot.yml PR #N modifies existing config — needs
+        review". Do NOT auto-merge.
+
+     If both (a) and (b) pass: merge with squash, delete the branch.
    - **Any other PR from `$OPERATOR`** (touches code, tests, configs
      other than dependabot.yml): signal BLOCKED for operator approval.
      Never auto-merge code changes, even from the trusted operator.

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -166,8 +166,16 @@ class SecopsPipeline:
         signal BLOCKED with a one-line summary like "operator
         dependabot.yml PR #N modifies existing config — needs
         review". Do NOT auto-merge.
+     c. **CI check**: confirm all status checks pass (matches the
+        Dependabot PR rule above). Run:
+        `gh pr checks <NUM> --repo {repo}`
+        Any failing or pending check -> BLOCKED. A PR that adds
+        invalid dependabot YAML can pass author+diff but fail
+        repo validation; without this gate the agent could merge
+        broken config and break Dependabot for the repo.
 
-     If both (a) and (b) pass: merge with squash, delete the branch.
+     If (a), (b), AND (c) all pass: merge with squash, delete the
+     branch. If any one fails: BLOCKED.
    - **Any other PR from `$OPERATOR`** (touches code, tests, configs
      other than dependabot.yml): signal BLOCKED for operator approval.
      Never auto-merge code changes, even from the trusted operator.

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -133,26 +133,34 @@ class SecopsPipeline:
    `gh api repos/{repo}/dependabot/alerts --jq '.[] | select(.state=="open")'`
 2. Check Dependabot-authored security PRs:
    `gh pr list --repo {repo} --author "app/dependabot" --json number,title`
-3. Check operator-authored config-only PRs that enable Dependabot itself.
-   These are prerequisites for future Dependabot work — they sit waiting
-   on the operator's own approval and block the security pipeline if
-   left open:
-   `gh pr list --repo {repo} --state open --json number,title,author,files \\
-     --jq '.[] | select(.author.login != "app/dependabot")'`
-   For each, inspect files via: `gh pr view <NUM> --repo {repo} --json files`
-4. For each alert or PR:
+3. Determine the trusted operator's GitHub login (the identity the
+   agent itself runs as). The auto-merge carve-out below applies ONLY
+   to PRs authored by this exact login — never to other contributors,
+   apps, or bots even if their PR looks safe:
+   `OPERATOR=$(gh api user --jq '.login')`
+4. Check open PRs authored by the trusted operator that enable
+   Dependabot itself. These are prerequisites for future Dependabot
+   work and block the security pipeline if left open:
+   `gh pr list --repo {repo} --state open --author "$OPERATOR" --json number,title,files`
+   For each, inspect files: `gh pr view <NUM> --repo {repo} --json files`
+5. For each alert or PR:
    - **Dependabot PRs**: if patch/minor update with passing CI, merge.
      If major or unclear, signal BLOCKED to ask for guidance.
-   - **Operator-authored PR touching ONLY `.github/dependabot.yml`**
-     (additive ecosystem entries, no other files changed): treat as
-     auto-merge eligible. These are the "enable Dependabot" prerequisites
-     the operator opened — a conservative review policy would otherwise
-     leave them stranded indefinitely. Merge with squash, delete the branch.
-   - **Any other operator-authored PR** (touches code, tests, configs other
-     than dependabot.yml): signal BLOCKED with a one-line summary so the
-     operator decides — never auto-merge code changes the operator
-     authored.
-5. Summarize actions taken
+   - **PR authored by `$OPERATOR` touching ONLY `.github/dependabot.yml`**
+     (additive ecosystem entries, no other files changed): auto-merge
+     eligible. These are the "enable Dependabot" prerequisites the
+     operator opened. Merge with squash, delete the branch.
+     **CRITICAL**: this carve-out applies only when `author.login`
+     exactly equals `$OPERATOR`. Do NOT auto-merge a dependabot.yml-only
+     PR from any other login — collaborators, GitHub apps, or external
+     contributors can craft such a PR to slip past review. Those go
+     to BLOCKED with a one-line summary instead.
+   - **Any other PR from `$OPERATOR`** (touches code, tests, configs
+     other than dependabot.yml): signal BLOCKED for operator approval.
+     Never auto-merge code changes, even from the trusted operator.
+   - **PRs from anyone else** (collaborators, contributors, other bots):
+     signal BLOCKED. Never on this path.
+6. Summarize actions taken
 
 ## Signaling Completion
 

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -205,19 +205,42 @@ class TestSecopsPromptOperatorConfigPRs:
         )
         prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
 
-        # Must explicitly tell the agent that operator-authored PRs
-        # touching ONLY dependabot.yml are auto-mergeable.
+        # Carve-out exists for dependabot.yml-only PRs.
         assert ".github/dependabot.yml" in prompt
         assert "auto-merge" in prompt.lower()
-        # Must distinguish operator-authored from Dependabot-authored
-        # so the agent doesn't blanket-merge any operator PR it sees.
-        assert "operator-authored" in prompt.lower()
-        # Must still preserve the safety: code changes from operator
-        # require BLOCKED.
-        assert (
-            "never auto-merge code changes the operator" in prompt
-            or "operator-authored PR" in prompt and "BLOCKED" in prompt
+        # Code changes always BLOCKED, even from the trusted operator.
+        assert "Never auto-merge code changes" in prompt or "never auto-merge code" in prompt.lower()
+
+    def test_prompt_positively_identifies_operator_not_just_excludes_dependabot(
+        self,
+    ) -> None:
+        """Codex P1 (review of #132): the carve-out must positively
+        identify the trusted operator (`author.login == $OPERATOR`),
+        not just `author.login != "app/dependabot"`. Otherwise a
+        collaborator, external contributor, or another bot could open
+        a `.github/dependabot.yml`-only PR and slip past review."""
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
         )
+        prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
+
+        # Must instruct the agent to derive its own identity from `gh api user`
+        # and use that as the trusted-operator allowlist.
+        assert "gh api user" in prompt
+        assert "OPERATOR" in prompt
+        assert '--author "$OPERATOR"' in prompt
+        # Must explicitly call out that other authors (collaborators, apps,
+        # external contributors) are NOT eligible — even for dependabot.yml-only.
+        assert "collaborators" in prompt.lower() or "external contributors" in prompt.lower()
+        # Must NOT use the original buggy filter pattern that codex flagged.
+        assert 'author.login != "app/dependabot"' not in prompt
 
 
 class TestSecopsCleanupLogging:

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -183,6 +183,43 @@ class TestSecopsPipeline:
         assert "locked" in results[0].error.lower()
 
 
+class TestSecopsPromptOperatorConfigPRs:
+    """The secops prompt must instruct the agent to auto-merge
+    operator-authored PRs that ONLY touch .github/dependabot.yml.
+    Without this, "enable Dependabot ecosystem" PRs the operator
+    opens manually sit forever — the conservative default treats
+    every operator-authored PR as needing approval, but a config-only
+    additive change has effectively the same risk as a Dependabot
+    config bump (zero)."""
+
+    def test_prompt_mentions_operator_config_pr_auto_merge(self) -> None:
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
+
+        # Must explicitly tell the agent that operator-authored PRs
+        # touching ONLY dependabot.yml are auto-mergeable.
+        assert ".github/dependabot.yml" in prompt
+        assert "auto-merge" in prompt.lower()
+        # Must distinguish operator-authored from Dependabot-authored
+        # so the agent doesn't blanket-merge any operator PR it sees.
+        assert "operator-authored" in prompt.lower()
+        # Must still preserve the safety: code changes from operator
+        # require BLOCKED.
+        assert (
+            "never auto-merge code changes the operator" in prompt
+            or "operator-authored PR" in prompt and "BLOCKED" in prompt
+        )
+
+
 class TestSecopsCleanupLogging:
     """Regression for codex round-4 [P3]: worktree cleanup failures must
     not be silently swallowed. Log them via the obs stream so operators

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -209,7 +209,11 @@ class TestSecopsPromptOperatorConfigPRs:
         assert ".github/dependabot.yml" in prompt
         assert "auto-merge" in prompt.lower()
         # Code changes always BLOCKED, even from the trusted operator.
-        assert "Never auto-merge code changes" in prompt or "never auto-merge code" in prompt.lower()
+        lower = prompt.lower()
+        assert (
+            "Never auto-merge code changes" in prompt
+            or "never auto-merge code" in lower
+        )
 
     def test_prompt_positively_identifies_operator_not_just_excludes_dependabot(
         self,

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -242,6 +242,36 @@ class TestSecopsPromptOperatorConfigPRs:
         # Must NOT use the original buggy filter pattern that codex flagged.
         assert 'author.login != "app/dependabot"' not in prompt
 
+    def test_prompt_requires_diff_validation_for_additive_only(self) -> None:
+        """Codex P2 (review of #132 round 2): the prompt says 'additive
+        ecosystem entries' in prose but must ACTUALLY require the agent
+        to inspect the diff and BLOCK non-additive changes (deletions
+        or modifications of existing stanzas). Otherwise a trusted
+        operator could open a PR that removes an entire ecosystem
+        block and the auto-merge would still fire."""
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
+
+        # Must instruct the agent to actually pull the diff.
+        assert "gh pr diff" in prompt
+        # Must explicitly say BLOCK if any deletion/modification line is
+        # present in the diff.
+        assert (
+            "PURELY" in prompt or "purely additive" in prompt.lower()
+        )
+        # Must reference the `-` line marker so the agent has a concrete
+        # signal to look for, not just vague "additive only" prose.
+        assert "begins with `-`" in prompt or "lines beginning with `-`" in prompt.lower()
+
 
 class TestSecopsCleanupLogging:
     """Regression for codex round-4 [P3]: worktree cleanup failures must

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -242,6 +242,28 @@ class TestSecopsPromptOperatorConfigPRs:
         # Must NOT use the original buggy filter pattern that codex flagged.
         assert 'author.login != "app/dependabot"' not in prompt
 
+    def test_prompt_requires_passing_ci_for_operator_config_merge(self) -> None:
+        """Codex P2 (review of #132 round 3): the Dependabot auto-merge
+        path requires patch/minor + passing CI. The operator-config
+        carve-out must require passing CI too — otherwise a PR that
+        introduces invalid dependabot YAML could auto-merge and break
+        Dependabot for the repo."""
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
+
+        assert "gh pr checks" in prompt
+        # CI must be in the same gate list as author+diff.
+        assert "CI check" in prompt or "all status checks pass" in prompt.lower()
+
     def test_prompt_requires_diff_validation_for_additive_only(self) -> None:
         """Codex P2 (review of #132 round 2): the prompt says 'additive
         ecosystem entries' in prose but must ACTUALLY require the agent


### PR DESCRIPTION
## Summary

Stack on top of #131. Adds a carve-out to the secops agent prompt: operator-authored PRs that ONLY touch `.github/dependabot.yml` (additive ecosystem entries) are auto-merge eligible, same as a Dependabot patch/minor with green CI. Other operator-authored PRs still BLOCKED for operator approval — code changes are never auto-merged.

## Why

Real-world incident this weekend:
1. Operator bulk-enabled Dependabot across ~50 Python repos (mass-add `dependabot.yml`).
2. Repos with branch protection wouldn't accept a direct push, so the enabling change went out as 7 operator-authored PRs.
3. Subsequent secops sweeps saw those PRs but the existing prompt only knew how to act on `app/dependabot`-authored PRs. It either said "no Dependabot work to do" and exited, or it BLOCKED waiting for the operator's own approval — defeating the autonomy.
4. The 7 PRs sat for a day until the operator merged them manually.

A config-only PR adding an ecosystem entry has effectively the same risk surface as a Dependabot config bump (zero), so it's the right fit for the existing auto-merge bucket.

## Changes

**Prompt (`secops.py:_build_prompt`):**
- New step 3: enumerate non-Dependabot open PRs and inspect their files.
- Step 4 split into three branches: Dependabot PRs (existing rules), operator-authored config-only `.github/dependabot.yml` (auto-merge), other operator-authored PRs (still BLOCKED).

## Test plan

- [x] New test `TestSecopsPromptOperatorConfigPRs::test_prompt_mentions_operator_config_pr_auto_merge` — asserts the rule, the file path, and the safety guard appear in the rendered prompt.
- [x] All 11 secops tests pass.
- [ ] After merge: trigger a manual `ctrlrelay run secops` on a repo with a stale operator-authored `dependabot.yml` PR; confirm the agent merges it instead of asking.

## Alternatives considered

- **Allowlist by author rather than file pattern.** Rejected: anyone who tricks the operator into authoring a malicious PR could ride the allowlist. The file-pattern guard limits blast radius to dependabot config only.
- **Whitelist multiple "safe" file paths** (e.g., `.github/CODEOWNERS`, `LICENSE`). Rejected for now: too easy to mis-scope. Keep the carve-out narrow and add more paths only if a real need emerges.