### PR TITLE
fix(secops): surface the cause when a repo's sweep fails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A secops repo failure now says what broke.** A sweep that died before
+  the `sessions` INSERT — anything raised by `ensure_bare_repo` or
+  `create_worktree`, both network-bound and both ahead of it — left no
+  trace at all: the DB update is guarded on the insert having happened,
+  and the `except` block had no logging. With an exception whose `str()`
+  is empty the Telegram alert then fell back to its generic summary, so
+  the operator got `Error processing <repo>` and nothing else. The
+  failure is now logged as `secops.repo.failed` regardless of which
+  branch runs, and both `summary` and `error` carry the exception type.
+- **`git` timeouts stringify to something.** `asyncio.wait_for` raises a
+  bare `TimeoutError` whose message is the empty string; it is now
+  re-raised as the same type with the command, timeout, and cwd
+  attached, so it stays useful wherever it surfaces.
+- **Bare clone and fetch get a transfer-sized timeout.** Both inherited
+  the 120s budget meant for local git plumbing, which a multi-gigabyte
+  repo cannot meet on any normal link — a 1.8 GB repo failed its sweep
+  this way every day. Network transfers now use 1800s, matching claude's
+  own `default_timeout_seconds`.
+
 - **Telegram questions now say which repo and session they belong to.** A
   secops sweep posts one consolidated question per repo back-to-back and
   the agent's text rarely names its own repo, so the operator saw a run of

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -25,6 +25,17 @@ _PR_PROBE_RETRY_SLEEP_SECONDS = 1.0
 # single pr-list call with --head filter against GitHub.
 _PR_PROBE_TIMEOUT_SECONDS = 10
 
+# Network-bound git transfers (bare clone, fetch) get their own, much
+# larger budget than the 120s that suits local plumbing. A 1.8 GB repo
+# cannot clone or fetch its first time inside two minutes on any normal
+# link, and the failure mode was silent: `asyncio.wait_for` raises a
+# bare `TimeoutError` whose `str()` is empty, so the sweep reported
+# "Error processing <repo>" with no cause attached and wrote neither a
+# session row nor a log line. 1800s matches claude's own
+# `default_timeout_seconds` — a transfer still running past that is
+# genuinely stuck, not merely large.
+_GIT_TRANSFER_TIMEOUT_SECONDS = 1800
+
 
 class WorktreeError(Exception):
     """Raised when worktree operations fail."""
@@ -68,6 +79,7 @@ class WorktreeManager:
         for one call — useful for cheap probes that shouldn't inherit the full
         120s default when network is flaky."""
         cmd = ["git", *args]
+        effective_timeout = timeout if timeout is not None else self.timeout
         proc = await asyncio.create_subprocess_exec(
             *cmd,
             cwd=cwd,
@@ -77,7 +89,7 @@ class WorktreeManager:
         try:
             stdout, stderr = await asyncio.wait_for(
                 proc.communicate(),
-                timeout=timeout if timeout is not None else self.timeout,
+                timeout=effective_timeout,
             )
         except asyncio.TimeoutError:
             try:
@@ -85,7 +97,17 @@ class WorktreeManager:
                 await proc.wait()
             except Exception:
                 pass
-            raise
+            # Re-raise the SAME type (callers filter on TimeoutError) but
+            # with a message attached. A bare `asyncio.TimeoutError()`
+            # stringifies to "", so every layer above rendered it as
+            # empty: the secops sweep reported "Error processing <repo>"
+            # with no cause, and the operator got a Telegram alert that
+            # named a repo and nothing else.
+            raise asyncio.TimeoutError(
+                f"git {' '.join(args)} timed out after "
+                f"{effective_timeout}s"
+                + (f" (cwd={cwd})" if cwd is not None else "")
+            ) from None
         except asyncio.CancelledError:
             # Scheduler/shutdown cancel: kill the child BEFORE re-raising
             # so the git subprocess isn't left mutating the bare repo /
@@ -768,12 +790,14 @@ class WorktreeManager:
                 "fetch", "--prune", "origin",
                 "refs/heads/*:refs/heads/*",
                 cwd=bare_path,
+                timeout=_GIT_TRANSFER_TIMEOUT_SECONDS,
             )
         else:
             await self._run_git(
                 "clone", "--bare",
                 f"https://github.com/{repo}.git",
                 str(bare_path),
+                timeout=_GIT_TRANSFER_TIMEOUT_SECONDS,
             )
 
         return bare_path

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -698,15 +698,24 @@ async def run_secops_all(
             # the generic summary and named only the repo. Log first, so
             # the cause survives regardless of which branch runs next.
             detail = str(e) or type(e).__name__
-            log_event(
-                _logger,
-                "secops.repo.failed",
-                session_id=session_id,
-                repo=repo,
-                session_row_inserted=session_row_inserted,
-                error_type=type(e).__name__,
-                error=detail[:200],
-            )
+            # This is the last-resort handler for the whole repo, and
+            # every repo after this one in the sweep depends on it
+            # returning normally. A raising logger here would abort the
+            # remaining repos AND destroy the original exception —
+            # trading one repo's failure for the entire pass. Losing the
+            # log line is the strictly better failure.
+            try:
+                log_event(
+                    _logger,
+                    "secops.repo.failed",
+                    session_id=session_id,
+                    repo=repo,
+                    session_row_inserted=session_row_inserted,
+                    error_type=type(e).__name__,
+                    error=detail[:200],
+                )
+            except Exception:
+                pass
             if session_row_inserted:
                 state_db.execute(
                     "UPDATE sessions SET status = ?, summary = ?, "

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -686,18 +686,42 @@ async def run_secops_all(
             raise
 
         except Exception as e:
+            # Never let a repo fail silently. Two independent holes put
+            # the cause beyond reach for the operator:
+            #   1. No log_event here, so nothing reached poller.log.
+            #   2. The DB row is written only when the failure lands
+            #      AFTER the INSERT — anything raised by ensure_bare_repo
+            #      or create_worktree (both network-bound, both before
+            #      it) left no row at all.
+            # With an exception whose str() is empty (a bare
+            # asyncio.TimeoutError) the Telegram alert then fell back to
+            # the generic summary and named only the repo. Log first, so
+            # the cause survives regardless of which branch runs next.
+            detail = str(e) or type(e).__name__
+            log_event(
+                _logger,
+                "secops.repo.failed",
+                session_id=session_id,
+                repo=repo,
+                session_row_inserted=session_row_inserted,
+                error_type=type(e).__name__,
+                error=detail[:200],
+            )
             if session_row_inserted:
                 state_db.execute(
                     "UPDATE sessions SET status = ?, summary = ?, "
                     "ended_at = ? WHERE id = ?",
-                    ("failed", f"Error: {e}", int(time.time()), session_id),
+                    ("failed", f"Error: {detail}", int(time.time()), session_id),
                 )
                 state_db.commit()
             results.append(PipelineResult(
                 success=False,
                 session_id=session_id,
-                summary=f"Error processing {repo}",
-                error=str(e),
+                summary=f"Error processing {repo}: {type(e).__name__}: {detail}",
+                # `str(e)` alone can be empty; the notifier picks
+                # `result.error or result.summary`, so an empty error
+                # silently degraded the alert to the bare summary.
+                error=f"{type(e).__name__}: {detail}",
             ))
 
         finally:

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -1430,3 +1430,65 @@ class TestSecopsEdgeCasePromptDirectives:
             or "three exits" in prompt.lower()
         )
 
+
+
+class TestSecopsFailureIsDiagnosable:
+    """A repo whose sweep died before the sessions INSERT left no trace
+    anywhere: no DB row (the UPDATE is guarded on the insert having
+    happened), no log line (the except block had none), and a Telegram
+    alert that fell back to the generic summary because the exception's
+    `str()` was empty. The operator got a repo name and nothing else."""
+
+    @pytest.mark.asyncio
+    async def test_early_failure_logs_and_names_the_cause(
+        self, tmp_path: Path
+    ) -> None:
+        import asyncio
+
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.release_lock.return_value = True
+
+        # Fail in ensure_bare_repo — i.e. BEFORE the sessions row exists,
+        # with the empty-message exception that caused the mystery alert.
+        mock_worktree = AsyncMock()
+        mock_worktree.ensure_bare_repo.side_effect = asyncio.TimeoutError()
+
+        repo = MagicMock(local_path=tmp_path / "repo")
+        repo.name = "owner/big-repo"
+
+        with patch("ctrlrelay.pipelines.secops.log_event") as mock_log:
+            results = await run_secops_all(
+                repos=[repo],
+                dispatcher=MagicMock(),
+                github=MagicMock(),
+                worktree=mock_worktree,
+                dashboard=None,
+                state_db=mock_db,
+                transport=None,
+                contexts_dir=tmp_path / "contexts",
+            )
+
+        assert len(results) == 1
+        result = results[0]
+        assert not result.success
+
+        # The notifier picks `result.error or result.summary`. Both must
+        # now name the exception type rather than stringify to "".
+        assert result.error
+        assert "TimeoutError" in result.error
+        assert "TimeoutError" in result.summary
+        assert "owner/big-repo" in result.summary
+
+        # And the failure must reach the log even with no DB row.
+        failure_events = [
+            call for call in mock_log.call_args_list
+            if len(call.args) > 1 and call.args[1] == "secops.repo.failed"
+        ]
+        assert failure_events, "early failure must emit secops.repo.failed"
+        kwargs = failure_events[0].kwargs
+        assert kwargs["repo"] == "owner/big-repo"
+        assert kwargs["error_type"] == "TimeoutError"
+        assert kwargs["session_row_inserted"] is False

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -1492,3 +1492,46 @@ class TestSecopsFailureIsDiagnosable:
         assert kwargs["repo"] == "owner/big-repo"
         assert kwargs["error_type"] == "TimeoutError"
         assert kwargs["session_row_inserted"] is False
+
+    @pytest.mark.asyncio
+    async def test_logging_failure_does_not_abort_the_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        """The failure logger runs in the last-resort handler, and every
+        later repo depends on that handler returning. A raising logger
+        must not take the whole pass down with it."""
+        import asyncio
+
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.release_lock.return_value = True
+
+        mock_worktree = AsyncMock()
+        mock_worktree.ensure_bare_repo.side_effect = asyncio.TimeoutError()
+
+        first = MagicMock(local_path=tmp_path / "a")
+        first.name = "owner/a"
+        second = MagicMock(local_path=tmp_path / "b")
+        second.name = "owner/b"
+
+        with patch(
+            "ctrlrelay.pipelines.secops.log_event",
+            side_effect=RuntimeError("logging backend down"),
+        ):
+            results = await run_secops_all(
+                repos=[first, second],
+                dispatcher=MagicMock(),
+                github=MagicMock(),
+                worktree=mock_worktree,
+                dashboard=None,
+                state_db=mock_db,
+                transport=None,
+                contexts_dir=tmp_path / "contexts",
+            )
+
+        # Both repos still reported, and each names its real cause.
+        assert len(results) == 2
+        assert all(not r.success for r in results)
+        assert all("TimeoutError" in r.error for r in results)

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1533,3 +1533,69 @@ class TestRunGitCancellation:
 
         mock_proc.kill.assert_called_once()
         mock_proc.wait.assert_awaited()
+
+
+class TestGitTimeoutIsDiagnosable:
+    """A bare `asyncio.TimeoutError()` stringifies to "". That empty
+    string propagated all the way to Telegram, where the secops alert
+    rendered as "Error processing <repo>" with no cause attached."""
+
+    @pytest.mark.asyncio
+    async def test_git_timeout_carries_a_message(self, tmp_path: Path) -> None:
+        import asyncio
+
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        wt = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "bare",
+            timeout=1,
+        )
+
+        async def _always_timeout(*_a: object, **_kw: object) -> None:
+            raise asyncio.TimeoutError()
+
+        with patch(
+            "ctrlrelay.core.worktree.asyncio.wait_for", _always_timeout
+        ):
+            with pytest.raises(asyncio.TimeoutError) as excinfo:
+                await wt._run_git("fetch", "--prune", "origin", timeout=42)
+
+        message = str(excinfo.value)
+        assert message, "timeout must not stringify to an empty string"
+        assert "timed out after 42s" in message
+        assert "fetch --prune origin" in message
+
+    @pytest.mark.asyncio
+    async def test_transfer_timeout_applies_to_clone_and_fetch(
+        self, tmp_path: Path
+    ) -> None:
+        """Network transfers must not inherit the 120s plumbing budget.
+        A 1.8 GB bare clone cannot finish inside it, and the failure was
+        indistinguishable from a hung git."""
+        from unittest.mock import AsyncMock
+
+        from ctrlrelay.core.worktree import (
+            _GIT_TRANSFER_TIMEOUT_SECONDS,
+            WorktreeManager,
+        )
+
+        assert _GIT_TRANSFER_TIMEOUT_SECONDS > 120
+
+        wt = WorktreeManager(
+            worktrees_dir=tmp_path / "wt",
+            bare_repos_dir=tmp_path / "bare",
+        )
+        wt._run_git = AsyncMock(return_value="")  # type: ignore[method-assign]
+
+        # Bare repo absent -> clone path.
+        await wt.ensure_bare_repo("owner/repo")
+        clone_kwargs = wt._run_git.await_args_list[0].kwargs
+        assert clone_kwargs["timeout"] == _GIT_TRANSFER_TIMEOUT_SECONDS
+
+        # Bare repo present -> fetch path.
+        wt._get_bare_repo_path("owner/repo").mkdir(parents=True, exist_ok=True)
+        wt._run_git.reset_mock()
+        await wt.ensure_bare_repo("owner/repo")
+        fetch_kwargs = wt._run_git.await_args_list[0].kwargs
+        assert fetch_kwargs["timeout"] == _GIT_TRANSFER_TIMEOUT_SECONDS


### PR DESCRIPTION
## Problem

A scheduled sweep reported:

```
❌ Scheduled secops failed on AInvirion/ai-model-knowledge-base
Session: `secops-AInvirion-ai-model-knowledge-base-6fd3f496`

Error processing AInvirion/ai-model-knowledge-base
```

That message is the whole record. The session id appears in no log line and no `sessions` row — the failure was untraceable after the fact.

Three separate holes lined up:

1. **No log call.** The `except Exception` in `run_secops_all` never logged, so `poller.log` stayed silent.
2. **No DB row.** The failure UPDATE is guarded on `session_row_inserted`. But `ensure_bare_repo` and `create_worktree` — both network-bound — run *ahead* of that INSERT, so anything they raise leaves no row.
3. **No message.** `_run_git` re-raises a bare `asyncio.TimeoutError`, whose `str()` is `""`. The notifier picks `result.error or result.summary` (`cli.py:1553`), so the empty error silently degraded the alert to the generic summary.

The likely trigger: `ai-model-knowledge-base` is a **1.8 GB** bare repo, and `ensure_bare_repo`'s fetch inherited the 120s timeout meant for local git plumbing.

## Change

- Log `secops.repo.failed` before either branch, carrying `error_type` and `session_row_inserted`, so an early failure is visible even with no DB row.
- Fall back to the exception type name when `str(e)` is empty — in `summary`, in `error`, and in the persisted row.
- Re-raise git timeouts with the command, timeout and cwd attached. Same exception type, since `pr_watcher`, `pr_verifier` and `cli` all filter on `TimeoutError`.
- Give bare clone and fetch `_GIT_TRANSFER_TIMEOUT_SECONDS = 1800` instead of the 120s plumbing budget. Matches claude's own `default_timeout_seconds`; only `semantic-copycat` (2.1 GB) is in the same size band.

## Verification

- 3 new tests: an early `ensure_bare_repo` failure now logs and names the cause; a git timeout stringifies to something useful; clone and fetch both pass the transfer timeout.
- Full suite: **743 passed**.
- `ruff check`: clean.

## Note

This does not stop the failure — a 1.8 GB fetch may still be slow. It makes the next one legible instead of a repo name with no cause.
