### PR TITLE
chore(release): v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-09-07
+
 ### Added
 
 - **`transport.telegram.question_ttl_seconds`: unanswered questions now
@@ -1396,7 +1398,8 @@ pipeline).
   per-phase implementation plans (Phase 0 through Phase 4).
 - `docs/Claude_Code_Project_Guide.md` — project development guide.
 
-[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.1...HEAD
+[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.9.0...HEAD
+[0.9.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.0...v0.8.1
 [0.8.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.7.0...v0.8.0
 [0.7.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.6.0...v0.7.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.8.1"
+version = "0.9.0"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Cuts `v0.9.0`: 7 commits and 15 changelog entries since `v0.8.1`.

**Minor, not patch** — #152 adds a config key (`transport.telegram.question_ttl_seconds`) and a new scheduled job (`question_expiry_sweeper`).

| PR | |
|---|---|
| #150 | secops fenced to its two author-filtered PR queries; questions may not be padded with decided items |
| #151 | repo failures name their cause; git timeouts stringify; clone/fetch get a transfer-sized timeout |
| #152 | unanswered questions expire on age or on resolution elsewhere |
| #153 | an expired question can never be resumed |

Mechanical: `[Unreleased]` closed as `[0.9.0] - 2026-09-07` with a fresh `[Unreleased]` above it, compare links updated, `pyproject.toml` bumped.

Suite: **774 passed**. `ruff check`: clean.