### PR TITLE
test(github): cover every CheckRun conclusion and StatusContext state

### DIFF
--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -192,6 +192,81 @@ class TestGitHubCLI:
         }]
 
     @pytest.mark.asyncio
+    async def test_get_pr_checks_maps_every_checkrun_conclusion(self) -> None:
+        """Every terminal CheckRun conclusion GitHub can emit, not just the
+        SUCCESS/FAILURE pair - an unmapped conclusion silently falling into
+        the wrong bucket is what decides whether ctrlrelay merges or waits."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        cases = [
+            ("SUCCESS", "pass"),
+            ("NEUTRAL", "pass"),
+            ("SKIPPED", "skipping"),
+            ("CANCELLED", "cancel"),
+            ("FAILURE", "fail"),
+            ("TIMED_OUT", "fail"),
+            ("ACTION_REQUIRED", "fail"),
+            ("STARTUP_FAILURE", "fail"),
+            ("STALE", "fail"),
+        ]
+        for conclusion, expected_bucket in cases:
+            mock_output = json.dumps({"statusCheckRollup": [
+                {
+                    "__typename": "CheckRun",
+                    "name": "job",
+                    "status": "COMPLETED",
+                    "conclusion": conclusion,
+                    "detailsUrl": "https://example.com/run",
+                },
+            ]})
+
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+            mock_proc.returncode = 0
+
+            with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+                gh = GitHubCLI()
+                checks = await gh.get_pr_checks("owner/repo", 42)
+
+            assert checks[0]["bucket"] == expected_bucket, conclusion
+
+    @pytest.mark.asyncio
+    async def test_get_pr_checks_maps_every_status_context_state(self) -> None:
+        """EXPECTED is the one that matters: it means a branch-protection
+        status that hasn't reported yet. Bucketing it as `fail` rather than
+        `pending` would abort a PR that is merely still waiting."""
+        from ctrlrelay.core.github import GitHubCLI
+
+        cases = [
+            ("SUCCESS", "pass"),
+            ("PENDING", "pending"),
+            ("EXPECTED", "pending"),
+            ("ERROR", "fail"),
+            ("FAILURE", "fail"),
+        ]
+        for state, expected_bucket in cases:
+            mock_output = json.dumps({"statusCheckRollup": [
+                {
+                    "__typename": "StatusContext",
+                    "context": "legacy-ci",
+                    "state": state,
+                    "targetUrl": "https://example.com/build",
+                },
+            ]})
+
+            mock_proc = MagicMock()
+            mock_proc.communicate = AsyncMock(return_value=(mock_output.encode(), b""))
+            mock_proc.returncode = 0
+
+            with patch("asyncio.create_subprocess_exec", AsyncMock(return_value=mock_proc)):
+                gh = GitHubCLI()
+                checks = await gh.get_pr_checks("owner/repo", 42)
+
+            assert checks[0]["name"] == "legacy-ci"
+            assert checks[0]["bucket"] == expected_bucket, state
+            assert checks[0]["link"] == "https://example.com/build"
+
+    @pytest.mark.asyncio
     async def test_get_pr_checks_returns_empty_when_no_checks_reported(self) -> None:
         """A PR with no CI at all (or checks not registered yet) just comes
         back as an empty statusCheckRollup - gh pr view exits 0 either way,


### PR DESCRIPTION
# Description

`get_pr_checks` normalizes `statusCheckRollup` into a `bucket` that decides whether ctrlrelay merges a PR, keeps waiting, or aborts. The suite only asserted three of those mappings: `SUCCESS`, `IN_PROGRESS` and `FAILURE` for `CheckRun`, plus a single `SUCCESS` `StatusContext`. Every other state GitHub can emit was unasserted, so a wrong bucket would ship silently.

This adds two table-driven tests:

- `test_get_pr_checks_maps_every_checkrun_conclusion` — the nine terminal conclusions (`SUCCESS`, `NEUTRAL`, `SKIPPED`, `CANCELLED`, `FAILURE`, `TIMED_OUT`, `ACTION_REQUIRED`, `STARTUP_FAILURE`, `STALE`)
- `test_get_pr_checks_maps_every_status_context_state` — the five legacy commit-status states (`SUCCESS`, `PENDING`, `EXPECTED`, `ERROR`, `FAILURE`)

`EXPECTED` is the case that earns its place. It means a branch-protection status that has not reported yet; bucketing it as `fail` rather than `pending` would abort a PR that is merely still waiting.

No production code changes — the implementation from #146 already behaves correctly for all fourteen cases. These tests pin that behaviour down.

### Provenance

Salvaged from #144, which was an independent reimplementation of the same fix #146 shipped nine minutes later. #144 is closed as superseded. Its normalizer had no `EXPECTED` entry and fell through to `fail`, so the assertions here follow #146's semantics rather than #144's.

## Type of Change

- [x] Test coverage (no production code change)

## How Has This Been Tested?

- [x] All fourteen expectations executed directly against the real `_normalize_check` from `main` — 14/14 match, 0 mismatches
- [x] `python3 -m py_compile tests/test_github.py` — clean
- [ ] **`pytest` not run locally** — the dev machine has no pip/venv/pytest available, so the mock and async plumbing in these tests is unexercised until CI runs. Please confirm on green CI before merging.

**Test Configuration**:
- OS: Linux 6.17.4
- Python: 3.13.5

## Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes — see above, CI must confirm
- [x] CHANGELOG.md not updated — tests only, no behaviour change

https://claude.ai/code/session_014QpPtcrkgJ8jVsJufrDbLV