### PR TITLE
feat(poller): add require_labels to gate assignment on a label

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`require_labels`: an AND-gate between assignment and a label,
+  closing the gap `include_labels` (#80) couldn't cover.** `exclude_labels`
+  is a block-list and `include_labels` is an OR-alternate trigger, but
+  neither could express "only pick this up if it's assigned to me AND
+  carries a specific label." On a repo with a long history of
+  self-assigned issues used as personal reminders, that meant the poller
+  replayed the whole backlog as new work the first time it saw the repo —
+  including issues that weren't code tasks at all. `require_labels`
+  (default `[]`, no behavior change) tightens the plain-assignment path
+  only: when set, an issue needs both the assignment and a matching label.
+  `include_labels` keeps triggering on a label match alone regardless.
+  An assigned issue missing the required label is left unmarked so a
+  later label addition still surfaces it. See #139.
+
 ## [0.6.0] - 2026-06-10
 
 ### Added

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -139,3 +139,10 @@ repos: []
   #     # Matching is case-insensitive. Defaults to ["manual", "operator",
   #     # "instruction"]; override with an empty list to disable.
   #     exclude_labels: ["manual", "operator", "instruction"]
+  #     # Gates the plain-assignment trigger: when set, assignment alone
+  #     # is no longer enough on its own — an issue must ALSO carry at
+  #     # least one of these labels to be picked up. Does not affect
+  #     # include_labels, which still triggers on a label match alone.
+  #     # Matching is case-insensitive. Defaults to [] (assignment alone
+  #     # is sufficient, same as today).
+  #     require_labels: []

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -200,6 +200,7 @@ and ask the operator), or `never` (skip).
 | `accept_foreign_assignments` | `false` | When `true`, the poller also picks up issues assigned to you by someone else. Default (`false`) runs the dev pipeline only on issues you self-assigned. |
 | `exclude_labels` | `["manual", "operator", "instruction"]` | Issue labels that tell the poller "this isn't for the agent". See [exclude_labels](#reposautomationexclude_labels) below. |
 | `include_labels` | `[]` | Issue labels that opt an issue **into** the dev pipeline regardless of who is (or isn't) assigned. See [include_labels](#reposautomationinclude_labels) below. |
+| `require_labels` | `[]` | Issue labels that gate the plain-assignment trigger: when set, assignment alone is no longer enough — the issue must also carry one of these labels. See [require_labels](#reposautomationrequire_labels) below. |
 
 The current secops and dev pipelines read these settings to bias their prompts
 to Claude — they're not enforced by hard-coded checks.
@@ -307,6 +308,42 @@ repos and which labels trigger the pipeline; a hostile collaborator with
 triage access was already able to push branches and trigger CI, so allowing
 them to opt an issue into the dev pipeline is a narrower extension, not a new
 vector.
+
+### repos[].automation.require_labels
+
+Assignment-only ends up too loose on repos with a long history: issues
+self-assigned as personal reminders or notes, unrelated to automation, get
+replayed into the dev pipeline the first time the poller sees the repo (or
+after any config change that clears `poller_state.json` for it). Some of
+those issues aren't code tasks at all — "create an account with a
+third-party service", "look into pricing" — and shouldn't go anywhere near
+an unsupervised `claude -p ... --dangerously-skip-permissions` run.
+
+`require_labels` closes that gap: when configured, bare assignment is no
+longer sufficient by itself. An issue must be **both** assigned to the
+operator **and** carry at least one of the configured labels to be picked
+up via the assignment path.
+
+```yaml
+repos:
+  - name: "your-org/your-repo"
+    local_path: "~/Projects/your-repo"
+    automation:
+      require_labels: ["ctrlrelay:auto"]
+```
+
+- Default: `[]`. An empty list preserves today's behavior — assignment
+  alone is sufficient, no change for operators who haven't opted in.
+- Matching is **case-insensitive**, same as `exclude_labels` / `include_labels`.
+- This only tightens the **assignment** path. `include_labels` is
+  unaffected — a label match there still admits the issue regardless of
+  `require_labels`, since that path already treats the label as its own
+  trust signal.
+- An issue that's assigned but missing the required label is left
+  **unmarked** (not added to `seen_issues`), so applying the label later
+  still surfaces it on a subsequent poll — nothing is lost, it's just not
+  picked up yet.
+- `exclude_labels` is still checked first, same precedence as always.
 
 ## schedules
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1055,6 +1055,9 @@ def poller_start(
         include_labels_by_repo = {
             r.name: list(r.automation.include_labels) for r in config.repos
         }
+        require_labels_by_repo = {
+            r.name: list(r.automation.require_labels) for r in config.repos
+        }
 
         poller = IssuePoller(
             github=github,
@@ -1064,6 +1067,7 @@ def poller_start(
             accept_foreign_assignments=accept_foreign,
             exclude_labels_by_repo=exclude_labels_by_repo,
             include_labels_by_repo=include_labels_by_repo,
+            require_labels_by_repo=require_labels_by_repo,
         )
 
         # NOTE: first-run seeding moved into `_main()` so the APScheduler

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -183,6 +183,16 @@ class AutomationConfig(BaseModel):
     # Matching is case-insensitive. An issue that is both labeled AND
     # assigned is processed exactly once — not duplicated. See #80.
     include_labels: list[str] = Field(default_factory=list)
+    # Labels that gate the plain-assignment trigger. Default ``[]``
+    # preserves today's behavior (assignment alone is sufficient).
+    # When non-empty, bare assignment is no longer enough on its own:
+    # an issue must be assigned to the operator AND carry at least one
+    # of these labels to be picked up. This only tightens the
+    # assignment path — ``include_labels`` keeps triggering on label
+    # match alone regardless of ``require_labels``, and
+    # ``exclude_labels`` is still checked first. Matching is
+    # case-insensitive. See #139.
+    require_labels: list[str] = Field(default_factory=list)
     # Labels that route an issue to the task pipeline (run a command /
     # investigate / report findings via issue comment) instead of the
     # dev pipeline (branch + PR). Matching is case-insensitive; the

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -84,6 +84,16 @@ class IssuePoller:
     or ``seen_issues``). A repo with an empty / missing ``include_labels``
     keeps the pre-#80 ``--assignee``-filtered query so we don't
     over-fetch.
+
+    ``require_labels_by_repo`` tightens the plain-assignment trigger
+    (see #139). When a repo has any require-labels configured, bare
+    assignment is no longer sufficient by itself — an issue must be
+    assigned to the operator AND carry at least one of the configured
+    labels to be admitted via the assignment path. ``include_labels``
+    is unaffected: a label_match there still admits the issue
+    regardless of ``require_labels``. An issue that's assigned but
+    missing the required label is left unmarked (not seen) so a later
+    label addition still surfaces it on a subsequent poll.
     """
 
     github: GitHubCLI
@@ -94,6 +104,7 @@ class IssuePoller:
     accept_foreign_assignments: set[str] = field(default_factory=set)
     exclude_labels_by_repo: dict[str, list[str]] = field(default_factory=dict)
     include_labels_by_repo: dict[str, list[str]] = field(default_factory=dict)
+    require_labels_by_repo: dict[str, list[str]] = field(default_factory=dict)
     # Per-repo consecutive-skip counter; populated at runtime by poll() /
     # seed_current(). Not persisted — intentionally resets on daemon
     # restart so an operator fix is exercised before we re-escalate.
@@ -343,6 +354,10 @@ class IssuePoller:
                 label.lower()
                 for label in self.exclude_labels_by_repo.get(repo, [])
             }
+            require_lowered = {
+                label.lower()
+                for label in self.require_labels_by_repo.get(repo, [])
+            }
             for issue in issues:
                 # Per-issue guard so ONE malformed payload (missing 'number',
                 # wrong type, non-dict entry) doesn't poison the remaining
@@ -412,6 +427,18 @@ class IssuePoller:
                         is_assigned = self._issue_is_assigned_to(
                             issue, self.username,
                         )
+                    if (
+                        is_assigned
+                        and require_lowered
+                        and self._matched_require_label(
+                            issue, require_lowered,
+                        ) is None
+                    ):
+                        # Assigned but missing the required label
+                        # (#139): the plain-assignment trigger doesn't
+                        # count on this repo. label_match (below) can
+                        # still admit the issue independently.
+                        is_assigned = False
                     if label_match is None and not is_assigned:
                         # Defensive: a targeted query should never
                         # return an issue that matches neither trigger,
@@ -423,7 +450,13 @@ class IssuePoller:
                 else:
                     # Server-side ``--assignee`` already filtered; by
                     # construction every issue reaching here is
-                    # assignment-triggered.
+                    # assignment-triggered — unless require_labels
+                    # (#139) is configured, in which case the missing
+                    # label leaves the issue unmarked for a later poll.
+                    if require_lowered and self._matched_require_label(
+                        issue, require_lowered,
+                    ) is None:
+                        continue
                     is_assigned = True
 
                 if label_match is not None:
@@ -585,6 +618,27 @@ class IssuePoller:
         return None
 
     @staticmethod
+    def _matched_require_label(
+        issue: dict[str, Any], require_lowered: set[str]
+    ) -> str | None:
+        """Return the first issue label that matches ``require_lowered``.
+
+        Mirrors ``_matched_exclude_label`` / ``_matched_include_label``.
+        Used to gate the plain-assignment trigger when a repo has
+        ``require_labels`` configured. See #139.
+        """
+        if not require_lowered:
+            return None
+        for label in issue.get("labels") or []:
+            if isinstance(label, dict):
+                name = label.get("name", "")
+            else:
+                name = str(label)
+            if name and name.lower() in require_lowered:
+                return name
+        return None
+
+    @staticmethod
     def _issue_is_assigned_to(issue: dict[str, Any], username: str) -> bool:
         """Check whether ``username`` is listed in the issue's assignees.
 
@@ -726,6 +780,10 @@ class IssuePoller:
             self._clear_repo_failure(repo)
             seen_for_repo = self.seen_issues.setdefault(repo, set())
             include_lowered = {label.lower() for label in include_labels}
+            require_lowered = {
+                label.lower()
+                for label in self.require_labels_by_repo.get(repo, [])
+            }
             for issue in issues:
                 try:
                     number = int(issue["number"])
@@ -776,11 +834,25 @@ class IssuePoller:
                         seen_for_repo.add(number)
                         continue
                     if self_assigned:
+                        if require_lowered and self._matched_require_label(
+                            issue, require_lowered,
+                        ) is None:
+                            # Assigned but missing the required label
+                            # (#139): leave unseeded so a later
+                            # label-add still surfaces it on the next
+                            # poll.
+                            continue
                         seen_for_repo.add(number)
                 else:
                     # Pre-#80 behavior: server-side --assignee already
                     # filtered, seed everything so first poll doesn't
-                    # flood.
+                    # flood — unless require_labels (#139) is
+                    # configured, in which case an issue missing the
+                    # required label is left unseeded.
+                    if require_lowered and self._matched_require_label(
+                        issue, require_lowered,
+                    ) is None:
+                        continue
                     seen_for_repo.add(number)
         self._save_state_best_effort()
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -544,3 +544,99 @@ class TestAutomationIncludeLabels:
 
         assert config.repos[0].automation.include_labels == ["ctrlrelay:auto"]
         assert config.repos[1].automation.include_labels == []
+
+
+class TestAutomationRequireLabels:
+    """require_labels gates the plain-assignment trigger — an issue must be
+    BOTH assigned and labeled to be picked up. Default [] preserves
+    today's assignment-only behavior. See #139."""
+
+    def test_default_require_labels_is_empty(self) -> None:
+        """Default preserves assignment-only behavior."""
+        auto = AutomationConfig()
+        assert auto.require_labels == []
+
+    def test_require_labels_override_accepts_list(self) -> None:
+        """Explicit list of label strings is accepted verbatim."""
+        auto = AutomationConfig(require_labels=["ctrlrelay:auto"])
+        assert auto.require_labels == ["ctrlrelay:auto"]
+
+    def test_config_without_require_labels_key_defaults_to_empty(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """Legacy configs without require_labels load and get [] — no
+        behavior change for operators who haven't opted in."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"dependabot_patch": "auto"},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.require_labels == []
+
+    def test_require_labels_from_yaml(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """YAML ``require_labels: [...]`` is plumbed through to the
+        resolved AutomationConfig so the CLI can pass it to the poller."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"require_labels": ["ctrlrelay:auto"]},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.require_labels == ["ctrlrelay:auto"]
+
+    def test_require_labels_rejects_non_list(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """A scalar value (common mistake: forgetting list brackets) must
+        fail loudly at config load time rather than silently coerce."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"require_labels": "ctrlrelay:auto"},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        with pytest.raises(ConfigError, match="require_labels"):
+            load_config(cfg_path)
+
+    def test_mixed_repos_with_and_without_require_labels(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        """Two repos in the same config: A opts in, B doesn't. Each keeps
+        its own list — the config surface is per-repo, not global."""
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo-a",
+                "local_path": "~/Projects/repo-a",
+                "automation": {"require_labels": ["ctrlrelay:auto"]},
+            },
+            {
+                "name": "owner/repo-b",
+                "local_path": "~/Projects/repo-b",
+            },
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.require_labels == ["ctrlrelay:auto"]
+        assert config.repos[1].automation.require_labels == []

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1831,3 +1831,153 @@ class TestIncludeLabelsFilter:
         assert rec.repo == "owner/repo-a"
         assert rec.issue_number == 11
         assert rec.matched_label == "ctrlrelay:auto"
+
+
+class TestRequireLabelsFilter:
+    """Per-repo require_labels gates the plain-assignment trigger. See
+    #139. Behavior contract:
+
+    - Empty / missing ``require_labels`` preserves today's behavior:
+      assignment alone is sufficient.
+    - A configured list means assignment is no longer enough by
+      itself: the issue must ALSO carry at least one of the
+      configured labels.
+    - Matching is case-insensitive.
+    - An assigned issue missing the required label is left unmarked
+      (not seen) so a later label addition still surfaces it.
+    - ``include_labels`` is unaffected: a label match there still
+      admits the issue regardless of ``require_labels``.
+    """
+
+    @pytest.mark.asyncio
+    async def test_assigned_without_required_label_is_not_accepted(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(1, "Create a Stripe account", assignees=["alice"]),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            require_labels_by_repo={"owner/repo-a": ["ctrlrelay:auto"]},
+        )
+
+        results = await poller.poll()
+
+        assert results == []
+        # Left unmarked so a later label-add still triggers it.
+        assert 1 not in poller.seen_issues.get("owner/repo-a", set())
+
+    @pytest.mark.asyncio
+    async def test_assigned_with_required_label_is_accepted(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(
+                2, "Fix the bug", assignees=["alice"],
+                labels=[{"name": "ctrlrelay:auto"}],
+            ),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            require_labels_by_repo={"owner/repo-a": ["ctrlrelay:auto"]},
+        )
+
+        results = await poller.poll()
+
+        assert [r["issue"]["number"] for r in results] == [2]
+        assert 2 in poller.seen_issues["owner/repo-a"]
+
+    @pytest.mark.asyncio
+    async def test_matching_is_case_insensitive(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(
+                3, "Fix the bug", assignees=["alice"],
+                labels=[{"name": "CtrlRelay:Auto"}],
+            ),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            require_labels_by_repo={"owner/repo-a": ["ctrlrelay:auto"]},
+        )
+
+        results = await poller.poll()
+
+        assert [r["issue"]["number"] for r in results] == [3]
+
+    @pytest.mark.asyncio
+    async def test_empty_require_labels_preserves_default_behavior(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """Missing / empty require_labels_by_repo entry: assignment
+        alone still triggers, exactly as before #139."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(4, "Fix the bug", assignees=["alice"]),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+        )
+
+        results = await poller.poll()
+
+        assert [r["issue"]["number"] for r in results] == [4]
+
+    @pytest.mark.asyncio
+    async def test_include_label_match_bypasses_require_labels(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """A repo can have both include_labels and require_labels
+        configured. A label match via include_labels still admits the
+        issue even though it lacks a require_labels label — the two
+        knobs gate different paths (#139)."""
+        mock_github.list_assigned_issues.return_value = []
+        mock_github.list_issues_by_label.return_value = [
+            make_issue(5, "Safe to hand off", labels=[{"name": "ctrlrelay:auto"}]),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            include_labels_by_repo={"owner/repo-a": ["ctrlrelay:auto"]},
+            require_labels_by_repo={"owner/repo-a": ["some-other-label"]},
+        )
+
+        results = await poller.poll()
+
+        assert [r["issue"]["number"] for r in results] == [5]
+
+    @pytest.mark.asyncio
+    async def test_seed_current_does_not_seed_missing_required_label(
+        self, mock_github: MagicMock, state_file: Path
+    ) -> None:
+        """An assigned issue missing the required label must NOT be
+        seeded as seen — otherwise adding the label later would never
+        surface it, since it's already marked seen."""
+        mock_github.list_assigned_issues.return_value = [
+            make_issue(6, "Create a Stripe account", assignees=["alice"]),
+        ]
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state_file,
+            require_labels_by_repo={"owner/repo-a": ["ctrlrelay:auto"]},
+        )
+
+        await poller.seed_current()
+
+        assert 6 not in poller.seen_issues.get("owner/repo-a", set())


### PR DESCRIPTION
## Summary
- Adds `AutomationConfig.require_labels` (default `[]`): when set for a repo, plain assignment is no longer sufficient on its own — an issue must be both assigned to the operator and carry at least one of the configured labels to enter the dev pipeline.
- `include_labels` is unaffected: a label match there still admits the issue regardless of `require_labels`. `exclude_labels` is still checked first, same precedence as before.
- An issue that's assigned but missing the required label is left unmarked (not added to `seen_issues`) in both `poll()` and `seed_current()`, so applying the label later still surfaces it on a subsequent poll.

Motivated by #139: a repo with a long history of self-assigned issues (personal reminders, not automation tasks) replays its whole backlog as new work the first time the poller sees it — including issues that aren't code tasks at all.

## Test plan
- [x] `uv run pytest` — 680 passed
- [x] `uv run ruff check .` — clean
- [x] New `TestRequireLabelsFilter` in `tests/test_poller.py`: assignment without required label is not accepted / left unseeded, assignment with required label is accepted, case-insensitive matching, default empty list preserves old behavior, `include_labels` match bypasses `require_labels`, `seed_current` does not seed a missing-required-label issue.
- [x] New `TestAutomationRequireLabels` in `tests/test_config.py`: default, override, YAML load, non-list rejection, mixed per-repo config.

Closes #139