### PR TITLE
feat(transport): expire questions nobody can answer any more

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **`transport.telegram.question_ttl_seconds`: unanswered questions now
+  expire.** A `pending_resumes` row deliberately outlives the in-session
+  wait so a late reply can still drive the resume — but nothing ever
+  retired one, so the table only grew. Measured on one deployment: 46
+  questions posted, 4 ever answered, 16 still live and five repos
+  re-asking the same question on consecutive days. An expired row stops
+  being offered as the routing target for an orphan Telegram reply, and
+  a late answer can no longer revive it. Defaults to 172800 (48h),
+  minimum 3600.
+- **New hourly `question_expiry_sweeper` job.** Retires a question early
+  once every issue and PR it cites is closed or merged — the case where
+  someone merged the PR by hand and the question became meaningless
+  rather than merely unanswered. Fails safe in both directions: a
+  question citing nothing is never expired this way, and any probe error
+  leaves the row alone, because re-asking a dead question is recoverable
+  while dropping a live one is not. The TTL pass runs first and needs no
+  network, so a GitHub outage still lets age-based expiry make progress.
+
 - **`transport.telegram.ask_timeout_seconds`: how long a pipeline waits on
   your Telegram reply.** Was a hard-coded 300s in `SocketTransport.ask`,
   with no call site overriding it and no way to configure it. Defaults to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   leaves the row alone, because re-asking a dead question is recoverable
   while dropping a live one is not. The TTL pass runs first and needs no
   network, so a GitHub outage still lets age-based expiry make progress.
+  Probing is capped at 200 numbers per run so one pass cannot outlive its
+  own hourly interval — unbounded, a 2000-row backlog against a slow
+  GitHub would be 8.3h of serialized `gh api` reads. Rows past the cap
+  are examined on the next run, and the TTL pass retires them on age
+  regardless.
 
 - **`transport.telegram.ask_timeout_seconds`: how long a pipeline waits on
   your Telegram reply.** Was a hard-coded 300s in `SocketTransport.ask`,

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -118,6 +118,8 @@ transport:
 | `bot_token_env` | string | `"CTRLRELAY_TELEGRAM_TOKEN"` | Name of the environment variable holding the bot token. ctrlrelay never reads the token directly — only the variable name. |
 | `chat_id` | int | `0` | Telegram chat ID the bridge sends messages to and accepts replies from. |
 | `socket_path` | path | `"~/.ctrlrelay/ctrlrelay.sock"` | Unix socket path the bridge listens on. Pipelines connect to this socket as clients. |
+| `ask_timeout_seconds` | int | `900` | How long a pipeline blocks waiting on your reply in-session. Minimum `60`. A reply arriving later still works: the question is persisted to `pending_resumes` and the every-minute sweeper drives the resume. |
+| `question_ttl_seconds` | int | `172800` (48h) | How long an **unanswered** question stays routable before it is retired. Minimum `3600`. Without a ceiling those rows never die — a question whose PR was merged by hand weeks ago stays a live target for an orphan reply. The hourly `question_expiry_sweeper` also retires a question early once every issue/PR it cites is closed or merged. |
 
 See [Telegram bridge]({{ '/bridge/' | relative_url }}) for the full setup walkthrough.
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -11,6 +11,7 @@ from ctrlrelay import __version__
 from ctrlrelay.core.config import ConfigError, load_config, resolve_config_path
 from ctrlrelay.core.github import GitHubCLI, GitHubError
 from ctrlrelay.core.pr_verifier import PRVerifier
+from ctrlrelay.core.question_expiry import expire_stale_questions
 
 app = typer.Typer(
     name="ctrlrelay",
@@ -1591,6 +1592,38 @@ def poller_start(
                     except Exception:
                         pass
 
+        async def _run_question_expiry_sweeper() -> None:
+            """Retire BLOCKED questions the operator can no longer
+            usefully answer: aged past the TTL, or whose cited PRs and
+            issues have all been closed or merged outside ctrlrelay.
+
+            Hourly, not per-minute: expiry is never urgent, and the
+            resolved-elsewhere pass costs one `gh api` read per cited
+            number. TTL runs first and needs no network, so a GitHub
+            outage still lets the age-based sweep make progress.
+            """
+            ttl = getattr(
+                getattr(config.transport, "telegram", None),
+                "question_ttl_seconds",
+                None,
+            )
+            if not ttl:
+                return
+            try:
+                expired = await expire_stale_questions(
+                    state_db, github, ttl_seconds=ttl,
+                )
+            except Exception as e:
+                console.print(
+                    f"[yellow]question_expiry_sweeper: failed ({e})[/yellow]"
+                )
+                return
+            for row in expired:
+                console.print(
+                    f"[dim]question_expiry: retired "
+                    f"{row['session_id']} ({row['expired_reason']})[/dim]"
+                )
+
         async def _run_pending_resume_sweeper() -> None:
             """Drain pending_resumes rows that an operator answered via
             Telegram while the original BLOCKED session had already torn
@@ -1917,6 +1950,16 @@ def poller_start(
                 cron_expr="* * * * *",
                 func=_run_pending_resume_sweeper,
             )
+            # Retire questions nobody can act on any more. Without
+            # this the pending_resumes table only grows: unanswered
+            # rows stay live targets for orphan reply routing and get
+            # re-posted every sweep, including ones whose PR was
+            # merged by hand days earlier.
+            scheduler.add_cron_job(
+                name="question_expiry_sweeper",
+                cron_expr="0 * * * *",
+                func=_run_question_expiry_sweeper,
+            )
             # Register the personalization auto-pull only when the
             # operator has both configured the personalization block
             # AND set a cron expression. Either alone is intentional
@@ -1940,7 +1983,8 @@ def poller_start(
             console.print(
                 f"[dim]Scheduler: secops cron={config.schedules.secops_cron} "
                 f"tz={config.timezone} | "
-                f"pending_resume_sweeper=every 1m"
+                f"pending_resume_sweeper=every 1m | "
+                f"question_expiry_sweeper=hourly"
                 f"{personalization_cron_summary}[/dim]"
             )
 

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -118,6 +118,16 @@ class TelegramConfig(BaseModel):
     #
     # Lower bound of 60s: shorter is a misconfiguration, not a preference.
     ask_timeout_seconds: int = Field(default=900, ge=60)
+    # How long an UNANSWERED question stays routable before it is
+    # retired. `ask_timeout_seconds` only bounds the in-session wait;
+    # the pending_resumes row outlives it so a later reply can still
+    # drive the resume. Without a ceiling those rows never die: a
+    # question whose PR was merged by hand weeks ago stays a live
+    # target for an orphan Telegram reply, and each sweep re-posts it.
+    # 48h spans a weekend-adjacent gap without letting a stale decision
+    # act on a PR whose state has since moved on. Lower bound of 3600s:
+    # anything shorter races the operator's own working day.
+    question_ttl_seconds: int = Field(default=172800, ge=3600)
 
     @field_validator("socket_path", mode="before")
     @classmethod

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -376,6 +376,32 @@ class GitHubCLI:
         )
         return json.loads(output)
 
+    async def get_issue_or_pr_state(
+        self,
+        repo: str,
+        number: int,
+        *,
+        timeout: int | None = None,
+    ) -> dict[str, Any]:
+        """Return ``{"number", "state", "is_pr", "merged"}`` for a
+        number that may name either an issue or a PR.
+
+        A BLOCKED question only ever cites ``#N``; nothing in the text
+        says which kind it is. The REST ``issues`` endpoint covers both
+        — GitHub models a PR as an issue — so one call answers it
+        without guessing and retrying. ``state`` is ``"open"`` or
+        ``"closed"``; ``merged`` is only meaningful when ``is_pr``.
+        """
+        output = await self._run_gh(
+            "api", f"repos/{repo}/issues/{number}",
+            "--jq",
+            '{number: .number, state: .state, '
+            'is_pr: (.pull_request != null), '
+            'merged: (.pull_request.merged_at != null)}',
+            timeout=timeout,
+        )
+        return json.loads(output)
+
     async def comment_on_issue(
         self,
         repo: str,

--- a/src/ctrlrelay/core/question_expiry.py
+++ b/src/ctrlrelay/core/question_expiry.py
@@ -1,0 +1,148 @@
+"""Retirement of BLOCKED questions the operator can no longer usefully answer.
+
+A ``pending_resumes`` row deliberately outlives the in-session wait: the
+transport gives up after ``ask_timeout_seconds``, but the row survives so
+a reply arriving hours later still drives the resume. Nothing ever
+retired those rows, so two failure modes accumulated:
+
+- **Nobody answered.** Real numbers from one deployment: 46 questions
+  posted, 4 ever answered. The unanswered 42 stayed live targets for
+  orphan reply routing, and each sweep re-posted the same question.
+- **Somebody acted outside ctrlrelay.** The PR got merged by hand, or
+  the issue was closed by a teammate. The question is now not just
+  unanswered but meaningless, and an answer to it would drive a resume
+  against state that has already moved on.
+
+This module retires both. It only ever sets ``expired_at`` on rows that
+are still unanswered, so a reply that lands in the same tick wins.
+"""
+
+from __future__ import annotations
+
+import re
+import time
+from typing import Any
+
+from ctrlrelay.core.github import GitHubCLI, GitHubError
+from ctrlrelay.core.obs import get_logger, log_event
+from ctrlrelay.core.state import StateDB
+
+_logger = get_logger("core.question_expiry")
+
+# Captures both "PR #60" and "#60" forms the agent uses interchangeably
+# in BLOCKED questions. The negative-lookahead on trailing digits avoids
+# matching CVE-2026-... style identifiers; PR numbers are always >= 1.
+_PR_NUM_RE = re.compile(r"(?:PR\s*)?#(\d+)(?!\d)", re.IGNORECASE)
+
+# Per-call cap on the `gh api` probe. The sweep runs on a schedule and
+# holds no repo lock, but a hung gh would still stall the whole pass;
+# a single REST read has no business taking longer than this.
+_STATE_PROBE_TIMEOUT_SECONDS = 15
+
+EXPIRY_REASON_TTL = "ttl"
+EXPIRY_REASON_RESOLVED = "resolved_elsewhere"
+
+
+def extract_referenced_numbers(question: str) -> list[str]:
+    """Pull deduplicated issue/PR numbers out of a question, in the
+    order the agent listed them."""
+    seen: set[str] = set()
+    out: list[str] = []
+    for n in _PR_NUM_RE.findall(question or ""):
+        if n in seen:
+            continue
+        seen.add(n)
+        out.append(n)
+    return out
+
+
+async def _all_references_resolved(
+    github: GitHubCLI,
+    *,
+    repo: str,
+    numbers: list[str],
+) -> bool:
+    """True when every cited number is closed or merged.
+
+    Conservative on purpose. One still-open reference means the question
+    retains something to decide, so the row stays. Any probe error at
+    all — network, auth, a number that names nothing — returns False:
+    we would rather re-ask a dead question than silently drop a live
+    one, since the operator can ignore noise but cannot recover a
+    question that was never posted.
+    """
+    if not numbers:
+        return False
+
+    for number in numbers:
+        try:
+            state = await github.get_issue_or_pr_state(
+                repo,
+                int(number),
+                timeout=_STATE_PROBE_TIMEOUT_SECONDS,
+            )
+        except (GitHubError, TimeoutError, OSError, ValueError):
+            return False
+        except Exception:
+            return False
+
+        if (state.get("state") or "").lower() != "closed":
+            return False
+
+    return True
+
+
+async def expire_stale_questions(
+    state_db: StateDB,
+    github: GitHubCLI | None,
+    *,
+    ttl_seconds: int,
+    now: int | None = None,
+) -> list[dict[str, Any]]:
+    """Retire questions that aged out or whose subject is already
+    resolved. Returns the rows actually expired.
+
+    TTL runs first and needs no network, so a GitHub outage still lets
+    the age-based sweep make progress. ``github=None`` disables only the
+    resolved-elsewhere pass.
+    """
+    now = int(time.time()) if now is None else now
+    expired: list[dict[str, Any]] = []
+
+    for row in state_db.list_expirable_pending_resumes(now - ttl_seconds):
+        if state_db.expire_pending_resume(row["session_id"], EXPIRY_REASON_TTL):
+            expired.append({**row, "expired_reason": EXPIRY_REASON_TTL})
+            log_event(
+                _logger,
+                "question.expired",
+                session_id=row["session_id"],
+                repo=row["repo"],
+                pipeline=row["pipeline"],
+                reason=EXPIRY_REASON_TTL,
+                age_seconds=now - int(row["created_at"]),
+            )
+
+    if github is None:
+        return expired
+
+    for row in state_db.list_unanswered_pending_resumes():
+        numbers = extract_referenced_numbers(row["question"])
+        if not await _all_references_resolved(
+            github, repo=row["repo"], numbers=numbers
+        ):
+            continue
+        if state_db.expire_pending_resume(
+            row["session_id"], EXPIRY_REASON_RESOLVED
+        ):
+            expired.append({**row, "expired_reason": EXPIRY_REASON_RESOLVED})
+            log_event(
+                _logger,
+                "question.expired",
+                session_id=row["session_id"],
+                repo=row["repo"],
+                pipeline=row["pipeline"],
+                reason=EXPIRY_REASON_RESOLVED,
+                references=",".join(numbers),
+            )
+
+    return expired

--- a/src/ctrlrelay/core/question_expiry.py
+++ b/src/ctrlrelay/core/question_expiry.py
@@ -137,19 +137,40 @@ async def expire_stale_questions(
 
     probes_used = 0
     for row in state_db.list_unanswered_pending_resumes():
-        if probes_used >= _MAX_RESOLVED_PROBES_PER_RUN:
-            log_event(
-                _logger,
-                "question.expiry.probe_budget_exhausted",
-                budget=_MAX_RESOLVED_PROBES_PER_RUN,
-                reason="remaining rows deferred to the next run",
-            )
-            break
         numbers = extract_referenced_numbers(row["question"])
         # Rows citing nothing are skipped without spending budget —
         # they can never be resolution-expired anyway.
         if not numbers:
             continue
+
+        # Check the budget against what this row will actually COST,
+        # before spending any of it. Testing `probes_used` alone lets a
+        # single row overshoot without limit: one question citing 300
+        # numbers passes a `0 >= 200` check and then issues all 300
+        # calls, ~75min of a job that fires hourly.
+        if len(numbers) > _MAX_RESOLVED_PROBES_PER_RUN:
+            # Bigger than any run's whole budget, so it can never be
+            # resolution-checked — expiry needs EVERY reference closed.
+            # Skip rather than break: one pathological row must not
+            # starve the rest. The TTL pass still retires it on age.
+            log_event(
+                _logger,
+                "question.expiry.row_exceeds_budget",
+                session_id=row["session_id"],
+                repo=row["repo"],
+                references=len(numbers),
+                budget=_MAX_RESOLVED_PROBES_PER_RUN,
+            )
+            continue
+        if probes_used + len(numbers) > _MAX_RESOLVED_PROBES_PER_RUN:
+            log_event(
+                _logger,
+                "question.expiry.probe_budget_exhausted",
+                budget=_MAX_RESOLVED_PROBES_PER_RUN,
+                probes_used=probes_used,
+                reason="remaining rows deferred to the next run",
+            )
+            break
         probes_used += len(numbers)
         if not await _all_references_resolved(
             github, repo=row["repo"], numbers=numbers

--- a/src/ctrlrelay/core/question_expiry.py
+++ b/src/ctrlrelay/core/question_expiry.py
@@ -39,6 +39,16 @@ _PR_NUM_RE = re.compile(r"(?:PR\s*)?#(\d+)(?!\d)", re.IGNORECASE)
 # a single REST read has no business taking longer than this.
 _STATE_PROBE_TIMEOUT_SECONDS = 15
 
+# Ceiling on probes per run, so one pass cannot outlive its own cron
+# interval. Unbounded, the cost is one serialized `gh api` call per
+# cited number: 2000 backlogged rows against a slow GitHub is
+# 2000 x 15s = 8.3h of a job that fires hourly, and the sweep would
+# spend all day overlapping itself. Rows past the cap are simply
+# examined on the next run — expiry is never urgent, and the TTL pass
+# retires them on age regardless of whether they were ever probed.
+# 200 x 15s worst case = 50min, inside the hour with room to spare.
+_MAX_RESOLVED_PROBES_PER_RUN = 200
+
 EXPIRY_REASON_TTL = "ttl"
 EXPIRY_REASON_RESOLVED = "resolved_elsewhere"
 
@@ -125,8 +135,22 @@ async def expire_stale_questions(
     if github is None:
         return expired
 
+    probes_used = 0
     for row in state_db.list_unanswered_pending_resumes():
+        if probes_used >= _MAX_RESOLVED_PROBES_PER_RUN:
+            log_event(
+                _logger,
+                "question.expiry.probe_budget_exhausted",
+                budget=_MAX_RESOLVED_PROBES_PER_RUN,
+                reason="remaining rows deferred to the next run",
+            )
+            break
         numbers = extract_referenced_numbers(row["question"])
+        # Rows citing nothing are skipped without spending budget —
+        # they can never be resolution-expired anyway.
+        if not numbers:
+            continue
+        probes_used += len(numbers)
         if not await _all_references_resolved(
             github, repo=row["repo"], numbers=numbers
         ):

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -70,7 +70,9 @@ CREATE TABLE IF NOT EXISTS pending_resumes (
     created_at INTEGER NOT NULL,
     answer TEXT,
     answered_at INTEGER,
-    resumed_at INTEGER
+    resumed_at INTEGER,
+    expired_at INTEGER,
+    expired_reason TEXT
 );
 
 -- In-flight PR merge watchers that must survive a poller restart. Without
@@ -155,6 +157,21 @@ class StateDB:
         if pr_watches_cols and "cleanup_phase" not in pr_watches_cols:
             self._conn.execute(
                 "ALTER TABLE pr_watches ADD COLUMN cleanup_phase TEXT"
+            )
+
+        pending_cols = {
+            row[1]
+            for row in self._conn.execute(
+                "PRAGMA table_info(pending_resumes)"
+            ).fetchall()
+        }
+        if pending_cols and "expired_at" not in pending_cols:
+            self._conn.execute(
+                "ALTER TABLE pending_resumes ADD COLUMN expired_at INTEGER"
+            )
+        if pending_cols and "expired_reason" not in pending_cols:
+            self._conn.execute(
+                "ALTER TABLE pending_resumes ADD COLUMN expired_reason TEXT"
             )
 
     def close(self) -> None:
@@ -314,13 +331,14 @@ class StateDB:
         if pipeline is None:
             row = self._conn.execute(
                 "SELECT * FROM pending_resumes "
-                "WHERE answered_at IS NULL "
+                "WHERE answered_at IS NULL AND expired_at IS NULL "
                 "ORDER BY created_at ASC LIMIT 1"
             ).fetchone()
         else:
             row = self._conn.execute(
                 "SELECT * FROM pending_resumes "
-                "WHERE answered_at IS NULL AND pipeline = ? "
+                "WHERE answered_at IS NULL AND expired_at IS NULL "
+                "AND pipeline = ? "
                 "ORDER BY created_at ASC LIMIT 1",
                 (pipeline,),
             ).fetchone()
@@ -333,8 +351,43 @@ class StateDB:
         about repo B onto repo A."""
         rows = self._conn.execute(
             "SELECT * FROM pending_resumes "
-            "WHERE answered_at IS NULL "
+            "WHERE answered_at IS NULL AND expired_at IS NULL "
             "ORDER BY created_at ASC"
+        ).fetchall()
+        return [dict(row) for row in rows]
+
+    def expire_pending_resume(self, session_id: str, reason: str) -> bool:
+        """Retire an unanswered question so it stops being routable.
+
+        A question nobody can act on is worse than no question: the
+        bridge keeps offering it as a target for an orphan reply, and
+        the operator keeps seeing it re-posted. Guarded on
+        ``answered_at IS NULL`` so a reply that landed in the same tick
+        wins the race — expiry must never discard a real answer.
+
+        Returns True iff a row was expired."""
+        cursor = self._conn.execute(
+            """UPDATE pending_resumes
+               SET expired_at = ?, expired_reason = ?
+               WHERE session_id = ? AND answered_at IS NULL
+                 AND expired_at IS NULL""",
+            (int(time.time()), reason, session_id),
+        )
+        self._conn.commit()
+        return cursor.rowcount > 0
+
+    def list_expirable_pending_resumes(
+        self,
+        older_than_ts: int,
+    ) -> list[dict[str, Any]]:
+        """Unanswered, unexpired questions created at or before
+        ``older_than_ts``. The TTL sweep's candidate set."""
+        rows = self._conn.execute(
+            "SELECT * FROM pending_resumes "
+            "WHERE answered_at IS NULL AND expired_at IS NULL "
+            "AND created_at <= ? "
+            "ORDER BY created_at ASC",
+            (older_than_ts,),
         ).fetchall()
         return [dict(row) for row in rows]
 
@@ -345,7 +398,8 @@ class StateDB:
         cursor = self._conn.execute(
             """UPDATE pending_resumes
                SET answer = ?, answered_at = ?
-               WHERE session_id = ? AND answered_at IS NULL""",
+               WHERE session_id = ? AND answered_at IS NULL
+                 AND expired_at IS NULL""",
             (answer, int(time.time()), session_id),
         )
         self._conn.commit()

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import asyncio
-import re
 import time
 import uuid
 from dataclasses import dataclass
@@ -14,6 +13,7 @@ from ctrlrelay.core.checkpoint import CheckpointStatus
 from ctrlrelay.core.dispatcher import AgentAdapter, SessionResult
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
+from ctrlrelay.core.question_expiry import extract_referenced_numbers
 from ctrlrelay.core.state import StateDB
 from ctrlrelay.core.worktree import WorktreeManager
 from ctrlrelay.dashboard.client import DashboardClient, EventPayload
@@ -31,25 +31,10 @@ DEFAULT_MAX_BLOCKED_ROUNDS = 5
 # changed maintainer, etc.).
 DECISION_RECALL_SECONDS = 30 * 86400
 
-# Captures both "PR #60" and "#60" forms the agent uses interchangeably
-# in BLOCKED questions. The negative-lookahead on `#0` avoids matching
-# CVE-2026-... style identifiers; PR numbers are always >= 1.
-_PR_NUM_RE = re.compile(r"(?:PR\s*)?#(\d+)(?!\d)", re.IGNORECASE)
-
-
-def _extract_pr_numbers(question: str) -> list[str]:
-    """Pull deduplicated PR numbers out of a BLOCKED question so we
-    can record one operator-decision row per PR. Order-preserving so
-    a multi-PR question like 'approve #60, #61, #62?' records the
-    decision against each in the order the agent listed them."""
-    seen: set[str] = set()
-    out: list[str] = []
-    for n in _PR_NUM_RE.findall(question or ""):
-        if n in seen:
-            continue
-        seen.add(n)
-        out.append(n)
-    return out
+# Shared with the question-expiry sweep, which parses the same "#N"
+# citations out of the same questions to decide whether a question's
+# subject has already been resolved elsewhere. One regex, one meaning.
+_extract_pr_numbers = extract_referenced_numbers
 
 
 def _record_decisions_from_answer(

--- a/tests/test_question_expiry.py
+++ b/tests/test_question_expiry.py
@@ -243,3 +243,64 @@ class TestMigration:
         assert {"expired_at", "expired_reason"} <= cols
         # The pre-existing row survives and stays routable.
         assert len(db.list_unanswered_pending_resumes()) == 1
+
+
+class TestProbeBudget:
+    """One resolved-elsewhere pass must not outlive its own cron
+    interval. Unbounded it is one serialized `gh api` call per cited
+    number: 2000 backlogged rows against a slow GitHub is 8.3h of a job
+    that fires hourly."""
+
+    @pytest.mark.asyncio
+    async def test_probe_count_is_capped_per_run(self, db: StateDB) -> None:
+        from ctrlrelay.core import question_expiry
+
+        cap = question_expiry._MAX_RESOLVED_PROBES_PER_RUN
+        for i in range(cap + 25):
+            _add(db, f"s{i}", f"Approve #{i + 1}?", age_seconds=60)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=False)
+
+        await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert github.get_issue_or_pr_state.await_count <= cap
+
+    @pytest.mark.asyncio
+    async def test_deferred_rows_are_still_processed_next_run(
+        self, db: StateDB
+    ) -> None:
+        """Hitting the cap defers work; it must not drop it."""
+        from ctrlrelay.core import question_expiry
+
+        cap = question_expiry._MAX_RESOLVED_PROBES_PER_RUN
+        for i in range(cap + 5):
+            _add(db, f"s{i}", f"Approve #{i + 1}?", age_seconds=60)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=True)
+
+        first = await expire_stale_questions(db, github, ttl_seconds=TTL)
+        second = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert len(first) == cap
+        assert len(second) == 5
+        assert db.list_unanswered_pending_resumes() == []
+
+    @pytest.mark.asyncio
+    async def test_rows_citing_nothing_do_not_consume_budget(
+        self, db: StateDB
+    ) -> None:
+        """A repo full of 'Enable Dependabot alerts?' questions must not
+        starve the rows that can actually be resolution-expired."""
+        for i in range(50):
+            _add(db, f"noref{i}", "Enable Dependabot alerts?", age_seconds=60)
+        _add(db, "real", "Approve #7?", age_seconds=60)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=True)
+
+        expired = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert [r["session_id"] for r in expired] == ["real"]
+        assert github.get_issue_or_pr_state.await_count == 1

--- a/tests/test_question_expiry.py
+++ b/tests/test_question_expiry.py
@@ -1,0 +1,245 @@
+"""Tests for retiring BLOCKED questions nobody can act on."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+from unittest.mock import AsyncMock
+
+import pytest
+
+from ctrlrelay.core.question_expiry import (
+    EXPIRY_REASON_RESOLVED,
+    EXPIRY_REASON_TTL,
+    expire_stale_questions,
+    extract_referenced_numbers,
+)
+from ctrlrelay.core.state import StateDB
+
+TTL = 172800  # 48h
+
+
+@pytest.fixture
+def db(tmp_path: Path) -> StateDB:
+    return StateDB(tmp_path / "state.db")
+
+
+def _add(db: StateDB, session_id: str, question: str, age_seconds: int) -> None:
+    db.add_pending_resume(
+        session_id=session_id,
+        pipeline="secops",
+        repo="owner/repo",
+        question=question,
+    )
+    db.execute(
+        "UPDATE pending_resumes SET created_at = ? WHERE session_id = ?",
+        (int(time.time()) - age_seconds, session_id),
+    )
+    db.commit()
+
+
+def _state(*, closed: bool, is_pr: bool = True) -> dict[str, object]:
+    return {
+        "number": 1,
+        "state": "closed" if closed else "open",
+        "is_pr": is_pr,
+        "merged": closed and is_pr,
+    }
+
+
+class TestExtractReferencedNumbers:
+    def test_matches_bare_and_prefixed_forms(self) -> None:
+        q = "Merged #214. Approve PR #213 and #212?"
+        assert extract_referenced_numbers(q) == ["214", "213", "212"]
+
+    def test_ignores_cve_identifiers(self) -> None:
+        """A CVE id must not be read as a PR number, or a question about
+        an unfixed CVE would look 'resolved' the moment some unrelated
+        low-numbered PR closed."""
+        q = "pyarrow CVE-2026-25087 (high, needs >=23.0.1) has no PR"
+        assert extract_referenced_numbers(q) == []
+
+
+class TestTTLExpiry:
+    @pytest.mark.asyncio
+    async def test_expires_questions_past_the_ttl(self, db: StateDB) -> None:
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+
+        expired = await expire_stale_questions(db, None, ttl_seconds=TTL)
+
+        assert [r["session_id"] for r in expired] == ["old"]
+        assert expired[0]["expired_reason"] == EXPIRY_REASON_TTL
+        assert db.list_unanswered_pending_resumes() == []
+
+    @pytest.mark.asyncio
+    async def test_leaves_fresh_questions_alone(self, db: StateDB) -> None:
+        _add(db, "fresh", "Approve #1?", age_seconds=TTL - 60)
+
+        assert await expire_stale_questions(db, None, ttl_seconds=TTL) == []
+        assert len(db.list_unanswered_pending_resumes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_answered_questions_are_never_expired(
+        self, db: StateDB
+    ) -> None:
+        """An answer that landed before the sweep must survive it —
+        otherwise the sweeper would discard work the operator did."""
+        _add(db, "answered", "Approve #1?", age_seconds=TTL + 60)
+        assert db.answer_pending_resume("answered", "yes, merge")
+
+        assert await expire_stale_questions(db, None, ttl_seconds=TTL) == []
+        assert [r["session_id"] for r in db.list_pending_resumes_to_execute()] == [
+            "answered"
+        ]
+
+
+class TestResolvedElsewhereExpiry:
+    @pytest.mark.asyncio
+    async def test_expires_when_every_reference_is_closed(
+        self, db: StateDB
+    ) -> None:
+        _add(db, "done", "Approve #12 and #13?", age_seconds=60)
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=True)
+
+        expired = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert [r["session_id"] for r in expired] == ["done"]
+        assert expired[0]["expired_reason"] == EXPIRY_REASON_RESOLVED
+        assert db.list_unanswered_pending_resumes() == []
+
+    @pytest.mark.asyncio
+    async def test_keeps_question_when_one_reference_is_open(
+        self, db: StateDB
+    ) -> None:
+        _add(db, "partial", "Approve #12 and #13?", age_seconds=60)
+        github = AsyncMock()
+        github.get_issue_or_pr_state.side_effect = [
+            _state(closed=True),
+            _state(closed=False),
+        ]
+
+        assert await expire_stale_questions(db, github, ttl_seconds=TTL) == []
+        assert len(db.list_unanswered_pending_resumes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_keeps_question_when_it_cites_nothing(
+        self, db: StateDB
+    ) -> None:
+        """'Enable Dependabot alerts?' names no PR. Vacuous truth over an
+        empty list would expire every such question instantly."""
+        _add(db, "no-refs", "Enable Dependabot alerts for this repo?", 60)
+        github = AsyncMock()
+
+        assert await expire_stale_questions(db, github, ttl_seconds=TTL) == []
+        assert len(db.list_unanswered_pending_resumes()) == 1
+        github.get_issue_or_pr_state.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_probe_failure_keeps_the_question(self, db: StateDB) -> None:
+        """Fail safe: re-asking a dead question is recoverable, dropping
+        a live one is not."""
+        from ctrlrelay.core.github import GitHubError
+
+        _add(db, "flaky", "Approve #12?", age_seconds=60)
+        github = AsyncMock()
+        github.get_issue_or_pr_state.side_effect = GitHubError("api down")
+
+        assert await expire_stale_questions(db, github, ttl_seconds=TTL) == []
+        assert len(db.list_unanswered_pending_resumes()) == 1
+
+    @pytest.mark.asyncio
+    async def test_ttl_pass_runs_without_github(self, db: StateDB) -> None:
+        """A GitHub outage must not stall age-based expiry."""
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+
+        expired = await expire_stale_questions(db, None, ttl_seconds=TTL)
+
+        assert [r["session_id"] for r in expired] == ["old"]
+
+
+class TestExpiredRowsAreInert:
+    @pytest.mark.asyncio
+    async def test_expired_question_is_not_routable(self, db: StateDB) -> None:
+        """The bridge routes an orphan reply to the oldest unanswered
+        question. An expired one must not be that target."""
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+        _add(db, "live", "Approve #2?", age_seconds=60)
+
+        await expire_stale_questions(db, None, ttl_seconds=TTL)
+
+        oldest = db.get_oldest_unanswered_pending_resume()
+        assert oldest is not None
+        assert oldest["session_id"] == "live"
+
+    @pytest.mark.asyncio
+    async def test_late_answer_cannot_revive_an_expired_question(
+        self, db: StateDB
+    ) -> None:
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+        await expire_stale_questions(db, None, ttl_seconds=TTL)
+
+        assert db.answer_pending_resume("old", "yes") is False
+        assert db.list_pending_resumes_to_execute() == []
+
+    @pytest.mark.asyncio
+    async def test_expiry_is_idempotent(self, db: StateDB) -> None:
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+
+        first = await expire_stale_questions(db, None, ttl_seconds=TTL)
+        second = await expire_stale_questions(db, None, ttl_seconds=TTL)
+
+        assert len(first) == 1
+        assert second == []
+
+    def test_reason_is_persisted(self, db: StateDB) -> None:
+        _add(db, "old", "Approve #1?", age_seconds=TTL + 60)
+        assert db.expire_pending_resume("old", EXPIRY_REASON_TTL)
+
+        row = db.execute(
+            "SELECT expired_at, expired_reason FROM pending_resumes "
+            "WHERE session_id = ?",
+            ("old",),
+        ).fetchone()
+        assert row["expired_at"] is not None
+        assert row["expired_reason"] == EXPIRY_REASON_TTL
+
+
+class TestMigration:
+    def test_existing_db_without_expiry_columns_is_migrated(
+        self, tmp_path: Path
+    ) -> None:
+        """Real deployments already have a pending_resumes table with 16
+        rows in it; CREATE TABLE IF NOT EXISTS won't add the columns."""
+        import sqlite3
+
+        db_path = tmp_path / "old.db"
+        conn = sqlite3.connect(db_path)
+        conn.execute(
+            """CREATE TABLE pending_resumes (
+                   session_id TEXT PRIMARY KEY,
+                   pipeline TEXT NOT NULL,
+                   repo TEXT NOT NULL,
+                   question TEXT NOT NULL,
+                   created_at INTEGER NOT NULL,
+                   answer TEXT,
+                   answered_at INTEGER,
+                   resumed_at INTEGER
+               )"""
+        )
+        conn.execute(
+            "INSERT INTO pending_resumes VALUES "
+            "('s1','secops','o/r','Approve #1?',1,NULL,NULL,NULL)"
+        )
+        conn.commit()
+        conn.close()
+
+        db = StateDB(db_path)
+
+        cols = {
+            row[1]
+            for row in db.execute("PRAGMA table_info(pending_resumes)").fetchall()
+        }
+        assert {"expired_at", "expired_reason"} <= cols
+        # The pre-existing row survives and stays routable.
+        assert len(db.list_unanswered_pending_resumes()) == 1

--- a/tests/test_question_expiry.py
+++ b/tests/test_question_expiry.py
@@ -304,3 +304,65 @@ class TestProbeBudget:
 
         assert [r["session_id"] for r in expired] == ["real"]
         assert github.get_issue_or_pr_state.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_a_single_row_cannot_overshoot_the_cap(
+        self, db: StateDB
+    ) -> None:
+        """Checking `probes_used` alone lets one row blow past the cap:
+        a question citing 300 numbers passes `0 >= 200` and then issues
+        all 300 calls. The budget must be tested against what the row
+        will cost, before any of it is spent."""
+        from ctrlrelay.core import question_expiry
+
+        cap = question_expiry._MAX_RESOLVED_PROBES_PER_RUN
+        many = " ".join(f"#{i}" for i in range(1, cap))  # just under cap
+        _add(db, "wide", f"Approve {many}?", age_seconds=60)
+        _add(db, "also-wide", f"Approve {many}?", age_seconds=60)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=False)
+
+        await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert github.get_issue_or_pr_state.await_count <= cap
+
+    @pytest.mark.asyncio
+    async def test_oversized_row_is_skipped_not_blocking(
+        self, db: StateDB
+    ) -> None:
+        """A row citing more numbers than a whole run's budget can never
+        be resolution-checked — expiry needs every reference closed. It
+        must be skipped, not allowed to starve every row behind it."""
+        from ctrlrelay.core import question_expiry
+
+        cap = question_expiry._MAX_RESOLVED_PROBES_PER_RUN
+        huge = " ".join(f"#{i}" for i in range(1, cap + 50))
+        _add(db, "huge", f"Approve {huge}?", age_seconds=60)
+        _add(db, "normal", "Approve #7?", age_seconds=60)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.return_value = _state(closed=True)
+
+        expired = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        # The oversized row is left alone; the one behind it still ran.
+        assert [r["session_id"] for r in expired] == ["normal"]
+        assert github.get_issue_or_pr_state.await_count == 1
+
+    @pytest.mark.asyncio
+    async def test_oversized_row_still_expires_on_age(
+        self, db: StateDB
+    ) -> None:
+        """Skipping it for resolution must not make it immortal."""
+        from ctrlrelay.core import question_expiry
+
+        cap = question_expiry._MAX_RESOLVED_PROBES_PER_RUN
+        huge = " ".join(f"#{i}" for i in range(1, cap + 50))
+        _add(db, "huge", f"Approve {huge}?", age_seconds=TTL + 60)
+
+        github = AsyncMock()
+        expired = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        assert [r["session_id"] for r in expired] == ["huge"]
+        assert expired[0]["expired_reason"] == EXPIRY_REASON_TTL

--- a/tests/test_question_expiry.py
+++ b/tests/test_question_expiry.py
@@ -366,3 +366,38 @@ class TestProbeBudget:
 
         assert [r["session_id"] for r in expired] == ["huge"]
         assert expired[0]["expired_reason"] == EXPIRY_REASON_TTL
+
+
+class TestReplyDuringSweepWins:
+    """The sweep enumerates rows, then expires them one at a time, so a
+    reply can land in between. The expiry UPDATE is guarded on
+    `answered_at IS NULL`, so the reply wins that race — an operator
+    answer is never traded for an expiry."""
+
+    @pytest.mark.asyncio
+    async def test_reply_between_enumeration_and_expiry_is_kept(
+        self, db: StateDB
+    ) -> None:
+        _add(db, "racing", "Approve #12?", age_seconds=60)
+
+        answered: list[str] = []
+
+        async def _reply_mid_sweep(*_a: object, **_kw: object) -> dict[str, object]:
+            # Fires while the sweep is probing this very row.
+            if not answered:
+                db.answer_pending_resume("racing", "yes, merge it")
+                answered.append("racing")
+            return _state(closed=True)
+
+        github = AsyncMock()
+        github.get_issue_or_pr_state.side_effect = _reply_mid_sweep
+
+        expired = await expire_stale_questions(db, github, ttl_seconds=TTL)
+
+        # Every reference read as closed, so the sweep tried to expire —
+        # and the guard refused because the answer had landed.
+        assert answered == ["racing"]
+        assert expired == []
+        assert [r["session_id"] for r in db.list_pending_resumes_to_execute()] == [
+            "racing"
+        ]


### PR DESCRIPTION
## Problem

A `pending_resumes` row deliberately outlives the in-session wait: the transport gives up after `ask_timeout_seconds`, but the row survives so a reply arriving hours later still drives the resume. Nothing ever retired one, so the table only grows.

Measured on a live deployment:

- **46 questions posted, 4 ever answered.**
- **16 still sitting unanswered**, oldest 2 days old.
- Five repos re-asked the identical question on consecutive days.
- Every stale row stayed a routing target for an orphan Telegram reply — including ones whose PR had been merged by hand days earlier.

The second case is the sharper one. `answer_pending_resume` on a question about an already-merged PR would drive a resume against state that has since moved on.

## Change

Two ways a question retires:

| Trigger | Where | Needs network |
|---|---|---|
| Age past `question_ttl_seconds` (default **48h**, min 1h) | new hourly `question_expiry_sweeper` | no |
| Every issue/PR it cites is closed or merged | same job | yes |

TTL runs first, so a GitHub outage still lets age-based expiry make progress.

Expired rows drop out of the unanswered queries, so the bridge stops offering them as reply targets, and `answer_pending_resume` refuses to revive one.

## Fails safe in every direction

- Expiry is guarded on `answered_at IS NULL` — a reply landing in the same tick wins. Expiry must never discard operator work.
- A question citing **no** number is never resolution-expired. Vacuous truth over an empty list would have retired every "Enable Dependabot alerts?" instantly.
- **Any** probe error leaves the row alone. Re-asking a dead question is recoverable; dropping a live one is not.
- The `#N` regex keeps its CVE guard, so `CVE-2026-25087` is not read as PR #2026.

## Notes

- `get_issue_or_pr_state` uses the REST `issues` endpoint, which covers both kinds — a question only ever says `#N`, never which it is.
- Migration adds `expired_at` / `expired_reason` via guarded `ALTER TABLE`; `CREATE TABLE IF NOT EXISTS` would not touch the 16 rows already out there. Covered by a test that builds a pre-migration DB.
- The `#N` extractor moves to `core/question_expiry.py`; `secops` imports it and keeps its `_extract_pr_numbers` name so existing tests are untouched.

## Verification

- 15 new tests in `tests/test_question_expiry.py`, covering both triggers, all four fail-safe paths, idempotency, the routing change, and the migration.
- Full suite: **755 passed**.
- `ruff check`: clean.
