### PR TITLE
fix(github): stop depending on gh pr checks --json for CI verification

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **`ctrlrelay ci wait` was unconditionally broken on `gh` releases without
+  `--json` support on `pr checks`** (confirmed on gh 2.45.0, the current
+  Ubuntu 24.04 package — no newer version exists in the distro repos, so
+  this wasn't an "apt upgrade" problem for anyone on that platform).
+  `GitHubCLI.get_pr_checks` shelled out to `gh pr checks --json ...`; on an
+  affected install every single poll failed with `unknown flag: --json`,
+  which `PRVerifier.wait_for_checks` treats as transient and retries —
+  so every `ci wait` call was guaranteed to eat its full timeout and then
+  fail, regardless of the PR's actual state. Reproduced directly and
+  confirmed as the likely cause behind some "session never signaled DONE"
+  reports. Switched to `gh pr view --json statusCheckRollup`, stable since
+  early gh 2.x and always exit-0 regardless of check state, with a new
+  normalizer mapping its two GraphQL shapes (`CheckRun` and the legacy
+  `StatusContext`) into the `{name, state, bucket, link}` shape
+  `PRVerifier` already expects. See #145.
+
 ## [0.8.0] - 2026-09-04
 
 ### Added

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -13,6 +13,65 @@ class GitHubError(Exception):
     """Raised when gh CLI operations fail."""
 
 
+# CheckRun.conclusion values (only present once status == "COMPLETED").
+_CHECK_RUN_PASS = frozenset({"SUCCESS", "NEUTRAL"})
+_CHECK_RUN_SKIP = frozenset({"SKIPPED"})
+_CHECK_RUN_CANCEL = frozenset({"CANCELLED"})
+# StatusContext.state values (the legacy commit-status API, e.g. CLA bots).
+_STATUS_CONTEXT_PASS = frozenset({"SUCCESS"})
+_STATUS_CONTEXT_PENDING = frozenset({"PENDING", "EXPECTED"})
+
+
+def _normalize_check(entry: dict[str, Any]) -> dict[str, Any]:
+    """Map one `statusCheckRollup` entry to the `{name, state, bucket,
+    link}` shape `PRVerifier` expects (see #145).
+
+    `statusCheckRollup` mixes two GraphQL shapes: `CheckRun` (Actions
+    jobs, CodeQL — `status`/`conclusion`) and `StatusContext` (the
+    legacy commit-status API, e.g. CLA bots — `state`). `bucket` is
+    the only field the rest of the app actually branches on; `state`
+    is carried through for parity/debugging.
+    """
+    if entry.get("__typename") == "StatusContext":
+        state = entry.get("state", "")
+        if state in _STATUS_CONTEXT_PASS:
+            bucket = "pass"
+        elif state in _STATUS_CONTEXT_PENDING:
+            bucket = "pending"
+        else:
+            bucket = "fail"
+        return {
+            "name": entry.get("context", ""),
+            "state": state,
+            "bucket": bucket,
+            "link": entry.get("targetUrl", ""),
+        }
+
+    status = entry.get("status", "")
+    conclusion = entry.get("conclusion")
+    if status != "COMPLETED":
+        bucket = "pending"
+        state = status
+    elif conclusion in _CHECK_RUN_PASS:
+        bucket = "pass"
+        state = conclusion
+    elif conclusion in _CHECK_RUN_SKIP:
+        bucket = "skipping"
+        state = conclusion
+    elif conclusion in _CHECK_RUN_CANCEL:
+        bucket = "cancel"
+        state = conclusion
+    else:
+        bucket = "fail"
+        state = conclusion or "FAILURE"
+    return {
+        "name": entry.get("name", ""),
+        "state": state,
+        "bucket": bucket,
+        "link": entry.get("detailsUrl", ""),
+    }
+
+
 def _find_gh() -> str:
     """Find gh binary, checking common paths if not in PATH."""
     gh = shutil.which("gh")
@@ -146,57 +205,30 @@ class GitHubCLI:
     ) -> list[dict[str, Any]]:
         """Get status checks for a PR.
 
-        Bypasses `_run_gh` because we need to inspect stdout, stderr, and the
-        exit code independently. `gh pr checks`:
-          - prints a JSON array on stdout when checks exist (exits non-zero
-            when any are pending or failing — the payload is still valid)
-          - prints "no checks reported on the '<branch>' branch" to stderr
-            and exits non-zero when the PR has no checks at all
-          - emits arbitrary errors to stderr (auth, network, missing PR) on
-            non-zero exit with empty stdout
+        Uses `gh pr view --json statusCheckRollup` rather than `gh pr
+        checks --json ...` — the latter's `--json` flag isn't available
+        on `gh` releases before it was added (confirmed absent on gh
+        2.45.0, the current Ubuntu 24.04 package with no newer version
+        in the distro repos), which made this unconditionally broken on
+        those installs regardless of the PR's actual state (#145).
 
-        We return [] only for the "no checks reported" case. Real failures
-        raise GitHubError so callers can distinguish "no CI configured" from
-        "gh is broken".
+        `gh pr view --json` always exits 0 once the PR itself resolves —
+        the check states live in the JSON, not the exit code — so unlike
+        the old implementation, a non-zero exit here is always a genuine
+        failure (auth, network, missing PR): `_run_gh` already raises
+        `GitHubError` for that case. No checks yet (or ever) on the PR
+        just means an empty `statusCheckRollup` list — the ambiguity
+        between "not registered yet" and "no CI configured" is handled
+        by `PRVerifier`'s empty-streak retry, not here.
         """
-        cmd = [
-            self.gh_binary,
-            "pr", "checks",
-            str(pr_number),
+        stdout = await self._run_gh(
+            "pr", "view", str(pr_number),
             "--repo", repo,
-            "--json", "name,state,bucket,link",
-        ]
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+            "--json", "statusCheckRollup",
         )
-        try:
-            stdout_bytes, stderr_bytes = await asyncio.wait_for(
-                proc.communicate(), timeout=self.timeout,
-            )
-        except asyncio.TimeoutError:
-            proc.kill()
-            try:
-                await proc.wait()
-            except Exception:
-                pass
-            raise
-        stdout = stdout_bytes.decode().strip()
-        stderr = stderr_bytes.decode().strip()
-
-        # JSON payload on stdout — always trust it, regardless of exit code.
-        if stdout:
-            return json.loads(stdout)
-
-        # No stdout. Distinguish "no CI configured" from genuine failures by
-        # looking for gh's well-known "no checks reported" message.
-        if "no checks reported" in stderr.lower():
-            return []
-
-        # Anything else is an honest-to-goodness failure. Don't pretend the
-        # repo has no CI.
-        raise GitHubError(f"gh pr checks failed: {stderr}")
+        payload = json.loads(stdout)
+        rollup = payload.get("statusCheckRollup") or []
+        return [_normalize_check(entry) for entry in rollup]
 
     def all_checks_passed(self, checks: list[dict[str, Any]]) -> bool:
         """Check if all PR checks passed."""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -98,14 +98,55 @@ class TestGitHubCLI:
             assert "--squash" in args
 
     @pytest.mark.asyncio
-    async def test_get_pr_checks(self) -> None:
-        """Should get PR check status using the bucket field."""
+    async def test_get_pr_checks_uses_pr_view_not_pr_checks(self) -> None:
+        """`gh pr checks --json` isn't available on gh releases before it
+        shipped (confirmed absent on gh 2.45.0, the current Ubuntu 24.04
+        package - #145) - get_pr_checks must use `gh pr view --json
+        statusCheckRollup` instead, which has been stable since early gh 2.x."""
         from ctrlrelay.core.github import GitHubCLI
 
-        mock_output = json.dumps([
-            {"name": "tests", "state": "SUCCESS", "bucket": "pass"},
-            {"name": "lint", "state": "SUCCESS", "bucket": "pass"},
-        ])
+        mock_output = json.dumps({"statusCheckRollup": []})
+
+        mock_proc = MagicMock()
+        mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+        mock_proc.returncode = 0
+
+        with patch(
+            "asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)
+        ) as mock_exec:
+            gh = GitHubCLI()
+            await gh.get_pr_checks("owner/repo", 42)
+
+        args = mock_exec.call_args[0]
+        assert "checks" not in args
+        assert ("pr", "view", "42") == args[1:4]
+        assert "--repo" in args and "owner/repo" in args
+        assert "statusCheckRollup" in args
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_normalizes_check_run_entries(self) -> None:
+        """CheckRun entries (Actions jobs, CodeQL) use status/conclusion,
+        not state - must be mapped into the {name, state, bucket, link}
+        shape PRVerifier's bucket logic expects."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        mock_output = json.dumps({"statusCheckRollup": [
+            {
+                "__typename": "CheckRun", "name": "pytest",
+                "status": "COMPLETED", "conclusion": "SUCCESS",
+                "detailsUrl": "https://example.com/1",
+            },
+            {
+                "__typename": "CheckRun", "name": "lint",
+                "status": "IN_PROGRESS", "conclusion": None,
+                "detailsUrl": "https://example.com/2",
+            },
+            {
+                "__typename": "CheckRun", "name": "flaky-e2e",
+                "status": "COMPLETED", "conclusion": "FAILURE",
+                "detailsUrl": "https://example.com/3",
+            },
+        ]})
 
         mock_proc = MagicMock()
         mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
@@ -115,45 +156,54 @@ class TestGitHubCLI:
             gh = GitHubCLI()
             checks = await gh.get_pr_checks("owner/repo", 42)
 
-        assert len(checks) == 2
-        assert all(c["bucket"] == "pass" for c in checks)
+        by_name = {c["name"]: c for c in checks}
+        assert by_name["pytest"]["bucket"] == "pass"
+        assert by_name["lint"]["bucket"] == "pending"
+        assert by_name["flaky-e2e"]["bucket"] == "fail"
 
     @pytest.mark.asyncio
-    async def test_get_pr_checks_parses_json_on_nonzero_exit(self) -> None:
-        """`gh pr checks` exits non-zero while checks are pending/failing, but
-        still prints the JSON payload to stdout. get_pr_checks must parse it
-        instead of silently returning []."""
-
+    async def test_get_pr_checks_normalizes_status_context_entries(self) -> None:
+        """StatusContext entries (the legacy commit-status API, e.g. CLA
+        bots) use `state` and `context` instead of CheckRun's fields."""
         from ctrlrelay.core.github import GitHubCLI
 
-        mock_output = json.dumps([
-            {"name": "ci", "state": "IN_PROGRESS", "bucket": "pending"},
-        ])
+        mock_output = json.dumps({"statusCheckRollup": [
+            {
+                "__typename": "StatusContext",
+                "context": "verification/cla-signed",
+                "state": "SUCCESS",
+                "targetUrl": "https://example.com/cla",
+            },
+        ]})
 
         mock_proc = MagicMock()
         mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
-        mock_proc.returncode = 1  # non-zero, checks still pending
+        mock_proc.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             gh = GitHubCLI()
             checks = await gh.get_pr_checks("owner/repo", 42)
 
-        assert len(checks) == 1
-        assert checks[0]["bucket"] == "pending"
+        assert checks == [{
+            "name": "verification/cla-signed",
+            "state": "SUCCESS",
+            "bucket": "pass",
+            "link": "https://example.com/cla",
+        }]
 
     @pytest.mark.asyncio
     async def test_get_pr_checks_returns_empty_when_no_checks_reported(self) -> None:
-        """gh prints 'no checks reported on the <branch> branch' to stderr
-        and exits non-zero when the PR genuinely has no CI. Treat that as []."""
+        """A PR with no CI at all (or checks not registered yet) just comes
+        back as an empty statusCheckRollup - gh pr view exits 0 either way,
+        no stderr-message sniffing needed."""
 
         from ctrlrelay.core.github import GitHubCLI
 
         mock_proc = MagicMock()
         mock_proc.communicate = AsyncMock(return_value=(
-            b"",
-            b"no checks reported on the 'fix/issue-10' branch\n",
+            json.dumps({"statusCheckRollup": []}).encode(), b"",
         ))
-        mock_proc.returncode = 1
+        mock_proc.returncode = 0
 
         with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
             gh = GitHubCLI()
@@ -163,9 +213,9 @@ class TestGitHubCLI:
 
     @pytest.mark.asyncio
     async def test_get_pr_checks_raises_on_genuine_failure(self) -> None:
-        """Auth/network/missing-PR failures print errors to stderr and leave
-        stdout empty. Must raise GitHubError rather than silently returning []
-        (which would be indistinguishable from 'no CI configured')."""
+        """Auth/network/missing-PR failures exit non-zero with an error on
+        stderr. Must raise GitHubError (via _run_gh) rather than silently
+        returning [] (which would be indistinguishable from 'no CI configured')."""
 
         from ctrlrelay.core.github import GitHubCLI, GitHubError
 


### PR DESCRIPTION
## Summary
- `GitHubCLI.get_pr_checks` shelled out to `gh pr checks --json name,state,bucket,link`. That `--json` flag isn't available on `gh` releases before it shipped - confirmed absent on gh 2.45.0, the current Ubuntu 24.04 package (no newer version exists in the distro repos, so this isn't fixable with `apt upgrade` on that platform).
- `PRVerifier.wait_for_checks` treats `GitHubError` as transient and retries - so on an affected install, every single poll failed identically, every `ci wait` call was guaranteed to eat its full `--timeout` and then fail, regardless of the PR's real CI state. Reproduced directly against a real green PR on gh 2.45.0.
- Switched to `gh pr view --json statusCheckRollup` (stable since early gh 2.x, always exits 0 once the PR resolves) with a new normalizer for the two GraphQL shapes it mixes together (`CheckRun`: `status`/`conclusion`, and the legacy `StatusContext`: `state` - e.g. CLA bots) into the `{name, state, bucket, link}` shape `PRVerifier` already expects.

Closes #145 (filed from a real blocked-session report, then independently reproduced).

## Test plan
- [x] `uv run pytest` - 705 passed
- [x] `uv run ruff check .` - clean
- [x] Live-tested `GitHubCLI.get_pr_checks` and `ctrlrelay ci wait` directly against a real PR (6 checks, including a `StatusContext` CLA check) on the exact gh 2.45.0 install that reproduces the bug - all correctly bucketed as `pass`, `ci wait` exits 0.
- [x] New/updated tests in `tests/test_github.py`: command shape assertion (`pr view`, not `pr checks`), CheckRun normalization (pass/pending/fail), StatusContext normalization, empty-rollup case, genuine-failure passthrough via `_run_gh`.