### PR TITLE
fix(secops): fence the sweep to its two author-filtered PR queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,7 +62,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   repo cannot meet on any normal link — a 1.8 GB repo failed its sweep
   this way every day. Network transfers now use 1800s, matching claude's
   own `default_timeout_seconds`.
-
+- **secops no longer looks at PRs outside its two author-filtered queries.**
+  The prompt only ever tells the agent to run `gh pr list` with
+  `--author "app/dependabot"` and `--author "$OPERATOR"` — but a step-5
+  bullet for "PRs from anyone else" implied a wider list existed, so the
+  agent ran its own unfiltered `gh pr list` to populate the category and
+  then signalled BLOCKED on PRs it can never merge. That fired a Telegram
+  question every sweep, forever, and every one timed out unanswered; run
+  summaries reporting "no open PRs at all" were the fingerprint of the
+  out-of-scope query. A third party's PR is now explicitly out of scope:
+  not fetched, not evaluated, not named in the summary. An explicit scope
+  fence forbids broadening the search. Operator-authored code PRs still
+  ASK, because there the answer genuinely decides what happens next.
+- **BLOCKED questions may no longer be padded with already-decided items.**
+  Real questions were bundling a genuine Dependabot decision with a
+  non-actionable tail ("...confirm no action wanted"), burying the part
+  that needed an answer. Decided items belong in the run summary; a repo
+  with nothing to decide now finishes DONE instead of signalling BLOCKED.
 - **Telegram questions now say which repo and session they belong to.** A
   secops sweep posts one consolidated question per repo back-to-back and
   the agent's text rarely names its own repo, so the operator saw a run of

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -356,6 +356,13 @@ manual code review of the bump, or any other freelance option. If
 the right action isn't clear from policy + prior decisions + edge
 cases above, ASK with a one-line question — don't invent.
 
+Every BLOCKED question must contain ONLY items where the operator's
+answer changes what you do next. Never pad a question with items you
+have already decided — no "confirm no action wanted", no "left open
+per policy" tails, no FYI clauses. Those belong in the step-6
+summary. If nothing in the repo needs a decision, do not signal
+BLOCKED at all: finish DONE and say what you left alone.
+
    - **PR authored by `$OPERATOR` touching ONLY `.github/dependabot.yml`**
      (additive ecosystem entries, no other files changed): MAYBE
      auto-merge — but only after diff validation. These are the
@@ -390,8 +397,26 @@ cases above, ASK with a one-line question — don't invent.
      other than dependabot.yml): signal BLOCKED for operator approval.
      Never auto-merge code changes, even from the trusted operator.
    - **PRs from anyone else** (collaborators, contributors, other bots):
-     signal BLOCKED. Never on this path.
-6. Summarize actions taken
+     out of scope — see the PR scope fence below. Do not fetch them, do
+     not evaluate them, do not name them, do not signal BLOCKED on them.
+6. Summarize actions taken. Report only what you acted on or decided
+   under the queries in steps 1-4. Do not report counts or descriptions
+   of PRs outside that scope.
+
+**PR scope fence:**
+
+The ONLY open PRs in scope are the ones returned by the two author-
+filtered queries above: `--author "app/dependabot"` (step 2) and
+`--author "$OPERATOR"` (step 4). That is the complete universe of PRs
+this pipeline may look at.
+
+Never run an unfiltered `gh pr list` (or any other broad PR/issue
+search) to discover PRs beyond those two queries. A third party's open
+PR is not this pipeline's business: it cannot be merged here, it needs
+no decision here, and surfacing it only produces noise. If you catch
+yourself about to write a phrase like "no open PRs at all" or "N open
+PRs total", you have already stepped outside the fence — you can only
+speak to the author-filtered results.
 
 ## Signaling Completion
 

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -1535,3 +1535,100 @@ class TestSecopsFailureIsDiagnosable:
         assert len(results) == 2
         assert all(not r.success for r in results)
         assert all("TimeoutError" in r.error for r in results)
+
+
+class TestNonOperatorPRsAreOutOfScope:
+    """Third-party PRs were never meant to reach this pipeline. The prompt
+    issues exactly two author-filtered queries (app/dependabot, $OPERATOR),
+    but a step-5 bullet for "PRs from anyone else" implied a wider list
+    existed, so the agent ran its own unfiltered `gh pr list` to fill the
+    category — then signalled BLOCKED on PRs it can never merge. Run
+    summaries saying "no open PRs at all" are the fingerprint of that
+    out-of-scope query."""
+
+    @staticmethod
+    def _prompt() -> str:
+        from ctrlrelay.pipelines.secops import SecopsPipeline
+
+        pipeline = SecopsPipeline(
+            dispatcher=MagicMock(),
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+        return pipeline._build_prompt(repo="o/r", session_id="s1")
+
+    def test_prompt_only_lists_prs_via_author_filtered_queries(self) -> None:
+        """Every `gh pr list` in the prompt must carry an --author filter.
+        An unfiltered one is what dragged third-party PRs in."""
+        prompt = self._prompt()
+
+        # Discriminate on backticks, not on a substring of the flags: a
+        # command the agent is told to run is always fenced, while the
+        # prohibition sentence names the bare command with no arguments.
+        # Keying off `--repo` instead would let `gh pr list --state open`
+        # slip past unexamined — the exact query this fence exists to
+        # forbid.
+        import re
+
+        fenced = re.findall(r"`([^`]+)`", prompt)
+        invocations = [
+            cmd.strip() for cmd in fenced
+            if cmd.strip().startswith("gh pr list")
+            and cmd.strip() != "gh pr list"
+        ]
+        assert invocations, "expected at least one PR query in the prompt"
+        for cmd in invocations:
+            assert "--author" in cmd, f"unfiltered PR query: {cmd}"
+
+    def test_guard_would_catch_an_unfiltered_query(self) -> None:
+        """The guard above is only worth having if it fails on the thing
+        it forbids. Feed it a prompt containing the query that started
+        this and confirm the same predicate rejects it."""
+        import re
+
+        bad_prompt = "Run `gh pr list --state open --json number` first."
+        fenced = re.findall(r"`([^`]+)`", bad_prompt)
+        invocations = [
+            cmd.strip() for cmd in fenced
+            if cmd.strip().startswith("gh pr list")
+            and cmd.strip() != "gh pr list"
+        ]
+
+        assert invocations, "the unfiltered query must be examined, not skipped"
+        assert not all("--author" in cmd for cmd in invocations)
+
+    def test_prompt_forbids_broadening_the_pr_search(self) -> None:
+        prompt = self._prompt()
+        lower = prompt.lower()
+
+        assert "never run an unfiltered `gh pr list`" in lower
+        assert "no open prs at all" in lower  # named as the tell-tale phrase
+
+    def test_prompt_puts_third_party_prs_out_of_scope(self) -> None:
+        prompt = self._prompt()
+        lower = prompt.lower()
+
+        assert "collaborators, contributors, other bots" in lower
+        assert "out of scope" in lower
+        assert "do not signal blocked on them" in lower
+
+    def test_prompt_still_blocks_on_operator_code_prs(self) -> None:
+        """The operator's own code PRs stay ASK — there an answer really
+        does change what happens next. Only the out-of-scope branch went."""
+        prompt = self._prompt()
+        lower = prompt.lower()
+
+        assert "signal blocked for operator approval" in lower
+        assert "never auto-merge code changes" in lower
+
+    def test_prompt_forbids_padding_questions_with_decided_items(self) -> None:
+        """Several real questions bundled a genuine Dependabot decision
+        with a non-actionable tail ("...confirm no action wanted")."""
+        prompt = self._prompt()
+        lower = prompt.lower()
+
+        assert "confirm no action wanted" in lower
+        assert "answer changes what you do next" in lower


### PR DESCRIPTION
## Problem

`_build_prompt` in `src/ctrlrelay/pipelines/secops.py` issues exactly **two** PR queries:

```
gh pr list --repo {repo} --author "app/dependabot"           # step 2
gh pr list --repo {repo} --state open --author "$OPERATOR"   # step 4
```

Neither returns a third party's PR. But step 5 carried a bullet for a category nobody had fetched:

> **PRs from anyone else** (collaborators, contributors, other bots): signal BLOCKED. Never on this path.

The bullet implied a wider list existed, so the agent went and ran its own unfiltered `gh pr list` to populate it — then signalled BLOCKED on PRs the very same rule says it can never merge.

The fingerprint is in the stored run summaries:

> "No open Dependabot alerts, no Dependabot PRs, no open operator PRs, **no open PRs at all**."

Nothing in the prompt asks for a total. The agent could only know it by querying outside its scope.

## Impact

From one morning's sweep (2026-09-07, 91 repos):

- 7 questions asked, **4 about PRs from `diegojorquera` / `dantoac`** — contributors whose PRs this path may never merge.
- **All 7 timed out unanswered.**
- 16 unanswered questions had stacked up in `pending_resumes`; five repos asked the identical question two days running.
- Lifetime bridge counters: **46 questions posted, 4 ever answered.**
- ~1h45m of the 3h09m sweep was spent in dead 15-minute waits, holding each repo's lock and worktree.

## Change

- Third-party PRs are **out of scope**: not fetched, not evaluated, not named in the summary.
- An explicit **PR scope fence** names the two author-filtered queries as the complete universe and forbids an unfiltered `gh pr list`, calling out "no open PRs at all" as the phrase that proves the fence was crossed.
- Step 6 may only report what was acted on within that scope — no outside counts.
- Operator-authored code PRs **still ASK**. There the answer genuinely decides the next action, so the interrupt earns its keep.
- Separately: a BLOCKED question may now contain only items whose answer changes what happens next — no "confirm no action wanted" tails. Several real questions buried a genuine Dependabot decision under one.

## Verification

- 5 regression tests in `TestNonOperatorPRsAreOutOfScope`, including one that walks every `gh pr list --repo` invocation in the rendered prompt and asserts each carries `--author`, and one asserting the operator-code-PR path still blocks.
- Full suite: **745 passed**.
- `ruff check`: clean. `mypy`: 20 errors, all pre-existing on `main` (verified by stashing).

## Not covered here

This is the secops sweep only. It is repo-scoped by design and has no notion of issue assignment — the assignment/label gating that governs the dev pipeline is a separate path (`require_labels`).
