### PR TITLE
feat(dev): make the ci-wait timeout per-repo configurable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`ci_wait_timeout_seconds`: per-repo cap on the dev pipeline's
+  `ctrlrelay ci wait` call.** The dev pipeline prompt tells Claude to run
+  `ctrlrelay ci wait --pr <PR> --repo <repo> --timeout 600` before
+  signaling DONE — a single blocking call, hardcoded to 10 minutes, that
+  generates zero tokens while it polls GitHub. Measured directly on a real
+  session: two `ci wait` calls accounted for 12 of a 26-minute run, versus
+  under 35K output tokens generated the whole time — the wall-clock cost
+  is CI runtime, not model work. `ci_wait_timeout_seconds` (default `600`,
+  unchanged behavior) lets a repo with a faster CI suite cap that single
+  call lower instead of always budgeting the full 10 minutes.
+
 ## [0.7.0] - 2026-09-04
 
 ### Added

--- a/config/orchestrator.yaml.example
+++ b/config/orchestrator.yaml.example
@@ -146,3 +146,9 @@ repos: []
   #     # Matching is case-insensitive. Defaults to [] (assignment alone
   #     # is sufficient, same as today).
   #     require_labels: []
+  #     # Hard cap, in seconds, on the single `ctrlrelay ci wait` call the
+  #     # dev pipeline prompt runs before signaling DONE. Lower this to
+  #     # match how long this repo's CI actually takes — no tokens are
+  #     # generated while blocked in this call, so a slow default here
+  #     # just adds idle wall-clock time. Defaults to 600 (10 minutes).
+  #     ci_wait_timeout_seconds: 600

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -201,6 +201,7 @@ and ask the operator), or `never` (skip).
 | `exclude_labels` | `["manual", "operator", "instruction"]` | Issue labels that tell the poller "this isn't for the agent". See [exclude_labels](#reposautomationexclude_labels) below. |
 | `include_labels` | `[]` | Issue labels that opt an issue **into** the dev pipeline regardless of who is (or isn't) assigned. See [include_labels](#reposautomationinclude_labels) below. |
 | `require_labels` | `[]` | Issue labels that gate the plain-assignment trigger: when set, assignment alone is no longer enough — the issue must also carry one of these labels. See [require_labels](#reposautomationrequire_labels) below. |
+| `ci_wait_timeout_seconds` | `600` | Hard cap, in seconds, on the single `ctrlrelay ci wait` call the dev pipeline prompt tells Claude to run before signaling DONE. See [ci_wait_timeout_seconds](#reposautomationci_wait_timeout_seconds) below. |
 
 The current secops and dev pipelines read these settings to bias their prompts
 to Claude — they're not enforced by hard-coded checks.
@@ -344,6 +345,31 @@ repos:
   still surfaces it on a subsequent poll — nothing is lost, it's just not
   picked up yet.
 - `exclude_labels` is still checked first, same precedence as always.
+
+### repos[].automation.ci_wait_timeout_seconds
+
+The dev pipeline prompt tells Claude to run `ctrlrelay ci wait --pr <PR>
+--repo <repo> --timeout <N>` before signaling DONE — a single blocking call
+that polls GitHub every 15s until CI finishes, fails, or the timeout hits.
+No tokens get generated while it's blocked; on a repo with a slow CI suite,
+that one call can eat most of a session's wall-clock time.
+
+```yaml
+repos:
+  - name: "your-org/your-repo"
+    local_path: "~/Projects/your-repo"
+    automation:
+      ci_wait_timeout_seconds: 300
+```
+
+- Default: `600` (10 minutes).
+- Lower it to match how long the repo's CI actually takes — a repo with a
+  2-minute CI suite gains nothing from a 10-minute cap.
+- A timeout here isn't a failure: `ctrlrelay ci wait` exits 2 (not 1) when
+  the deadline hits with checks still pending, and the prompt tells Claude
+  to treat that as acceptable and hand off rather than loop.
+- This does not change the overall session timeout (`agent.default_timeout_seconds`,
+  default 1800s) — it only bounds the one `ci wait` call.
 
 ## schedules
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -748,6 +748,7 @@ def run_dev(
             state_db=db,
             transport=None,
             contexts_dir=config.paths.contexts,
+            ci_wait_timeout_seconds=repo_config.automation.ci_wait_timeout_seconds,
         )
 
     try:
@@ -1273,6 +1274,7 @@ def poller_start(
                         state_db=state_db,
                         transport=connected_transport,
                         contexts_dir=config.paths.contexts,
+                        ci_wait_timeout_seconds=repo_config.automation.ci_wait_timeout_seconds,
                     )
 
                 # Lock-conflict retry hook. The poller marks issues seen

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -201,6 +201,13 @@ class AutomationConfig(BaseModel):
     # precedence so "not for the agent at all" overrides "agent does
     # this but differently".
     task_labels: list[str] = Field(default_factory=lambda: ["task"])
+    # Hard cap, in seconds, on a single `ctrlrelay ci wait` call the dev
+    # pipeline prompt tells Claude to run before signaling DONE. A repo
+    # with slow CI can eat most of a session's wall-clock time sitting
+    # in this one blocking call generating zero tokens; a fast-CI repo
+    # doesn't need anywhere near the 600s default. Lower this per-repo
+    # to match how long that repo's CI actually takes.
+    ci_wait_timeout_seconds: int = 600
 
 
 _REPO_NAME_RE = re.compile(r"^[A-Za-z0-9._-]+/[A-Za-z0-9._-]+$")

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -330,6 +330,7 @@ class DevPipeline:
         issue_title = extra.get("issue_title", "")
         issue_body = extra.get("issue_body", "")
         branch_name = extra.get("branch_name", "")
+        ci_wait_timeout_seconds = extra.get("ci_wait_timeout_seconds", 600)
         state_file_path = str(state_file) if state_file else "/tmp/state.json"
 
         return f"""You are working on issue #{issue_number} in repository {repo}.
@@ -349,7 +350,7 @@ Execute the following workflow:
 4. Push the branch and open a PR that references the issue
 5. Before signaling DONE, verify the PR is mergeable:
    - Wait for CI by running EXACTLY this command (do NOT improvise bash):
-     `ctrlrelay ci wait --pr <PR> --repo {repo} --timeout 600`
+     `ctrlrelay ci wait --pr <PR> --repo {repo} --timeout {ci_wait_timeout_seconds}`
      Exit codes: 0 = all checks passed, 1 = a check failed (investigate,
      fix, push, then re-run the wait), 2 = hard timeout while CI is still
      pending (treat as acceptable — hand off and let the orchestrator
@@ -608,6 +609,7 @@ async def run_dev_issue(
     max_fix_attempts: int = DEFAULT_MAX_FIX_ATTEMPTS,
     max_blocked_rounds: int = DEFAULT_MAX_BLOCKED_ROUNDS,
     pr_verifier: PRVerifier | None = None,
+    ci_wait_timeout_seconds: int = 600,
 ) -> PipelineResult:
     """Run dev pipeline for a single issue."""
     session_id = f"dev-{repo.replace('/', '-')}-{issue_number}-{uuid.uuid4().hex[:8]}"
@@ -715,6 +717,7 @@ async def run_dev_issue(
                 "issue_title": issue.get("title", ""),
                 "issue_body": issue.get("body", ""),
                 "branch_name": branch_name,
+                "ci_wait_timeout_seconds": ci_wait_timeout_seconds,
             },
         )
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -640,3 +640,67 @@ class TestAutomationRequireLabels:
 
         assert config.repos[0].automation.require_labels == ["ctrlrelay:auto"]
         assert config.repos[1].automation.require_labels == []
+
+
+class TestAutomationCiWaitTimeout:
+    """ci_wait_timeout_seconds caps the single `ctrlrelay ci wait` call the
+    dev pipeline prompt tells Claude to run before signaling DONE. Default
+    600 preserves today's behavior."""
+
+    def test_default_ci_wait_timeout_is_600(self) -> None:
+        auto = AutomationConfig()
+        assert auto.ci_wait_timeout_seconds == 600
+
+    def test_ci_wait_timeout_override_accepts_int(self) -> None:
+        auto = AutomationConfig(ci_wait_timeout_seconds=300)
+        assert auto.ci_wait_timeout_seconds == 300
+
+    def test_config_without_ci_wait_timeout_key_defaults_to_600(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"dependabot_patch": "auto"},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.ci_wait_timeout_seconds == 600
+
+    def test_ci_wait_timeout_from_yaml(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"ci_wait_timeout_seconds": 300},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        config = load_config(cfg_path)
+
+        assert config.repos[0].automation.ci_wait_timeout_seconds == 300
+
+    def test_ci_wait_timeout_rejects_non_int(
+        self, sample_config_dict: dict, tmp_path: Path
+    ) -> None:
+        sample_config_dict["repos"] = [
+            {
+                "name": "owner/repo",
+                "local_path": "~/Projects/repo",
+                "automation": {"ci_wait_timeout_seconds": "fast"},
+            }
+        ]
+        cfg_path = tmp_path / "cfg.yaml"
+        cfg_path.write_text(yaml.dump(sample_config_dict))
+
+        with pytest.raises(ConfigError, match="ci_wait_timeout_seconds"):
+            load_config(cfg_path)

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -61,6 +61,65 @@ class TestDevPipeline:
             "prompt should explicitly ban `until`/`while` bash CI-wait loops"
         )
 
+    def test_prompt_uses_default_ci_wait_timeout_when_not_configured(self) -> None:
+        """No ci_wait_timeout_seconds in extra: falls back to 600, matching
+        AutomationConfig's default so an unconfigured repo behaves as before."""
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        pipeline = DevPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+
+        prompt = pipeline._build_prompt(
+            repo="owner/repo",
+            issue_number=42,
+            extra={
+                "issue_title": "t",
+                "issue_body": "b",
+                "branch_name": "fix/issue-42",
+            },
+            session_id="dev-42",
+            state_file=Path("/tmp/state.json"),
+        )
+
+        assert "ctrlrelay ci wait --pr <PR> --repo owner/repo --timeout 600" in prompt
+
+    def test_prompt_uses_configured_ci_wait_timeout(self) -> None:
+        """A repo with a slow (or fast) CI can override the 600s default so
+        the dev pipeline doesn't spend most of a session blocked in one
+        `ctrlrelay ci wait` call."""
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        pipeline = DevPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+
+        prompt = pipeline._build_prompt(
+            repo="owner/repo",
+            issue_number=42,
+            extra={
+                "issue_title": "t",
+                "issue_body": "b",
+                "branch_name": "fix/issue-42",
+                "ci_wait_timeout_seconds": 300,
+            },
+            session_id="dev-42",
+            state_file=Path("/tmp/state.json"),
+        )
+
+        assert "ctrlrelay ci wait --pr <PR> --repo owner/repo --timeout 300" in prompt
+        assert "--timeout 600" not in prompt
+
     @pytest.mark.asyncio
     async def test_run_dispatches_claude_session(self, tmp_path: Path) -> None:
         """Should dispatch Claude session with issue context."""


### PR DESCRIPTION
## Summary
- Adds `AutomationConfig.ci_wait_timeout_seconds` (default `600`, no behavior change) - caps the single `ctrlrelay ci wait --pr <PR> --repo <repo> --timeout <N>` call the dev pipeline prompt tells Claude to run before signaling DONE.
- Threaded through both `run_dev_issue` call sites (poller-triggered and manual `ctrlrelay run dev`) into `DevPipeline._build_prompt`.

Measured directly on a real session (issue #384 on a downstream repo): two `ci wait` calls accounted for 12 of a 26-minute run, versus under 35K output tokens generated the whole time. The wall-clock cost of a "slow" ctrlrelay run is CI runtime, not model work - a repo with a fast CI suite gains nothing from always budgeting the full 10-minute default.

## Test plan
- [x] `uv run pytest` - 704 passed
- [x] `uv run ruff check .` - clean
- [x] New `TestAutomationCiWaitTimeout` in `tests/test_config.py`: default, override, YAML load, non-int rejection.
- [x] New prompt tests in `tests/test_dev_pipeline.py`: default 600 when unconfigured, configured value substituted correctly and the old default no longer present in the prompt.