### PR TITLE
test: require_labels end-to-end verification

### DIFF
--- a/scratch.md
+++ b/scratch.md
@@ -1,0 +1,1 @@
+<!-- issue #141: require_labels end-to-end verification test ran -->


### PR DESCRIPTION
## Summary
- Adds a one-line scratch note confirming the assigned+labeled gate for `require_labels` picks this up automatically.

Closes #141