### PR TITLE
fix(setup): respect git protocol for personalization clone; fix daemon log crash-loop

### DIFF
--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -2487,6 +2487,14 @@ def setup(
     )
     if result.personalization_summary:
         console.print(f"  personalization: {result.personalization_summary}")
+    if result.personalization_failed:
+        console.print(
+            "\n[bold red]ACTION NEEDED[/bold red] — personalization repo "
+            "sync failed; the rest of setup completed but your "
+            "personalization config/skills were not cloned. Check your "
+            "git auth (`gh auth status`, `gh config get git_protocol`) "
+            "and re-run `ctrlrelay personalization init` once it's fixed."
+        )
     if result.daemon_units:
         console.print("  daemon unit files:")
         for p in result.daemon_units:
@@ -2498,11 +2506,10 @@ def setup(
             "  systemctl --user daemon-reload && systemctl --user enable --now <unit>"
             "    # Linux"
         )
-    # Clone failures must surface as a non-zero exit even when daemon
-    # units were rendered — automation watching exit code shouldn't
-    # mistake a partial setup for success. Codex review pass 3 caught
-    # the prior `elif` that masked this.
-    if result.failed:
+    # Clone and personalization-sync failures must surface as a
+    # non-zero exit even when daemon units were rendered — automation
+    # watching exit code shouldn't mistake a partial setup for success.
+    if result.failed or result.personalization_failed:
         raise typer.Exit(1)
 
 

--- a/src/ctrlrelay/gh_protocol.py
+++ b/src/ctrlrelay/gh_protocol.py
@@ -1,0 +1,47 @@
+"""Detect the git transport protocol the operator has configured for
+GitHub via the ``gh`` CLI.
+
+``ctrlrelay`` clones a handful of GitHub repos on the operator's
+behalf (project repos, the personalization repo). Hardcoding HTTPS
+for these clones breaks operators who've set ``gh config set
+git_protocol ssh`` and have no HTTPS credential helper wired up —
+``git`` then fails with "could not read Username" instead of using
+the SSH key ``gh`` already knows about.
+"""
+
+from __future__ import annotations
+
+import subprocess
+
+_VALID_PROTOCOLS = ("ssh", "https")
+
+
+def detect_git_protocol(*, default: str = "https") -> str:
+    """Return ``"ssh"`` or ``"https"``, per ``gh config get git_protocol``.
+
+    Falls back to ``default`` whenever ``gh`` isn't installed, isn't
+    configured, or returns something unexpected — this is a
+    convenience read, not a hard requirement, so any failure here
+    should degrade to the previous hardcoded-HTTPS behavior rather
+    than blocking a clone.
+    """
+    try:
+        proc = subprocess.run(
+            ["gh", "config", "get", "git_protocol"],
+            capture_output=True,
+            text=True,
+            timeout=5,
+        )
+    except (OSError, subprocess.SubprocessError):
+        return default
+    value = proc.stdout.strip().lower()
+    if proc.returncode == 0 and value in _VALID_PROTOCOLS:
+        return value
+    return default
+
+
+def github_clone_url(repo: str, *, protocol: str) -> str:
+    """Build a clone URL for ``owner/repo`` under the given protocol."""
+    if protocol == "ssh":
+        return f"git@github.com:{repo}.git"
+    return f"https://github.com/{repo}.git"

--- a/src/ctrlrelay/install.py
+++ b/src/ctrlrelay/install.py
@@ -178,7 +178,17 @@ def write_units(
     silently overwriting an operator's customised plist would be a foot-gun.
     Returns the list of paths actually written. Raises ``FileExistsError``
     if any target exists and overwrite is False.
+
+    Also ensures ``~/.ctrlrelay/logs/`` exists — both the launchd and
+    systemd templates set StandardOutput/StandardError paths under it,
+    and systemd refuses to start a unit at all (EXIT_STDOUT, code 209)
+    when the directory is missing; combined with ``Restart=always``
+    that's an immediate crash-loop (#137).
+
+    Unit files are chmod'd ``0600`` after writing since they embed
+    ``CTRLRELAY_TELEGRAM_TOKEN`` as plaintext.
     """
+    (Path.home() / ".ctrlrelay" / "logs").mkdir(parents=True, exist_ok=True)
     written: list[Path] = []
     for unit in units:
         unit.target_path.parent.mkdir(parents=True, exist_ok=True)
@@ -188,5 +198,6 @@ def write_units(
                 "pass --force to replace it"
             )
         unit.target_path.write_text(unit.content, encoding="utf-8")
+        unit.target_path.chmod(0o600)
         written.append(unit.target_path)
     return written

--- a/src/ctrlrelay/personalization/manager.py
+++ b/src/ctrlrelay/personalization/manager.py
@@ -47,6 +47,7 @@ from dataclasses import dataclass
 from pathlib import Path
 
 from ctrlrelay.core.config import Config, Personalization, PersonalizationPath
+from ctrlrelay.gh_protocol import detect_git_protocol, github_clone_url
 from ctrlrelay.personalization.paths import (
     TemplateContext,
     project_slug,
@@ -120,7 +121,13 @@ class PersonalizationManager:
             raise PersonalizationError("personalization_branch is unset")
         self.working_branch: str = branch
         self.main_branch: str = self.cfg.main_branch
-        self.repo_url: str = f"https://github.com/{self.cfg.repo}.git"
+        # Respect the operator's configured git protocol (gh's
+        # git_protocol setting) rather than assuming HTTPS — an
+        # operator set up for SSH-only GitHub auth would otherwise
+        # hit "could not read Username" on the clone below (#137).
+        self.repo_url: str = github_clone_url(
+            self.cfg.repo, protocol=detect_git_protocol()
+        )
 
     # ----- top-level commands ------------------------------------------------
 

--- a/src/ctrlrelay/setup.py
+++ b/src/ctrlrelay/setup.py
@@ -19,6 +19,7 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 from ctrlrelay.core.config import Config, load_config
+from ctrlrelay.gh_protocol import detect_git_protocol, github_clone_url
 
 __all__ = [
     "SetupOptions",
@@ -117,6 +118,7 @@ class SetupResult:
     skipped: int
     failed: int
     personalization_summary: str | None = None
+    personalization_failed: bool = False
     daemon_units: list[Path] = field(default_factory=list)
 
 
@@ -218,14 +220,13 @@ def _ensure_personalization_clone(
     if (checkout / ".git").is_dir():
         return _checkout_matches_repo(checkout, repo)
     checkout.parent.mkdir(parents=True, exist_ok=True)
-    # Use HTTPS to match ``PersonalizationManager.repo_url`` so the
-    # pre-scan works for operators authenticated to GitHub via gh
-    # tokens / HTTPS without an SSH key on the machine. Codex review
-    # pass 3 caught the SSH/HTTPS mismatch — pre-scan would silently
-    # fail, the manager's own init() would later succeed via HTTPS,
-    # and the auto-wire feature would be bypassed in a common setup.
+    # Match the protocol ``PersonalizationManager.repo_url`` will use
+    # (gh's configured git_protocol) so the pre-scan doesn't fail for
+    # SSH-only operators while the manager's own later clone succeeds
+    # (or vice versa) — see #137.
+    url = github_clone_url(repo, protocol=detect_git_protocol())
     proc = subprocess.run(
-        ["git", "clone", "--quiet", f"https://github.com/{repo}.git", str(checkout)],
+        ["git", "clone", "--quiet", url, str(checkout)],
         capture_output=True,
         text=True,
     )
@@ -540,6 +541,7 @@ def run_setup(options: SetupOptions) -> SetupResult:
         cloned, skipped, failed = clone_repos(config)
 
     personalization_summary: str | None = None
+    personalization_failed = False
     if options.personalization_repo:
         from ctrlrelay.personalization import PersonalizationManager
         from ctrlrelay.personalization.manager import PersonalizationError
@@ -549,6 +551,7 @@ def run_setup(options: SetupOptions) -> SetupResult:
             personalization_summary = mgr.init(adopt=True)
         except PersonalizationError as e:
             personalization_summary = f"(failed: {e})"
+            personalization_failed = True
 
     daemon_units: list[Path] = []
     if options.install_daemons:
@@ -562,6 +565,7 @@ def run_setup(options: SetupOptions) -> SetupResult:
         skipped=skipped,
         failed=failed,
         personalization_summary=personalization_summary,
+        personalization_failed=personalization_failed,
         daemon_units=daemon_units,
     )
 

--- a/tests/test_gh_protocol.py
+++ b/tests/test_gh_protocol.py
@@ -1,0 +1,65 @@
+"""Tests for gh-configured git protocol detection (#137).
+
+``gh config get git_protocol`` tells us whether the operator has
+GitHub set up for SSH or HTTPS. ctrlrelay's own clones (personalization
+repo, pre-scan clone) must respect this instead of hardcoding HTTPS —
+an SSH-only operator otherwise hits "could not read Username" with no
+clear signal of what to do about it.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import patch
+
+from ctrlrelay.gh_protocol import detect_git_protocol, github_clone_url
+
+
+class TestDetectGitProtocol:
+    def test_returns_ssh_when_gh_reports_ssh(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "ssh\n", "")
+            assert detect_git_protocol() == "ssh"
+
+    def test_returns_https_when_gh_reports_https(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "https\n", "")
+            assert detect_git_protocol() == "https"
+
+    def test_falls_back_to_default_when_gh_missing(self) -> None:
+        with patch("subprocess.run", side_effect=FileNotFoundError("no gh")):
+            assert detect_git_protocol() == "https"
+            assert detect_git_protocol(default="ssh") == "ssh"
+
+    def test_falls_back_to_default_when_gh_exits_nonzero(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess(
+                [], 1, "", "unknown config key git_protocol"
+            )
+            assert detect_git_protocol() == "https"
+
+    def test_falls_back_to_default_on_unexpected_output(self) -> None:
+        with patch("subprocess.run") as mock_run:
+            mock_run.return_value = subprocess.CompletedProcess([], 0, "carrier-pigeon\n", "")
+            assert detect_git_protocol() == "https"
+
+    def test_falls_back_to_default_on_timeout(self) -> None:
+        with patch(
+            "subprocess.run",
+            side_effect=subprocess.TimeoutExpired(cmd=["gh"], timeout=5),
+        ):
+            assert detect_git_protocol() == "https"
+
+
+class TestGithubCloneUrl:
+    def test_ssh_protocol_builds_ssh_url(self) -> None:
+        assert (
+            github_clone_url("alice/dotclaude", protocol="ssh")
+            == "git@github.com:alice/dotclaude.git"
+        )
+
+    def test_https_protocol_builds_https_url(self) -> None:
+        assert (
+            github_clone_url("alice/dotclaude", protocol="https")
+            == "https://github.com/alice/dotclaude.git"
+        )

--- a/tests/test_install.py
+++ b/tests/test_install.py
@@ -11,6 +11,9 @@ out of docs and hand-edit /Users/$ME/... paths. Coverage focuses on:
   load-bearing one — silently writing a plist with a literal
   ``${TOKEN}`` would brick the bridge at next boot).
 * ``write_units`` refuses to clobber existing files unless ``overwrite``.
+* ``write_units`` creates ``~/.ctrlrelay/logs/`` (missing it crash-loops
+  the generated systemd units, see #137) and chmods unit files 0600
+  (they embed CTRLRELAY_TELEGRAM_TOKEN in plaintext).
 """
 
 from __future__ import annotations
@@ -26,6 +29,20 @@ from ctrlrelay.install import (
     render_systemd,
     write_units,
 )
+
+
+@pytest.fixture(autouse=True)
+def fake_home(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    """Point ``Path.home()`` at a scratch dir for every test in this
+    module. ``write_units`` now creates ``~/.ctrlrelay/logs/`` as a
+    side effect (#137) — without this, running the suite would create
+    that directory (and touch unit-file permissions) under the real
+    developer/CI home.
+    """
+    home = tmp_path / "home"
+    home.mkdir()
+    monkeypatch.setenv("HOME", str(home))
+    return home
 
 
 @pytest.fixture
@@ -166,6 +183,28 @@ class TestRenderSystemd:
 
 
 class TestWriteUnits:
+    def test_creates_logs_dir(
+        self, workdir: Path, target_dir: Path, fake_home: Path
+    ) -> None:
+        # Both the launchd and systemd templates set
+        # StandardOutput/StandardError under ~/.ctrlrelay/logs/, but
+        # nothing else in setup ever creates it. systemd refuses to
+        # start a unit whose log dir is missing (EXIT_STDOUT, 209),
+        # and with Restart=always that's an immediate crash-loop.
+        units = render_systemd(workdir=workdir, target_dir=target_dir)
+        write_units(units)
+        assert (fake_home / ".ctrlrelay" / "logs").is_dir()
+
+    def test_written_units_are_chmod_600(
+        self, workdir: Path, target_dir: Path
+    ) -> None:
+        # Unit files embed CTRLRELAY_TELEGRAM_TOKEN as plaintext —
+        # refuse to leave them group/world-readable.
+        units = render_systemd(workdir=workdir, target_dir=target_dir)
+        written = write_units(units)
+        for path in written:
+            assert (path.stat().st_mode & 0o777) == 0o600
+
     def test_writes_files_to_disk(
         self, workdir: Path, target_dir: Path
     ) -> None:

--- a/tests/test_personalization.py
+++ b/tests/test_personalization.py
@@ -1616,6 +1616,33 @@ class TestPersonalizationCronConfig:
             load_config(path)
 
 
+class TestRepoUrlProtocol:
+    """``repo_url`` must follow gh's configured git_protocol (#137)
+    instead of hardcoding HTTPS — see ``ctrlrelay.gh_protocol``."""
+
+    def test_defaults_to_https_url(
+        self, tmp_path: Path, remote_bare: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import ctrlrelay.personalization.manager as mgr_mod
+
+        monkeypatch.setattr(mgr_mod, "detect_git_protocol", lambda **kw: "https")
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        assert mgr.repo_url == "https://github.com/test/dotclaude.git"
+
+    def test_uses_ssh_url_when_gh_configured_for_ssh(
+        self, tmp_path: Path, remote_bare: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import ctrlrelay.personalization.manager as mgr_mod
+
+        monkeypatch.setattr(mgr_mod, "detect_git_protocol", lambda **kw: "ssh")
+        checkout = tmp_path / "personalization"
+        config = _config_for(checkout, remote_bare, node_id="machine-a")
+        mgr = PersonalizationManager(config)
+        assert mgr.repo_url == "git@github.com:test/dotclaude.git"
+
+
 class TestManagerErrors:
     def test_init_rejected_when_path_exists_and_not_ours(
         self, tmp_path: Path, remote_bare: Path

--- a/tests/test_setup.py
+++ b/tests/test_setup.py
@@ -220,12 +220,15 @@ def fake_gh(monkeypatch: pytest.MonkeyPatch) -> dict:
         "auth_ok": True,
         "repos_by_owner": {"alice": [], "AInvirion": []},
         "git_clone_calls": [],
+        "git_protocol": "https",
     }
 
     def fake_run(cmd, **kwargs):  # type: ignore[no-untyped-def]
         if cmd[:3] == ["gh", "auth", "status"]:
             rc = 0 if state["auth_ok"] else 1
             return subprocess.CompletedProcess(cmd, rc, "ok", "")
+        if cmd == ["gh", "config", "get", "git_protocol"]:
+            return subprocess.CompletedProcess(cmd, 0, state["git_protocol"] + "\n", "")
         if cmd[:3] == ["gh", "api", "user"]:
             return subprocess.CompletedProcess(cmd, 0, "alice\n", "")
         if cmd[:3] == ["gh", "api", "user/orgs"]:
@@ -640,6 +643,94 @@ class TestSkillAutoWiringInRunSetup:
         assert "global/skills/" not in text
 
 
+class TestPersonalizationCloneProtocol:
+    """The personalization pre-scan clone must respect gh's configured
+    git_protocol instead of hardcoding HTTPS (#137) — an SSH-only
+    operator otherwise hits "could not read Username" on every setup
+    run even though the other 27 repos clone fine over SSH."""
+
+    def test_uses_https_by_default(self, fake_gh: dict, tmp_path: Path) -> None:
+        from ctrlrelay.setup import _ensure_personalization_clone
+
+        checkout = tmp_path / "checkout"
+        assert _ensure_personalization_clone("alice/dotclaude", checkout)
+        clone_cmd = fake_gh["git_clone_calls"][-1]
+        assert clone_cmd[-2] == "https://github.com/alice/dotclaude.git"
+
+    def test_uses_ssh_when_gh_configured_for_ssh(
+        self, fake_gh: dict, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.setup import _ensure_personalization_clone
+
+        fake_gh["git_protocol"] = "ssh"
+        checkout = tmp_path / "checkout"
+        assert _ensure_personalization_clone("alice/dotclaude", checkout)
+        clone_cmd = fake_gh["git_clone_calls"][-1]
+        assert clone_cmd[-2] == "git@github.com:alice/dotclaude.git"
+
+
+class TestPersonalizationFailureSurfacesLoudly:
+    """A personalization clone/init failure must not be a silently
+    swallowed warning — run_setup flags it (#137) so the CLI can print
+    an unmissable banner and exit non-zero, instead of the prior single
+    buried log line + exit 0."""
+
+    def test_run_setup_flags_personalization_failure(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+        from ctrlrelay.personalization.manager import PersonalizationError
+
+        monkeypatch.setattr(
+            setup_mod, "_ensure_personalization_clone", lambda repo, checkout: False
+        )
+
+        def fail_init(self, **kw):  # type: ignore[no-untyped-def]
+            raise PersonalizationError(
+                "git clone ... exited 128: could not read Username "
+                "for 'https://github.com': terminal prompts disabled"
+            )
+
+        monkeypatch.setattr(mgr_mod.PersonalizationManager, "init", fail_init)
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=False,
+        )
+        result = run_setup(opts)
+        assert result.personalization_failed is True
+        assert result.personalization_summary is not None
+        assert "failed" in result.personalization_summary
+
+    def test_run_setup_does_not_flag_failure_on_success(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from ctrlrelay import setup as setup_mod
+        from ctrlrelay.personalization import manager as mgr_mod
+
+        monkeypatch.setattr(
+            setup_mod, "_ensure_personalization_clone", lambda repo, checkout: False
+        )
+        monkeypatch.setattr(
+            mgr_mod.PersonalizationManager, "init", lambda self, **kw: "stub-init"
+        )
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        opts = SetupOptions(
+            owners=["alice", "AInvirion"],
+            repo_root=tmp_path / "Projects",
+            config_out=tmp_path / "cfg.yaml",
+            personalization_repo="alice/dotclaude",
+            wire_skills=False,
+        )
+        result = run_setup(opts)
+        assert result.personalization_failed is False
+
+
 # ---------------------------------------------------------------------------
 # CLI surface
 
@@ -746,17 +837,27 @@ class TestSetupCli:
         tmp_config_out = tmp_path / "cfg.yaml"
         monkeypatch.setattr(setup_mod, "DEFAULT_CONFIG_OUT", tmp_config_out)
 
-        # Route plist writes to tmp so we don't touch ~/Library/LaunchAgents.
-        target_dir = tmp_path / "LaunchAgents"
+        # Route plist/unit writes to tmp, and fake $HOME, so this test
+        # never touches ~/Library/LaunchAgents, ~/.config/systemd/user,
+        # or ~/.ctrlrelay/logs on the machine actually running the
+        # suite (which may have a real ctrlrelay install/daemon).
+        monkeypatch.setenv("HOME", str(tmp_path / "fake-home"))
+        target_dir = tmp_path / "units"
         from ctrlrelay import install as install_mod
 
-        original_render = install_mod.render_launchd
+        original_render_launchd = install_mod.render_launchd
+        original_render_systemd = install_mod.render_systemd
 
-        def render_to_tmp(**kwargs):  # type: ignore[no-untyped-def]
+        def render_launchd_to_tmp(**kwargs):  # type: ignore[no-untyped-def]
             kwargs["target_dir"] = target_dir
-            return original_render(**kwargs)
+            return original_render_launchd(**kwargs)
 
-        monkeypatch.setattr(install_mod, "render_launchd", render_to_tmp)
+        def render_systemd_to_tmp(**kwargs):  # type: ignore[no-untyped-def]
+            kwargs["target_dir"] = target_dir
+            return original_render_systemd(**kwargs)
+
+        monkeypatch.setattr(install_mod, "render_launchd", render_launchd_to_tmp)
+        monkeypatch.setattr(install_mod, "render_systemd", render_systemd_to_tmp)
 
         # Wrap the existing fake_gh subprocess.run so git clone fails.
         original_run = subprocess.run
@@ -809,3 +910,36 @@ class TestSetupCli:
         assert result.exit_code == 0, result.output
         assert (tmp_path / "cfg.yaml").is_file()
         assert (tmp_path / "Projects" / "alice" / "foo" / ".git").is_dir()
+
+    def test_personalization_failure_exits_nonzero_with_action_needed_banner(
+        self, fake_gh: dict, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A failed personalization clone must be impossible to miss:
+        non-zero exit and an ACTION NEEDED banner, not a single buried
+        log line with exit 0 (#137)."""
+        from ctrlrelay.personalization import manager as mgr_mod
+        from ctrlrelay.personalization.manager import PersonalizationError
+
+        def fail_init(self, **kw):  # type: ignore[no-untyped-def]
+            raise PersonalizationError(
+                "git clone ... exited 128: could not read Username "
+                "for 'https://github.com': terminal prompts disabled"
+            )
+
+        monkeypatch.setattr(mgr_mod.PersonalizationManager, "init", fail_init)
+
+        fake_gh["repos_by_owner"] = {"alice": ["alice/foo"], "AInvirion": []}
+        result = runner.invoke(
+            app,
+            [
+                "setup",
+                "--yes",
+                "--repo-root", str(tmp_path / "Projects"),
+                "--config-out", str(tmp_path / "cfg.yaml"),
+                "--personalization-repo", "alice/dotclaude",
+                "--no-wire-skills",
+                "--transport", "file_mock",
+            ],
+        )
+        assert result.exit_code != 0, result.output
+        assert "ACTION NEEDED" in result.output


### PR DESCRIPTION
## Summary
- The personalization repo clone (setup's pre-scan clone and `PersonalizationManager.init`) hardcoded HTTPS, ignoring gh's configured `git_protocol`. SSH-only operators hit `could not read Username` with the failure buried in a single warning line while `ctrlrelay setup` still exited 0. Added `ctrlrelay.gh_protocol` to read gh's configured protocol (`gh config get git_protocol`) and build a matching clone URL, and `run_setup` now flags `personalization_failed` so the CLI prints an unmissable **ACTION NEEDED** banner and exits non-zero.
- Generated launchd/systemd units point `StandardOutput`/`StandardError` at `~/.ctrlrelay/logs/`, which setup never created. systemd refuses to start a unit whose log dir is missing (`EXIT_STDOUT`, code 209), and with `Restart=always` that's an immediate crash-loop. `write_units` now creates the log dir up front, and also chmods unit files `0600` since they embed `CTRLRELAY_TELEGRAM_TOKEN` in plaintext (the minor permissions note from the issue).

Fixes #137.

## Test plan
- [x] `uv run pytest` — full suite passes (685 tests)
- [x] `uv run ruff check .` — clean
- [x] New unit tests: `tests/test_gh_protocol.py` (protocol detection + URL building), plus coverage in `tests/test_setup.py`, `tests/test_personalization.py`, `tests/test_install.py` for SSH-protocol clone URLs, loud failure signaling (banner + exit code), log-dir creation, and unit-file permissions.