### PR TITLE
fix(state): never resume a question that was already expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,6 +44,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **An expired question can no longer be resumed by a stale bridge.**
+  `answer_pending_resume` already refuses to answer an expired row, but
+  that guard only holds while every process runs the same code. The
+  bridge writes the answer and the poller reads it back — separate
+  daemons — so a deploy that restarts one before the other leaves a
+  window where an old bridge stamps `answered_at` on a row the new
+  poller has already expired, and the resume fires against state that
+  moved on. Seen live: the bridge ran three-day-old code for an hour
+  after the poller was upgraded. `list_pending_resumes_to_execute` now
+  filters expired rows too, closing the window from the side that acts
+  on them.
+
 - **A secops repo failure now says what broke.** A sweep that died before
   the `sessions` INSERT — anything raised by `ensure_bare_repo` or
   `create_worktree`, both network-bound and both ahead of it — left no

--- a/src/ctrlrelay/core/state.py
+++ b/src/ctrlrelay/core/state.py
@@ -408,10 +408,21 @@ class StateDB:
     def list_pending_resumes_to_execute(self) -> list[dict[str, Any]]:
         """Rows that have been answered by the operator but not yet
         resumed. Poller's pending-resume sweeper loads these and drives
-        the pipeline resume. Oldest first so FIFO semantics hold."""
+        the pipeline resume. Oldest first so FIFO semantics hold.
+
+        Expired rows are excluded even though ``answer_pending_resume``
+        already refuses to answer one. That guard only holds while every
+        process runs the same code: the bridge writes the answer and the
+        poller reads it back, they are separate daemons, and a deploy
+        that restarts one before the other leaves a window where an old
+        bridge stamps ``answered_at`` on a row this poller has already
+        expired. Filtering on read closes that window from the side that
+        actually acts on the row.
+        """
         rows = self._conn.execute(
             "SELECT * FROM pending_resumes "
             "WHERE answered_at IS NOT NULL AND resumed_at IS NULL "
+            "AND expired_at IS NULL "
             "ORDER BY answered_at ASC"
         ).fetchall()
         return [dict(row) for row in rows]

--- a/tests/test_question_expiry.py
+++ b/tests/test_question_expiry.py
@@ -401,3 +401,38 @@ class TestReplyDuringSweepWins:
         assert [r["session_id"] for r in db.list_pending_resumes_to_execute()] == [
             "racing"
         ]
+
+
+class TestExpiredRowsNeverResume:
+    """`answer_pending_resume` refuses expired rows, but that guard only
+    holds while every process runs the same code. The bridge writes the
+    answer and the poller reads it back — separate daemons, so a deploy
+    that restarts one before the other leaves a window where an old
+    bridge stamps `answered_at` on a row the new poller already expired.
+    Observed live: the bridge ran three-day-old code for an hour after
+    the poller was upgraded."""
+
+    def test_expired_row_answered_out_of_band_is_not_executed(
+        self, db: StateDB
+    ) -> None:
+        _add(db, "s1", "Approve #1?", age_seconds=TTL + 60)
+        assert db.expire_pending_resume("s1", EXPIRY_REASON_TTL)
+
+        # An old bridge, unaware of expiry, writes the answer directly.
+        db.execute(
+            "UPDATE pending_resumes SET answer = ?, answered_at = ? "
+            "WHERE session_id = ?",
+            ("yes, merge it", 1, "s1"),
+        )
+        db.commit()
+
+        assert db.list_pending_resumes_to_execute() == []
+
+    def test_live_answered_rows_still_execute(self, db: StateDB) -> None:
+        """The filter must not swallow ordinary work."""
+        _add(db, "live", "Approve #2?", age_seconds=60)
+        assert db.answer_pending_resume("live", "yes")
+
+        assert [r["session_id"] for r in db.list_pending_resumes_to_execute()] == [
+            "live"
+        ]


### PR DESCRIPTION
## Problem

`answer_pending_resume` already refuses to answer an expired row:

```sql
UPDATE pending_resumes SET answer = ?, answered_at = ?
WHERE session_id = ? AND answered_at IS NULL AND expired_at IS NULL
```

But that guard only holds while **every process runs the same code**. The bridge writes the answer (`bridge/server.py:640`) and the poller reads it back — separate daemons, restarted independently. A deploy that upgrades one before the other leaves a window where an old bridge stamps `answered_at` on a row the new poller has already expired. `list_pending_resumes_to_execute` had no expiry filter, so the resume fires against state that has moved on.

**Not hypothetical.** Deploying #150/#151/#152 today, only the poller was restarted; the bridge kept running three-day-old code for roughly an hour. During that window a Telegram reply to any of the eight questions the new sweeper had just retired would have been accepted and resumed.

## Change

One `AND expired_at IS NULL` in `list_pending_resumes_to_execute`, closing the window from the side that actually acts on the row rather than relying on the writer being current.

Defence in depth, not a replacement: the write guard stays.

## Verification

- 2 new tests — an expired row answered out-of-band (simulating the stale bridge) is not executed; ordinary answered rows still are, so the filter does not swallow real work.
- Full suite: **774 passed**. `ruff check`: clean.
