### PR TITLE
fix(github): stop depending on gh pr checks --json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`get_pr_checks` no longer depends on `gh pr checks --json`.** That flag
+  isn't supported by every `gh` build in the wild — an older or
+  distro-packaged `gh` rejects it outright with `unknown flag: --json`,
+  which broke CI verification (`ctrlrelay ci wait`, the dev pipeline's
+  hand-off gate) on every PR. Switched to `gh pr view --json
+  statusCheckRollup`, which has been supported since `gh` introduced
+  `--json` at all, and derive the same pass/fail/pending/skipping/cancel
+  bucket gh itself computes from the raw CheckRun/StatusContext fields.
+
 ## [0.8.0] - 2026-09-04
 
 ### Added

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -24,6 +24,60 @@ def _find_gh() -> str:
     return "gh"
 
 
+# Terminal CheckRun conclusions that don't indicate a passing or skipped
+# check. Anything completed and not in _PASS_CONCLUSIONS/_SKIP_CONCLUSIONS/
+# _CANCEL_CONCLUSIONS (FAILURE, TIMED_OUT, ACTION_REQUIRED, STARTUP_FAILURE,
+# STALE, ...) maps to "fail".
+_PASS_CONCLUSIONS = frozenset({"SUCCESS"})
+_SKIP_CONCLUSIONS = frozenset({"NEUTRAL", "SKIPPED"})
+_CANCEL_CONCLUSIONS = frozenset({"CANCELLED"})
+
+_STATUS_CONTEXT_BUCKETS = {
+    "SUCCESS": "pass",
+    "PENDING": "pending",
+    "ERROR": "fail",
+    "FAILURE": "fail",
+}
+
+
+def _normalize_check(entry: dict[str, Any]) -> dict[str, Any]:
+    """Reduce one `statusCheckRollup` entry to the {name, state, bucket,
+    link} shape `gh pr checks --json` used to hand us directly.
+
+    The rollup mixes two GraphQL types: `CheckRun` (GitHub Actions and
+    most third-party checks) and `StatusContext` (legacy commit statuses).
+    They use different field names for the same concepts, so each gets
+    its own bucket derivation mirroring gh's own `pr checks` logic.
+    """
+    if entry.get("__typename") == "StatusContext":
+        state = entry.get("state", "")
+        return {
+            "name": entry.get("context", "?"),
+            "state": state,
+            "bucket": _STATUS_CONTEXT_BUCKETS.get(state, "fail"),
+            "link": entry.get("targetUrl"),
+        }
+
+    status = entry.get("status", "")
+    conclusion = entry.get("conclusion")
+    if status != "COMPLETED":
+        bucket = "pending"
+    elif conclusion in _PASS_CONCLUSIONS:
+        bucket = "pass"
+    elif conclusion in _SKIP_CONCLUSIONS:
+        bucket = "skipping"
+    elif conclusion in _CANCEL_CONCLUSIONS:
+        bucket = "cancel"
+    else:
+        bucket = "fail"
+    return {
+        "name": entry.get("name", "?"),
+        "state": conclusion or status,
+        "bucket": bucket,
+        "link": entry.get("detailsUrl"),
+    }
+
+
 @dataclass
 class GitHubCLI:
     """Async wrapper around the gh CLI."""
@@ -146,25 +200,27 @@ class GitHubCLI:
     ) -> list[dict[str, Any]]:
         """Get status checks for a PR.
 
-        Bypasses `_run_gh` because we need to inspect stdout, stderr, and the
-        exit code independently. `gh pr checks`:
-          - prints a JSON array on stdout when checks exist (exits non-zero
-            when any are pending or failing — the payload is still valid)
-          - prints "no checks reported on the '<branch>' branch" to stderr
-            and exits non-zero when the PR has no checks at all
-          - emits arbitrary errors to stderr (auth, network, missing PR) on
-            non-zero exit with empty stdout
+        Shells out to `gh pr view --json statusCheckRollup` rather than
+        `gh pr checks --json` — the latter's `--json` flag isn't supported
+        by every `gh` build in the wild (older/distro-packaged `gh` rejects
+        it outright with "unknown flag: --json"), while `pr view --json`
+        has been supported since `gh` introduced `--json` at all.
 
-        We return [] only for the "no checks reported" case. Real failures
-        raise GitHubError so callers can distinguish "no CI configured" from
-        "gh is broken".
+        Bypasses `_run_gh` because we need to inspect stdout, stderr, and
+        the exit code independently: `gh pr view` exits 0 with an empty or
+        null rollup when the PR has no CI configured, and non-zero with an
+        error on stderr for genuine failures (auth, network, missing PR).
+
+        We compute the same pass/fail/pending/skipping/cancel "bucket"
+        `gh pr checks` itself derives, from the raw CheckRun/StatusContext
+        fields in the rollup.
         """
         cmd = [
             self.gh_binary,
-            "pr", "checks",
+            "pr", "view",
             str(pr_number),
             "--repo", repo,
-            "--json", "name,state,bucket,link",
+            "--json", "statusCheckRollup",
         ]
         proc = await asyncio.create_subprocess_exec(
             *cmd,
@@ -185,18 +241,11 @@ class GitHubCLI:
         stdout = stdout_bytes.decode().strip()
         stderr = stderr_bytes.decode().strip()
 
-        # JSON payload on stdout — always trust it, regardless of exit code.
         if stdout:
-            return json.loads(stdout)
+            rollup = json.loads(stdout).get("statusCheckRollup") or []
+            return [_normalize_check(entry) for entry in rollup]
 
-        # No stdout. Distinguish "no CI configured" from genuine failures by
-        # looking for gh's well-known "no checks reported" message.
-        if "no checks reported" in stderr.lower():
-            return []
-
-        # Anything else is an honest-to-goodness failure. Don't pretend the
-        # repo has no CI.
-        raise GitHubError(f"gh pr checks failed: {stderr}")
+        raise GitHubError(f"gh pr view failed: {stderr}")
 
     def all_checks_passed(self, checks: list[dict[str, Any]]) -> bool:
         """Check if all PR checks passed."""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -98,15 +98,44 @@ class TestGitHubCLI:
             assert "--squash" in args
 
     @pytest.mark.asyncio
-    async def test_get_pr_checks(self) -> None:
-        """Should get PR check status using the bucket field."""
+    async def test_get_pr_checks_uses_pr_view_not_pr_checks(self) -> None:
+        """`gh pr checks --json` isn't supported by every gh build in the
+        wild (older/distro-packaged gh rejects the flag outright). `gh pr
+        view --json statusCheckRollup` has been supported since gh
+        introduced --json at all, so get_pr_checks must shell out to that
+        instead."""
         from ctrlrelay.core.github import GitHubCLI
 
-        mock_output = json.dumps([
-            {"name": "tests", "state": "SUCCESS", "bucket": "pass"},
-            {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
-        ])
+        mock_output = json.dumps({"statusCheckRollup": []})
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+        mock_proc.returncode = 0
 
+        with patch(
+            "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc),
+        ) as mock_exec:
+            gh = GitHubCLI()
+            await gh.get_pr_checks("owner/repo", 42)
+
+        args = mock_exec.call_args.args
+        assert "view" in args
+        assert "checks" not in args
+        assert "--json" in args
+        assert "statusCheckRollup" in args
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_maps_completed_checkrun_to_pass(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_output = json.dumps({"statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "tests",
+                "status": "COMPLETED",
+                "conclusion": "SUCCESS",
+                "detailsUrl": "https://github.com/x/y/runs/1",
+            },
+        ]})
         mock_proc = MagicMock()
         mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
         mock_proc.returncode = 0
@@ -115,45 +144,113 @@ class TestGitHubCLI:
             gh = GitHubCLI()
             checks = await gh.get_pr_checks("owner/repo", 42)
 
-        assert len(checks) == 2
-        assert all(c["bucket"] == "pass" for c in checks)
+        assert len(checks) == 1
+        assert checks[0]["name"] == "tests"
+        assert checks[0]["bucket"] == "pass"
+        assert checks[0]["link"] == "https://github.com/x/y/runs/1"
 
     @pytest.mark.asyncio
-    async def test_get_pr_checks_parses_json_on_nonzero_exit(self) -> None:
-        """`gh pr checks` exits non-zero while checks are pending/failing, but
-        still prints the JSON payload to stdout. get_pr_checks must parse it
-        instead of silently returning []."""
-
+    async def test_get_pr_checks_maps_incomplete_checkrun_to_pending(self) -> None:
         from ctrlrelay.core.github import GitHubCLI
 
-        mock_output = json.dumps([
-            {"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"},
-        ])
-
+        mock_output = json.dumps({"statusCheckRollup": [
+            {
+                "__typename": "CheckRun",
+                "name": "ci",
+                "status": "IN_PROGRESS",
+                "conclusion": None,
+                "detailsUrl": "https://github.com/x/y/runs/2",
+            },
+        ]})
         mock_proc = MagicMock()
         mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
-        mock_proc.returncode = 1  # non-zero, checks still pending
+        mock_proc.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             gh = GitHubCLI()
             checks = await gh.get_pr_checks("owner/repo", 42)
 
-        assert len(checks) == 1
         assert checks[0]["bucket"] == "pending"
 
     @pytest.mark.asyncio
-    async def test_get_pr_checks_returns_empty_when_no_checks_reported(self) -> None:
-        """gh prints 'no checks reported on the <branch> branch' to stderr
-        and exits non-zero when the PR genuinely has no CI. Treat that as []."""
-
+    async def test_get_pr_checks_maps_checkrun_conclusions_to_buckets(self) -> None:
         from ctrlrelay.core.github import GitHubCLI
 
+        cases = [
+            ("FAILURE", "fail"),
+            ("TIMED_OUT", "fail"),
+            ("ACTION_REQUIRED", "fail"),
+            ("STARTUP_FAILURE", "fail"),
+            ("STALE", "fail"),
+            ("CANCELLED", "cancel"),
+            ("NEUTRAL", "skipping"),
+            ("SKIPPED", "skipping"),
+        ]
+        for conclusion, expected_bucket in cases:
+            mock_output = json.dumps({"statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "job",
+                    "status": "COMPLETED",
+                    "conclusion": conclusion,
+                    "detailsUrl": "https://github.com/x/y/runs/3",
+                },
+            ]})
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+            mock_proc.returncode = 0
+
+            with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+                gh = GitHubCLI()
+                checks = await gh.get_pr_checks("owner/repo", 42)
+
+            assert checks[0]["bucket"] == expected_bucket, conclusion
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_maps_status_context_to_bucket(self) -> None:
+        """Legacy commit statuses (as opposed to check runs) come back as
+        StatusContext entries with a `state` field rather than
+        status/conclusion."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        cases = [
+            ("SUCCESS", "pass"),
+            ("PENDING", "pending"),
+            ("ERROR", "fail"),
+            ("FAILURE", "fail"),
+        ]
+        for state, expected_bucket in cases:
+            mock_output = json.dumps({"statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "legacy-ci",
+                    "state": state,
+                    "targetUrl": "https://example.com/build/1",
+                },
+            ]})
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+            mock_proc.returncode = 0
+
+            with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+                gh = GitHubCLI()
+                checks = await gh.get_pr_checks("owner/repo", 42)
+
+            assert checks[0]["name"] == "legacy-ci"
+            assert checks[0]["bucket"] == expected_bucket, state
+            assert checks[0]["link"] == "https://example.com/build/1"
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_returns_empty_when_no_checks_reported(self) -> None:
+        """`gh pr view` exits 0 with an empty/null rollup when the PR has no
+        CI configured at all — unlike `gh pr checks`, it doesn't need
+        stderr message-sniffing to tell "no CI" apart from a real error."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_output = json.dumps({"statusCheckRollup": None})
         mock_proc = MagicMock()
-        mock_proc.communicate = AsyncMock(return_value=(
-            b"",
-            b"no checks reported on the 'fix/issue-10' branch\n",
-        ))
-        mock_proc.returncode = 1
+        mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+        mock_proc.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             gh = GitHubCLI()


### PR DESCRIPTION
## Summary
- Found while working issue #141: `ctrlrelay ci wait` failed on every PR in this environment because `gh pr checks --json` isn't supported by the installed `gh` build (`unknown flag: --json`).
- `get_pr_checks` now shells out to `gh pr view --json statusCheckRollup` instead, which has been supported since `gh` introduced `--json` at all, and derives the same pass/fail/pending/skipping/cancel bucket from the raw CheckRun/StatusContext fields.
- Verified against the real (broken-for-`pr checks`) `gh` binary in this environment against a live PR — `get_pr_checks` now returns correctly bucketed results.

## Test plan
- [x] `uv run pytest tests/test_github.py` — all pass, including new coverage for CheckRun/StatusContext bucket mapping
- [x] `uv run pytest` — full suite (707 tests) passes
- [x] `uv run ruff check` — clean
- [x] Manual: `GitHubCLI().get_pr_checks("AInvirion/ctrlrelay", 142)` against the real gh CLI returns correct results