### PR TITLE
feat(secops): thread per-repo automation policy into the prompt

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1614,6 +1614,7 @@ def poller_start(
 
                     try:
                         if pipeline_name == "secops":
+                            sweep_repo_cfg = repo_cfg_by_name.get(repo)
                             result = await resume_secops_from_pending(
                                 session_id=session_id,
                                 repo=repo,
@@ -1625,6 +1626,11 @@ def poller_start(
                                 state_db=state_db,
                                 transport=sweeper_transport,
                                 contexts_dir=config.paths.contexts,
+                                automation=(
+                                    sweep_repo_cfg.automation
+                                    if sweep_repo_cfg is not None
+                                    else None
+                                ),
                             )
                         elif pipeline_name == "dev":
                             # Dev resume needs the repo's branch template

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -60,6 +60,7 @@ class SecopsPipeline:
             ctx.repo,
             session_id=ctx.session_id,
             state_file=ctx.state_file,
+            automation=ctx.extra.get("automation"),
         )
 
         result = await self._spawn(ctx, prompt, resume=False)
@@ -125,9 +126,59 @@ class SecopsPipeline:
         repo: str,
         session_id: str = "",
         state_file: Path | None = None,
+        automation: Any = None,
     ) -> str:
-        """Build the secops prompt."""
+        """Build the secops prompt.
+
+        ``automation`` is an optional ``AutomationConfig`` carrying the
+        per-repo Dependabot policy (auto/ask/never per severity tier).
+        When provided, the prompt explicitly tells the agent which tiers
+        auto-merge vs ask vs never-merge. When ``None``, falls back to
+        the default policy (patch=auto, minor=ask, never-major) so
+        existing callers and the schema defaults stay coherent."""
         state_file_path = str(state_file) if state_file else "/tmp/state.json"
+
+        # Translate per-repo policy into prompt directives. Use defaults
+        # from AutomationConfig if no policy was passed.
+        patch_pol = (
+            automation.dependabot_patch.value
+            if automation is not None and hasattr(automation, "dependabot_patch")
+            else "auto"
+        )
+        minor_pol = (
+            automation.dependabot_minor.value
+            if automation is not None and hasattr(automation, "dependabot_minor")
+            else "ask"
+        )
+        major_pol = (
+            automation.dependabot_major.value
+            if automation is not None and hasattr(automation, "dependabot_major")
+            else "never"
+        )
+
+        def _policy_directive(tier: str, policy: str) -> str:
+            if policy == "auto":
+                return (
+                    f"     - {tier}: AUTO-MERGE with passing CI. Squash + "
+                    "delete branch."
+                )
+            if policy == "ask":
+                return (
+                    f"     - {tier}: ASK — signal BLOCKED with a one-line "
+                    f"summary so the operator decides."
+                )
+            return (
+                f"     - {tier}: NEVER — do not merge. Leave the PR open "
+                "for manual review."
+            )
+
+        dependabot_policy_block = "\n".join(
+            [
+                _policy_directive("patch updates", patch_pol),
+                _policy_directive("minor updates", minor_pol),
+                _policy_directive("major updates", major_pol),
+            ]
+        )
 
         return f"""Execute security operations for repository {repo}.
 
@@ -146,8 +197,11 @@ class SecopsPipeline:
    `gh pr list --repo {repo} --state open --author "$OPERATOR" --json number,title,files`
    For each, inspect files: `gh pr view <NUM> --repo {repo} --json files`
 5. For each alert or PR:
-   - **Dependabot PRs**: if patch/minor update with passing CI, merge.
-     If major or unclear, signal BLOCKED to ask for guidance.
+   - **Dependabot PRs**: classify the update as patch/minor/major and
+     apply the per-repo policy below. If the severity is unclear, signal
+     BLOCKED to ask for guidance.
+
+{dependabot_policy_block}
    - **PR authored by `$OPERATOR` touching ONLY `.github/dependabot.yml`**
      (additive ecosystem entries, no other files changed): MAYBE
      auto-merge — but only after diff validation. These are the
@@ -307,6 +361,7 @@ async def run_secops_all(
                 worktree_path=worktree_path,
                 context_path=context_path,
                 state_file=state_file,
+                extra={"automation": getattr(repo_config, "automation", None)},
             )
 
             state_db.execute(
@@ -544,6 +599,7 @@ async def resume_secops_from_pending(
     state_db: StateDB,
     transport: Transport | None,
     contexts_dir: Path,
+    automation: Any = None,
 ) -> PipelineResult:
     """Resume a BLOCKED secops session using an answer that arrived via
     Telegram after the original session had already torn down.
@@ -589,6 +645,7 @@ async def resume_secops_from_pending(
             worktree_path=worktree_path,
             context_path=context_path,
             state_file=state_file,
+            extra={"automation": automation},
         )
 
         # Flip the session back to running so an observer sees progress,

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -432,6 +432,149 @@ class TestSecopsBlockedDispatch:
         assert "Need decision" in mock_db.add_pending_resume.call_args.kwargs["question"]
 
 
+class TestSecopsPromptRespectsAutomationConfig:
+    """The per-repo `automation:` block in orchestrator.yaml defines the
+    Dependabot policy per severity tier (patch/minor/major × auto/ask/never).
+    Before #133, the secops prompt had hardcoded prose ("merge patch/minor")
+    that ignored the config entirely — so a repo configured `dependabot_minor:
+    never` would still get its minors auto-merged. The prompt must reflect
+    the configured policy per repo.
+    """
+
+    def test_default_policy_when_no_automation_passed(self) -> None:
+        """With no automation, the prompt must use the AutomationConfig
+        defaults: patch=auto, minor=ask, never-major."""
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        prompt = pipeline._build_prompt(repo="o/r", session_id="s1")
+
+        assert "patch updates: AUTO-MERGE" in prompt
+        assert "minor updates: ASK" in prompt
+        assert "major updates: NEVER" in prompt
+
+    def test_per_repo_policy_overrides_defaults(self) -> None:
+        """When AutomationConfig is passed in, its values drive the prompt."""
+        from ctrlrelay.core.config import AutomationConfig, AutomationPolicy
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        # Aggressive: auto-merge everything including majors.
+        automation = AutomationConfig(
+            dependabot_patch=AutomationPolicy.AUTO,
+            dependabot_minor=AutomationPolicy.AUTO,
+            dependabot_major=AutomationPolicy.AUTO,
+        )
+        prompt = pipeline._build_prompt(
+            repo="o/r", session_id="s1", automation=automation,
+        )
+
+        assert "patch updates: AUTO-MERGE" in prompt
+        assert "minor updates: AUTO-MERGE" in prompt
+        assert "major updates: AUTO-MERGE" in prompt
+
+    def test_conservative_policy_renders_never_for_all(self) -> None:
+        """Conservative repo: dependabot disabled across all tiers."""
+        from ctrlrelay.core.config import AutomationConfig, AutomationPolicy
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        automation = AutomationConfig(
+            dependabot_patch=AutomationPolicy.NEVER,
+            dependabot_minor=AutomationPolicy.NEVER,
+            dependabot_major=AutomationPolicy.NEVER,
+        )
+        prompt = pipeline._build_prompt(
+            repo="o/r", session_id="s1", automation=automation,
+        )
+
+        assert "patch updates: NEVER" in prompt
+        assert "minor updates: NEVER" in prompt
+        assert "major updates: NEVER" in prompt
+
+    @pytest.mark.asyncio
+    async def test_run_secops_all_threads_automation_into_ctx_extra(
+        self, tmp_path: Path
+    ) -> None:
+        """run_secops_all must read each RepoConfig.automation and put it
+        in ctx.extra so the prompt builder picks it up. Without this, the
+        per-repo schema is decorative."""
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+        from ctrlrelay.core.config import AutomationConfig, AutomationPolicy
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        captured_prompts: list[str] = []
+
+        async def fake_spawn(**kwargs):
+            captured_prompts.append(kwargs["prompt"])
+            state = MagicMock()
+            state.status = CheckpointStatus.DONE
+            state.summary = "Done"
+            state.outputs = {}
+            state.error = None
+            return SessionResult(
+                session_id=kwargs["session_id"], exit_code=0, state=state,
+            )
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.side_effect = fake_spawn
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.release_lock.return_value = True
+
+        # Repo configured with NEVER on patches — a non-default policy.
+        repo = MagicMock()
+        repo.name = "owner/repo"
+        repo.automation = AutomationConfig(
+            dependabot_patch=AutomationPolicy.NEVER,
+            dependabot_minor=AutomationPolicy.NEVER,
+            dependabot_major=AutomationPolicy.NEVER,
+        )
+
+        await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert len(captured_prompts) == 1
+        # The spawned prompt must reflect the NEVER policy — not the
+        # auto/ask/never default.
+        assert "patch updates: NEVER" in captured_prompts[0]
+
+
 class TestSecopsCleanupLogging:
     """Regression for codex round-4 [P3]: worktree cleanup failures must
     not be silently swallowed. Log them via the obs stream so operators


### PR DESCRIPTION
## Summary

Closes the gap where `orchestrator.yaml`'s per-repo `automation:` block was decorative. The secops agent now reads `RepoConfig.automation.dependabot_{patch,minor,major}` and tells the agent exactly which severity tiers to auto-merge, ask about, or never touch — per repo.

## Why this matters

Before this PR:
- `orchestrator.yaml` has 86 repos each with `dependabot_patch: auto`, `dependabot_minor: ask`, `dependabot_major: never`.
- The schema in `config.py` defines those as policy fields.
- The prompt in `secops.py` had **zero references** to any of them — hardcoded prose said "merge patch/minor with passing CI" regardless of what the operator configured.
- Setting `dependabot_minor: never` on a sensitive repo would be ignored; the agent would still auto-merge minor bumps.

After this PR, the prompt renders per-repo directives like:

```
- patch updates: AUTO-MERGE with passing CI. Squash + delete branch.
- minor updates: ASK — signal BLOCKED with a one-line summary so the operator decides.
- major updates: NEVER — do not merge. Leave the PR open for manual review.
```

If the operator changes a repo to `dependabot_minor: never`, the prompt for THAT repo says "minor updates: NEVER".

## Threading

- `SecopsPipeline._build_prompt(repo, session_id, state_file, automation=None)` accepts the AutomationConfig and renders the policy block.
- `SecopsPipeline.run()` reads `ctx.extra["automation"]` and forwards it.
- `run_secops_all` constructs the PipelineContext with `extra={"automation": repo_config.automation}`.
- `resume_secops_from_pending` accepts an `automation` kwarg.
- `cli.py`'s `pending_resume_sweeper` looks up `repo_cfg_by_name[repo]` and passes `.automation` on resume.

## Test plan

- [x] `test_default_policy_when_no_automation_passed` — renders auto/ask/never when no automation arg.
- [x] `test_per_repo_policy_overrides_defaults` — all-auto renders correctly.
- [x] `test_conservative_policy_renders_never_for_all` — all-never renders correctly.
- [x] `test_run_secops_all_threads_automation_into_ctx_extra` — integration test capturing the spawned prompt; confirms `RepoConfig.automation` reaches the prompt builder.
- [x] All 20 secops tests pass locally; ruff clean.
- [ ] After merge: trigger `ctrlrelay run secops --repo <repo>` on a repo with `dependabot_minor: never`; confirm the prompt shows "minor updates: NEVER".

## Stacks on

Built on top of merged #131 and #132. Independent of any in-flight work.

## Followups (not in this PR)

- Use `automation.deploy_after_merge`, `automation.codeql_dismiss`, `automation.secret_alerts`, `automation.exclude_labels` in their respective code paths. Same gap pattern — schema exists, runtime ignored. Separate PRs per concern to keep the blast radius small.