### PR TITLE
docs(publish): describe the release flow that actually runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,9 +12,17 @@ name: Publish to PyPI
 #   Workflow:    publish.yml
 #   Environment: pypi
 #
-# The `pypi` environment adds a manual approval gate — releases pause
-# at the "Publish" step until a repo maintainer approves, so a
-# compromised tag alone can't silently push to PyPI.
+# Publishing is intentionally automatic: tag, publish the GitHub
+# release, and this ships to PyPI with no human step. The `pypi`
+# environment scopes the OIDC trust to this workflow — it is NOT an
+# approval gate and carries no protection rules. Anything that can
+# publish a release here can publish to PyPI.
+#
+# (This comment previously claimed the environment paused for a
+# maintainer. It never did, and someone reading it planned a release
+# around a checkpoint that was not there. If a gate is ever wanted,
+# it is a required reviewer on the `pypi` environment in repo
+# settings — not something this file can assert.)
 
 on:
   release:


### PR DESCRIPTION
## Problem

`publish.yml`'s header claimed:

> The `pypi` environment adds a manual approval gate — releases pause at the "Publish" step until a repo maintainer approves, so a compromised tag alone can't silently push to PyPI.

It does not. The `pypi` environment scopes OIDC trust to this workflow; it has no protection rules, so a published release ships to PyPI with no human step.

Confirmed on the v0.9.0 release — both jobs went straight to `completed/success` and `0.9.0` was on PyPI before anyone was asked anything.

**The behaviour is correct and intended.** Tag → publish the GitHub release → PyPI, automatically. Only the comment was wrong, and it cost a release planned around a checkpoint that was never there.

## Change

Comment only. No workflow logic touched — YAML re-validated.

Says plainly that publishing is automatic, that the environment is an OIDC trust scope rather than a gate, and that a real gate would be a required reviewer configured in repo settings — not something this file can assert.