### PR TITLE
Feed the issue discussion into the dev prompt

### DIFF
--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -209,7 +209,66 @@ AGENT_CLAIM_COMMENT = (
     f"{AGENT_CLAIM_MARKER}"
 )
 
+# Discussion budget for the prompt. Newest comments are kept because a
+# redirect is far likelier to be the latest word than the first reply,
+# and each body is clipped so one pasted log dump can't crowd out the
+# rest of the thread.
+MAX_PROMPT_COMMENTS = 20
+MAX_PROMPT_COMMENT_CHARS = 2000
+
 _logger = get_logger("pipeline.dev")
+
+
+def format_issue_comments(
+    comments: list[dict[str, Any]] | None,
+    *,
+    max_comments: int = MAX_PROMPT_COMMENTS,
+    max_chars: int = MAX_PROMPT_COMMENT_CHARS,
+) -> str:
+    """Render the issue discussion for the dev prompt.
+
+    The body states the problem as it was first filed. The thread is
+    where an operator narrows, redirects or outright vetoes that plan,
+    and nobody edits the body afterwards. A vulnq issue was filed asking
+    for a client fix and then redirected in a comment to price up
+    dropping the data source instead; the prompt carried only the body,
+    so the agent spent a full session building the plan that had already
+    been rejected in writing.
+
+    Drops our own claim comment — it is our noise, not the operator's.
+    Keeps the newest ``max_comments`` but renders them oldest-first so
+    the thread still reads in order.
+    """
+    if not comments:
+        return "_No comments._"
+
+    kept = [
+        c for c in comments
+        if AGENT_CLAIM_MARKER not in (c.get("body") or "")
+    ]
+    if not kept:
+        return "_No comments._"
+
+    dropped = len(kept) - max_comments
+    if dropped > 0:
+        kept = kept[-max_comments:]
+
+    blocks: list[str] = []
+    if dropped > 0:
+        blocks.append(
+            f"_({dropped} earlier comment(s) omitted; read the issue on "
+            f"GitHub if the thread below references them.)_"
+        )
+
+    for c in kept:
+        author = (c.get("author") or {}).get("login") or "unknown"
+        created = c.get("createdAt") or ""
+        body = (c.get("body") or "").strip() or "_(empty)_"
+        if len(body) > max_chars:
+            body = body[:max_chars] + "\n_[...truncated]_"
+        blocks.append(f"--- @{author} ({created}) ---\n{body}")
+
+    return "\n\n".join(blocks)
 
 
 def _question_for_persist(session_id: str, result: PipelineResult) -> str:
@@ -329,6 +388,7 @@ class DevPipeline:
         """Build the dev pipeline prompt."""
         issue_title = extra.get("issue_title", "")
         issue_body = extra.get("issue_body", "")
+        issue_comments = extra.get("issue_comments") or "_No comments._"
         branch_name = extra.get("branch_name", "")
         ci_wait_timeout_seconds = extra.get("ci_wait_timeout_seconds", 600)
         state_file_path = str(state_file) if state_file else "/tmp/state.json"
@@ -339,6 +399,15 @@ class DevPipeline:
 
 **Issue Body:**
 {issue_body}
+
+**Discussion:**
+{issue_comments}
+
+The body is the issue as first filed; the discussion is newer. Where a
+comment narrows, redirects or rejects what the body asks for, the comment
+wins — nobody goes back and edits the body after changing their mind in
+the thread. If the discussion contradicts the body in a way you cannot
+reconcile, signal BLOCKED and ask rather than picking one.
 
 **Branch:** {branch_name}
 
@@ -716,6 +785,7 @@ async def run_dev_issue(
             extra={
                 "issue_title": issue.get("title", ""),
                 "issue_body": issue.get("body", ""),
+                "issue_comments": format_issue_comments(issue.get("comments")),
                 "branch_name": branch_name,
                 "ci_wait_timeout_seconds": ci_wait_timeout_seconds,
             },
@@ -1145,6 +1215,7 @@ async def resume_dev_from_pending(
             extra={
                 "issue_title": issue.get("title", ""),
                 "issue_body": issue.get("body", ""),
+                "issue_comments": format_issue_comments(issue.get("comments")),
                 "branch_name": branch_name,
             },
         )

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1697,3 +1697,124 @@ class TestRepoLockHandleReacquireBudget:
             * dev_mod._REACQUIRE_LOCK_SLEEP_SECONDS
         )
         assert cleanup_seconds < fix_seconds / 10
+
+
+class TestIssueCommentsInPrompt:
+    """The body is the issue as filed; the thread is where an operator
+    changes their mind. A prompt built from the body alone sends the
+    agent to build a plan that was already rejected in writing."""
+
+    def test_discussion_reaches_the_prompt(self) -> None:
+        from ctrlrelay.pipelines.dev import DevPipeline, format_issue_comments
+
+        pipeline = DevPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+
+        rendered = format_issue_comments([
+            {
+                "author": {"login": "operator"},
+                "createdAt": "2026-09-04T03:42:45Z",
+                "body": "I disagree. Price up removing the source instead.",
+            },
+        ])
+        prompt = pipeline._build_prompt(
+            repo="owner/repo",
+            issue_number=42,
+            extra={
+                "issue_title": "t",
+                "issue_body": "make the client work",
+                "issue_comments": rendered,
+                "branch_name": "fix/issue-42",
+            },
+            session_id="dev-42",
+            state_file=Path("/tmp/state.json"),
+        )
+
+        assert "Price up removing the source instead." in prompt
+        assert "@operator" in prompt
+        # The agent must be told which one wins, not left to guess.
+        assert "the comment\nwins" in prompt
+
+    def test_claim_comment_is_not_fed_back(self) -> None:
+        """Our own claim marker is orchestrator noise; echoing it back
+        just spends tokens telling the agent it is itself."""
+        from ctrlrelay.pipelines.dev import (
+            AGENT_CLAIM_COMMENT,
+            format_issue_comments,
+        )
+
+        rendered = format_issue_comments([
+            {
+                "author": {"login": "operator"},
+                "createdAt": "2026-09-04T03:42:45Z",
+                "body": AGENT_CLAIM_COMMENT,
+            },
+        ])
+
+        assert rendered == "_No comments._"
+
+    def test_no_comments_renders_placeholder(self) -> None:
+        from ctrlrelay.pipelines.dev import format_issue_comments
+
+        assert format_issue_comments(None) == "_No comments._"
+        assert format_issue_comments([]) == "_No comments._"
+
+    def test_keeps_newest_and_says_what_it_dropped(self) -> None:
+        """A redirect is likelier to be the latest word than the first
+        reply, so the tail survives — and the agent is told the head is
+        missing rather than silently seeing a partial thread."""
+        from ctrlrelay.pipelines.dev import format_issue_comments
+
+        comments = [
+            {
+                "author": {"login": "operator"},
+                "createdAt": f"2026-09-0{i}T00:00:00Z",
+                "body": f"comment {i}",
+            }
+            for i in range(1, 6)
+        ]
+        rendered = format_issue_comments(comments, max_comments=2)
+
+        assert "comment 5" in rendered
+        assert "comment 4" in rendered
+        assert "comment 1" not in rendered
+        assert "3 earlier comment(s) omitted" in rendered
+        # Oldest-first inside the kept window: the thread must read in order.
+        assert rendered.index("comment 4") < rendered.index("comment 5")
+
+    def test_long_comment_is_clipped(self) -> None:
+        """One pasted log dump must not crowd the rest of the thread out
+        of the prompt."""
+        from ctrlrelay.pipelines.dev import format_issue_comments
+
+        rendered = format_issue_comments(
+            [
+                {
+                    "author": {"login": "operator"},
+                    "createdAt": "2026-09-04T00:00:00Z",
+                    "body": "x" * 5000,
+                },
+            ],
+            max_chars=100,
+        )
+
+        assert "truncated" in rendered
+        assert len(rendered) < 500
+
+    def test_missing_author_does_not_crash(self) -> None:
+        """gh has handed back comments with a null author for deleted
+        accounts; a prompt build must not die on one."""
+        from ctrlrelay.pipelines.dev import format_issue_comments
+
+        rendered = format_issue_comments([
+            {"author": None, "createdAt": "", "body": "still matters"},
+        ])
+
+        assert "@unknown" in rendered
+        assert "still matters" in rendered


### PR DESCRIPTION
## The problem

`_build_prompt` in the dev pipeline gave the agent the issue title and body, and nothing else:

```
**Issue Title:** {issue_title}

**Issue Body:**
{issue_body}
```

The body is the issue as it was first filed. The thread is where an operator narrows, redirects or vetoes that plan — and nobody goes back and edits the body after changing their mind in a comment.

A vulnq issue was filed asking for a VulnerableCode client fix, then redirected in a comment to price up dropping the source entirely instead. The prompt carried only the body, so the agent never saw the redirect and spent a full session building the plan that had already been rejected in writing.

## The fix

`get_issue` already requests `comments` — the claim-marker check at the top of `run_dev_issue` consumes them — so the data was on hand and simply never reached the prompt. Both the start path and the resume path now render it.

`format_issue_comments` handles the shape:

- Our own `<!-- ctrlrelay:claimed -->` comment is dropped. Echoing it back spends tokens telling the agent it is itself.
- Newest 20 comments survive, rendered oldest-first so the thread still reads in order. A redirect is far likelier to be the latest word than the first reply.
- Each body is clipped to 2000 chars, so one pasted log dump cannot crowd the rest of the thread out of the prompt.
- Anything dropped is declared in the output rather than silently cut.
- A null author (deleted account) renders as `@unknown` instead of raising.

The prompt states the precedence rather than leaving the agent to infer it: where a comment contradicts the body, the comment wins; an irreconcilable conflict is BLOCKED, not a guess.

## Verification

Run against the real issue that prompted this, the redirect survives and the claim comment does not:

```
--- @oscarvalenzuelab (2026-09-04T03:42:45Z) ---
I disagree with this approach. I think we should eval to remove/replace vulnerablecode and move to use REI.

Let's evaluate the cost of removing instead of fixing.
```

6 new tests covering render, claim filtering, empty input, the newest-N window and its dropped-count notice, clipping, and the null author. Full suite 711 passed; `ruff check` clean; `mypy` reports no new errors (the 5 remaining are pre-existing missing stubs in `telegram_handler`, `scheduler` and `config`).
