### PR TITLE
obs(dispatcher): give every agent session a trail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **The dispatcher now logs.** `core/dispatcher.py` is the module that
+  spawns and supervises every agent session, and it was the only core
+  module with no structured logging at all — so the one place where a
+  session is born, times out or dies was the one place with no trail.
+  It now emits `dispatcher.session.start` / `.finished` / `.timeout` /
+  `.subprocess_failed` / `.spawn_failed` / `.cancelled`, plus
+  `dispatcher.checkpoint.missing` when a session ends without
+  signalling and `dispatcher.checkpoint.read_failed` when the file
+  won't parse. Every failure event carries `error_type`, so a bare
+  `asyncio.TimeoutError` — whose `str()` is empty — is still
+  identifiable in the log. Prompts and agent output are never logged in
+  plaintext: only a `hash_text()` prefix and a length. See
+  [Tracing one agent session](https://ainvirion.github.io/ctrlrelay/operations/#tracing-one-agent-session).
+- **`dispatcher.binary.fallback` / `.unresolved` warn when `claude`
+  isn't on `PATH`.** Under systemd and launchd the unit's `PATH` is
+  minimal, and falling through to a hard-coded path is the usual
+  precursor to every session failing to spawn. It used to happen
+  silently.
+
+### Changed
+
+- `spawn_session` takes optional `repo` and `issue_number` arguments,
+  which the dev, task and secops pipelines now pass. They are
+  observability-only — they let dispatcher events be correlated with
+  pipeline events without re-parsing the composite session id.
+
 ## [0.9.0] - 2026-09-07
 
 ### Added

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -305,6 +305,34 @@ tail -f ~/.ctrlrelay/logs/poller.error.log
 The poller prints one line per detected issue and one line per pipeline outcome.
 The bridge prints connection events and Telegram API errors.
 
+### Tracing one agent session
+
+Log lines are newline-delimited JSON, and the dispatcher — the module that
+spawns and supervises every agent subprocess — tags each of its events with
+the session id, so one grep reconstructs a whole run:
+
+```bash
+grep dev-owner-repo-42- ~/.ctrlrelay/logs/poller.log | jq -c '{ts, level, event}'
+```
+
+The events it emits:
+
+| Event | Level | When |
+|---|---|---|
+| `dispatcher.session.start` | INFO | Subprocess about to launch. Carries `binary`, `timeout`, `resume`, `prompt_hash`, `prompt_len`. |
+| `dispatcher.session.finished` | INFO | Subprocess exited. Carries `exit_code`, `checkpoint_status`, `elapsed_ms`. |
+| `dispatcher.session.subprocess_failed` | ERROR | Non-zero exit, with `stderr_tail`. |
+| `dispatcher.session.timeout` | ERROR | The `timeout` seconds elapsed and the child was killed. |
+| `dispatcher.session.spawn_failed` | ERROR | The binary could not be exec'd at all. |
+| `dispatcher.session.cancelled` | INFO | Daemon shutdown killed the child mid-run. |
+| `dispatcher.checkpoint.missing` | WARNING | The session ended without writing a checkpoint. |
+| `dispatcher.checkpoint.read_failed` | ERROR | A checkpoint file existed but would not parse. |
+| `dispatcher.binary.fallback` | WARNING | `claude` was not on `PATH`; a well-known path was used instead. Expect this when the unit's `PATH` is minimal. |
+| `dispatcher.binary.unresolved` | WARNING | Not on `PATH` and not at any known path — sessions are about to start failing to spawn. |
+
+Prompts and agent output never appear in plaintext: only a short SHA-256
+prefix and a length are logged.
+
 ## Inspecting state
 
 ### `ctrlrelay status`

--- a/src/ctrlrelay/core/dispatcher.py
+++ b/src/ctrlrelay/core/dispatcher.py
@@ -13,18 +13,32 @@ import asyncio
 import json
 import os
 import shutil
+import time
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import TYPE_CHECKING, Protocol
+from typing import TYPE_CHECKING, Any, Protocol
 
 from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus, read_checkpoint
+from ctrlrelay.core.obs import get_logger, hash_text, log_event
 
 if TYPE_CHECKING:
     from ctrlrelay.core.config import AgentConfig
 
+_logger = get_logger("core.dispatcher")
+
+# Enough of the child's stderr to name the failure without dumping agent
+# output into the log stream.
+_STDERR_TAIL_CHARS = 500
+
 
 def _find_claude() -> str:
-    """Find claude binary, checking common paths if not in PATH."""
+    """Find claude binary, checking common paths if not in PATH.
+
+    Both fallback branches log at WARNING: under systemd/launchd the unit's
+    PATH is minimal, so ``shutil.which`` missing is the usual precursor to
+    every session failing to spawn, and it is worth seeing in the log
+    before the failures start.
+    """
     claude = shutil.which("claude")
     if claude:
         return claude
@@ -34,7 +48,15 @@ def _find_claude() -> str:
         "/opt/homebrew/bin/claude",
     ]:
         if os.path.isfile(path) and os.access(path, os.X_OK):
+            _logger.warning(
+                "dispatcher.binary.fallback",
+                extra={"binary": path, "reason": "not_on_path"},
+            )
             return path
+    _logger.warning(
+        "dispatcher.binary.unresolved",
+        extra={"binary": "claude", "reason": "not_on_path"},
+    )
     return "claude"
 
 
@@ -97,9 +119,24 @@ class ClaudeDispatcher:
         state_file: Path,
         timeout: int | None = None,
         resume_session_id: str | None = None,
+        repo: str | None = None,
+        issue_number: int | None = None,
     ) -> SessionResult:
-        """Spawn a Claude session and wait for completion."""
+        """Spawn a Claude session and wait for completion.
+
+        ``repo``/``issue_number`` are observability-only: they let the
+        dispatcher's events be correlated with the pipeline's without
+        re-parsing the composite session id.
+        """
         timeout = timeout or self.default_timeout
+
+        # Identity fields repeated on every event of this session, so a
+        # single grep on session_id reconstructs the whole run.
+        ident: dict[str, Any] = {
+            "session_id": session_id,
+            "repo": repo,
+            "issue_number": issue_number,
+        }
 
         env = os.environ.copy()
         env.update(self.extra_env)
@@ -115,32 +152,78 @@ class ClaudeDispatcher:
         if resume_session_id:
             cmd.extend(["--resume", resume_session_id])
 
-        proc = await asyncio.create_subprocess_exec(
-            *cmd,
-            cwd=working_dir,
-            env=env,
-            stdout=asyncio.subprocess.PIPE,
-            stderr=asyncio.subprocess.PIPE,
+        # The prompt can carry issue bodies and operator answers, so only its
+        # hash and length are ever logged (#41).
+        log_event(
+            _logger,
+            "dispatcher.session.start",
+            **ident,
+            resume=resume_session_id is not None,
+            binary=self.claude_binary,
+            working_dir=str(working_dir),
+            timeout=timeout,
+            prompt_hash=hash_text(prompt),
+            prompt_len=len(prompt),
         )
+        started = time.monotonic()
+
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                cwd=working_dir,
+                env=env,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+        except Exception as e:
+            # Usually the binary isn't where we resolved it — the exception
+            # propagates to the pipeline, but without this it lands there
+            # with no record of which path we tried.
+            _logger.error(
+                "dispatcher.session.spawn_failed",
+                extra={
+                    **ident,
+                    "binary": self.claude_binary,
+                    "error_type": type(e).__name__,
+                    "error": str(e)[:200],
+                },
+            )
+            raise
 
         try:
             stdout, stderr = await asyncio.wait_for(
                 proc.communicate(), timeout=timeout
             )
-        except asyncio.TimeoutError:
+        except asyncio.TimeoutError as e:
             proc.kill()
             await proc.wait()
+            _logger.error(
+                "dispatcher.session.timeout",
+                extra={
+                    **ident,
+                    "error_type": type(e).__name__,
+                    "timeout": timeout,
+                    "elapsed_ms": _elapsed_ms(started),
+                },
+            )
             return SessionResult(
                 session_id=session_id,
                 exit_code=-1,
                 state=None,
                 stderr="Session timed out",
             )
-        except asyncio.CancelledError:
+        except asyncio.CancelledError as e:
             # Scheduler/shutdown cancel: kill the child BEFORE re-raising
             # so `claude` isn't left running against the worktree after
             # the daemon exits. Shield the wait so further cancels don't
             # orphan the process between `kill()` and the reaping.
+            log_event(
+                _logger,
+                "dispatcher.session.cancelled",
+                **ident,
+                error_type=type(e).__name__,
+                elapsed_ms=_elapsed_ms(started),
+            )
             if proc.returncode is None:
                 proc.kill()
                 try:
@@ -149,24 +232,75 @@ class ClaudeDispatcher:
                     pass
             raise
 
+        elapsed_ms = _elapsed_ms(started)
+        exit_code = proc.returncode or 0
+        stdout_text = stdout.decode()
+        stderr_text = stderr.decode()
+
         state = None
         if state_file.exists():
             try:
                 state = read_checkpoint(state_file, delete_after=True)
-            except Exception:
-                pass
+            except Exception as e:
+                _logger.error(
+                    "dispatcher.checkpoint.read_failed",
+                    extra={
+                        **ident,
+                        "state_file": str(state_file),
+                        "error_type": type(e).__name__,
+                        "error": str(e)[:200],
+                    },
+                )
+        else:
+            # The session ended without signalling: the pipeline will report
+            # it as failed, and this is the only record of why.
+            _logger.warning(
+                "dispatcher.checkpoint.missing",
+                extra={
+                    **ident,
+                    "state_file": str(state_file),
+                    "exit_code": exit_code,
+                },
+            )
 
-        stdout_text = stdout.decode()
+        if exit_code != 0:
+            _logger.error(
+                "dispatcher.session.subprocess_failed",
+                extra={
+                    **ident,
+                    "exit_code": exit_code,
+                    "stderr_tail": stderr_text[-_STDERR_TAIL_CHARS:],
+                    "elapsed_ms": elapsed_ms,
+                },
+            )
+
         agent_session_id = _extract_agent_session_id(stdout_text)
+
+        log_event(
+            _logger,
+            "dispatcher.session.finished",
+            **ident,
+            exit_code=exit_code,
+            checkpoint_status=state.status.value if state else None,
+            elapsed_ms=elapsed_ms,
+            agent_session_id=agent_session_id,
+            stdout_hash=hash_text(stdout_text),
+            stdout_len=len(stdout_text),
+        )
 
         return SessionResult(
             session_id=session_id,
-            exit_code=proc.returncode or 0,
+            exit_code=exit_code,
             state=state,
             stdout=stdout_text,
-            stderr=stderr.decode(),
+            stderr=stderr_text,
             agent_session_id=agent_session_id,
         )
+
+
+def _elapsed_ms(started: float) -> int:
+    """Milliseconds since ``started`` (a :func:`time.monotonic` reading)."""
+    return int((time.monotonic() - started) * 1000)
 
 
 def _extract_agent_session_id(stdout_text: str) -> str | None:
@@ -211,6 +345,8 @@ class AgentAdapter(Protocol):
         state_file: Path,
         timeout: int | None = None,
         resume_session_id: str | None = None,
+        repo: str | None = None,
+        issue_number: int | None = None,
     ) -> SessionResult:
         ...
 

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -364,6 +364,8 @@ class DevPipeline:
             working_dir=ctx.worktree_path,
             state_file=ctx.state_file,
             resume_session_id=resume_uuid,
+            repo=ctx.repo,
+            issue_number=ctx.issue_number,
         )
 
         if result.agent_session_id:

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -162,6 +162,8 @@ class SecopsPipeline:
             working_dir=ctx.worktree_path,
             state_file=ctx.state_file,
             resume_session_id=resume_uuid,
+            repo=ctx.repo,
+            issue_number=ctx.issue_number,
         )
 
         if result.agent_session_id:

--- a/src/ctrlrelay/pipelines/task.py
+++ b/src/ctrlrelay/pipelines/task.py
@@ -113,6 +113,8 @@ class TaskPipeline:
             working_dir=ctx.worktree_path,
             state_file=ctx.state_file,
             resume_session_id=resume_uuid,
+            repo=ctx.repo,
+            issue_number=ctx.issue_number,
         )
 
         if result.agent_session_id:

--- a/tests/test_dev_pipeline.py
+++ b/tests/test_dev_pipeline.py
@@ -1818,3 +1818,53 @@ class TestIssueCommentsInPrompt:
 
         assert "@unknown" in rendered
         assert "still matters" in rendered
+
+
+class TestSpawnCorrelationFields:
+    """#156: the dispatcher logs repo/issue on every session event, so the
+    pipelines have to hand it those fields instead of making the reader
+    re-parse the composite session id."""
+
+    @pytest.mark.asyncio
+    async def test_resume_forwards_repo_and_issue_number(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.checkpoint import CheckpointState, CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.base import PipelineContext
+        from ctrlrelay.pipelines.dev import DevPipeline
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="dev-o-r-3-abc",
+            exit_code=0,
+            state=CheckpointState(
+                status=CheckpointStatus.DONE,
+                session_id="dev-o-r-3-abc",
+                summary="done",
+            ),
+        )
+
+        pipeline = DevPipeline(
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=MagicMock(),
+            dashboard=None,
+            state_db=MagicMock(),
+            transport=None,
+        )
+
+        ctx = PipelineContext(
+            session_id="dev-o-r-3-abc",
+            repo="owner/repo",
+            worktree_path=tmp_path,
+            context_path=tmp_path / "CLAUDE.md",
+            state_file=tmp_path / "state.json",
+            issue_number=3,
+        )
+
+        await pipeline.resume(ctx, "proceed")
+
+        call_kwargs = mock_dispatcher.spawn_session.call_args.kwargs
+        assert call_kwargs["repo"] == "owner/repo"
+        assert call_kwargs["issue_number"] == 3

--- a/tests/test_dispatcher.py
+++ b/tests/test_dispatcher.py
@@ -1,6 +1,7 @@
 """Tests for Claude dispatcher."""
 
 import json
+import logging
 from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock, patch
 
@@ -289,5 +290,379 @@ class TestClaudeDispatcher:
             assert result.state is not None
             assert "2.4.1" in result.state.question
 
+
+class TestDispatcherLogging:
+    """#156: the dispatcher spawns and supervises every agent session, so it
+    must leave a trail. Prompts and agent output stay out of the logs — hash
+    and length only."""
+
+    @staticmethod
+    def _events(caplog) -> list:
+        return [r for r in caplog.records if r.name == "ctrlrelay.core.dispatcher"]
+
+    @classmethod
+    def _find(cls, caplog, event: str):
+        matches = [r for r in cls._events(caplog) if r.getMessage() == event]
+        assert matches, (
+            f"expected {event}, got: "
+            f"{[r.getMessage() for r in cls._events(caplog)]}"
+        )
+        return matches[0]
+
+    @pytest.mark.asyncio
+    async def test_session_start_logs_identity_and_resume_mode(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="/usr/bin/claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="dev-o-r-9-abc",
+                    prompt="secret prompt text",
+                    working_dir=tmp_path,
+                    state_file=tmp_path / "state.json",
+                    timeout=42,
+                    repo="o/r",
+                    issue_number=9,
+                )
+
+        rec = self._find(caplog, "dispatcher.session.start").__dict__
+        assert rec["session_id"] == "dev-o-r-9-abc"
+        assert rec["repo"] == "o/r"
+        assert rec["issue_number"] == 9
+        assert rec["resume"] is False
+        assert rec["binary"] == "/usr/bin/claude"
+        assert rec["timeout"] == 42
+
+    @pytest.mark.asyncio
+    async def test_session_start_marks_resume(self, tmp_path: Path, caplog) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="dev-o-r-9-abc",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=tmp_path / "state.json",
+                    resume_session_id="b6a0e6f8-8e9b-4e4f-9a33-5a2e1f7c8a10",
+                )
+
+        assert self._find(caplog, "dispatcher.session.start").__dict__["resume"] is True
+
+    @pytest.mark.asyncio
+    async def test_prompt_and_output_are_never_logged_in_plaintext(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """#41: no prompt or agent output in the log stream — hash/length only."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+        from ctrlrelay.core.obs import hash_text
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        prompt = "SUPER-SECRET-PROMPT-NEEDLE"
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b'{"result": "AGENT-OUTPUT-NEEDLE"}', b"")
+        mock_proc.returncode = 0
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({
+            "version": "1",
+            "status": "DONE",
+            "session_id": "sid",
+            "timestamp": "2026-04-17T12:00:00Z",
+            "summary": "ok",
+        }))
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt=prompt,
+                    working_dir=tmp_path,
+                    state_file=state_file,
+                )
+
+        blob = json.dumps(
+            [
+                {k: str(v) for k, v in r.__dict__.items() if not k.startswith("_")}
+                for r in self._events(caplog)
+            ]
+        )
+        assert "SUPER-SECRET-PROMPT-NEEDLE" not in blob
+        assert "AGENT-OUTPUT-NEEDLE" not in blob
+
+        start = self._find(caplog, "dispatcher.session.start").__dict__
+        assert start["prompt_hash"] == hash_text(prompt)
+        assert start["prompt_len"] == len(prompt)
+
+    @pytest.mark.asyncio
+    async def test_checkpoint_status_is_logged_on_finish(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text(json.dumps({
+            "version": "1",
+            "status": "BLOCKED_NEEDS_INPUT",
+            "session_id": "sid",
+            "timestamp": "2026-04-17T12:00:00Z",
+            "question": "Pin or bump?",
+        }))
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=state_file,
+                )
+
+        rec = self._find(caplog, "dispatcher.session.finished").__dict__
+        assert rec["checkpoint_status"] == "BLOCKED_NEEDS_INPUT"
+        assert rec["exit_code"] == 0
+        assert "elapsed_ms" in rec
+        # The question text itself must not ride along.
+        assert "Pin or bump?" not in json.dumps(
+            {k: str(v) for k, v in rec.items() if not k.startswith("_")}
+        )
+
+    @pytest.mark.asyncio
+    async def test_missing_checkpoint_is_logged(self, tmp_path: Path, caplog) -> None:
+        """A session that ends without writing a checkpoint is the exact case
+        that used to vanish silently."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=tmp_path / "missing.json",
+                )
+
+        rec = self._find(caplog, "dispatcher.checkpoint.missing").__dict__
+        assert rec["session_id"] == "sid"
+        assert rec["levelname"] == "WARNING"
+
+    @pytest.mark.asyncio
+    async def test_unreadable_checkpoint_logs_exception_type(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"{}", b"")
+        mock_proc.returncode = 0
+
+        state_file = tmp_path / "state.json"
+        state_file.write_text("{ not json")
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                result = await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=state_file,
+                )
+
+        assert result.state is None
+        rec = self._find(caplog, "dispatcher.checkpoint.read_failed").__dict__
+        assert rec["error_type"]
+        assert rec["levelname"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_nonzero_exit_logs_error_with_stderr_tail(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.return_value = (b"", b"boom: could not start\n")
+        mock_proc.returncode = 2
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=tmp_path / "state.json",
+                )
+
+        rec = self._find(caplog, "dispatcher.session.subprocess_failed").__dict__
+        assert rec["exit_code"] == 2
+        assert "boom: could not start" in rec["stderr_tail"]
+        assert rec["levelname"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_event_with_exception_type_and_timeout(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """Acceptance for #156: the failure path emits an event carrying the
+        exception type, plus the timeout value that was applied."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude", default_timeout=1)
+
+        mock_proc = AsyncMock()
+        mock_proc.communicate.side_effect = asyncio.TimeoutError()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                await dispatcher.spawn_session(
+                    session_id="sid",
+                    prompt="x",
+                    working_dir=tmp_path,
+                    state_file=tmp_path / "state.json",
+                    timeout=7,
+                )
+
+        rec = self._find(caplog, "dispatcher.session.timeout").__dict__
+        assert rec["error_type"] == "TimeoutError"
+        assert rec["timeout"] == 7
+        assert rec["levelname"] == "ERROR"
+
+    @pytest.mark.asyncio
+    async def test_cancel_logs_event_with_exception_type(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        mock_proc = AsyncMock()
+        mock_proc.returncode = None
+        mock_proc.communicate.side_effect = asyncio.CancelledError()
+        mock_proc.kill = MagicMock()
+        mock_proc.wait = AsyncMock()
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("asyncio.create_subprocess_exec", return_value=mock_proc):
+                with pytest.raises(asyncio.CancelledError):
+                    await dispatcher.spawn_session(
+                        session_id="sid",
+                        prompt="x",
+                        working_dir=tmp_path,
+                        state_file=tmp_path / "state.json",
+                    )
+
+        rec = self._find(caplog, "dispatcher.session.cancelled").__dict__
+        assert rec["error_type"] == "CancelledError"
+
+    @pytest.mark.asyncio
+    async def test_spawn_failure_logs_exception_type(
+        self, tmp_path: Path, caplog
+    ) -> None:
+        """If the binary can't be exec'd at all (the systemd PATH case), the
+        dispatcher must say so instead of letting a bare OSError bubble up
+        unrecorded."""
+        from ctrlrelay.core.dispatcher import ClaudeDispatcher
+
+        dispatcher = ClaudeDispatcher(claude_binary="claude")
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch(
+                "asyncio.create_subprocess_exec",
+                side_effect=FileNotFoundError("no claude"),
+            ):
+                with pytest.raises(FileNotFoundError):
+                    await dispatcher.spawn_session(
+                        session_id="sid",
+                        prompt="x",
+                        working_dir=tmp_path,
+                        state_file=tmp_path / "state.json",
+                    )
+
+        rec = self._find(caplog, "dispatcher.session.spawn_failed").__dict__
+        assert rec["error_type"] == "FileNotFoundError"
+        assert rec["levelname"] == "ERROR"
+
+    def test_binary_fallback_warns_when_which_misses(self, caplog) -> None:
+        """Under systemd PATH is minimal; falling back to a hard-coded path is
+        worth a WARNING because it is where sessions silently stop starting."""
+        from ctrlrelay.core.dispatcher import _find_claude
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("shutil.which", return_value=None):
+                with patch("os.path.isfile", return_value=True):
+                    with patch("os.access", return_value=True):
+                        resolved = _find_claude()
+
+        assert resolved.endswith("claude")
+        rec = self._find(caplog, "dispatcher.binary.fallback").__dict__
+        assert rec["levelname"] == "WARNING"
+        assert rec["binary"] == resolved
+
+    def test_binary_unresolved_warns(self, caplog) -> None:
+        """Nothing on disk either: we still return the bare name, but the log
+        has to record that no real path was found."""
+        from ctrlrelay.core.dispatcher import _find_claude
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("shutil.which", return_value=None):
+                with patch("os.path.isfile", return_value=False):
+                    resolved = _find_claude()
+
+        assert resolved == "claude"
+        rec = self._find(caplog, "dispatcher.binary.unresolved").__dict__
+        assert rec["levelname"] == "WARNING"
+
+    def test_no_warning_when_binary_is_on_path(self, caplog) -> None:
+        from ctrlrelay.core.dispatcher import _find_claude
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with patch("shutil.which", return_value="/usr/bin/claude"):
+                assert _find_claude() == "/usr/bin/claude"
+
+        assert not self._events(caplog)
 
 import asyncio  # noqa: E402 — needed for TimeoutError reference in test body


### PR DESCRIPTION
Closes #156.

## The gap

`src/ctrlrelay/core/dispatcher.py` had zero logging calls. Every other core
module already used `core/obs.py`; the dispatcher — the module that actually
spawns and supervises every agent session — was the one exception. So when a
session failed, the pipeline logged *that* it failed and nothing recorded what
the dispatcher saw first.

## What it emits now

| Event | Level | When |
|---|---|---|
| `dispatcher.session.start` | INFO | Subprocess about to launch: `binary`, `timeout`, `resume`, `prompt_hash`, `prompt_len` |
| `dispatcher.session.finished` | INFO | Exited: `exit_code`, `checkpoint_status`, `elapsed_ms` |
| `dispatcher.session.subprocess_failed` | ERROR | Non-zero exit, with `stderr_tail` |
| `dispatcher.session.timeout` | ERROR | `asyncio.wait_for` expiry, with the `timeout` that was applied |
| `dispatcher.session.spawn_failed` | ERROR | The binary could not be exec'd at all |
| `dispatcher.session.cancelled` | INFO | Daemon shutdown killed the child mid-run |
| `dispatcher.checkpoint.missing` | WARNING | Session ended without writing a checkpoint |
| `dispatcher.checkpoint.read_failed` | ERROR | Checkpoint existed but would not parse — this was a bare `except: pass` |
| `dispatcher.binary.fallback` | WARNING | `claude` not on `PATH`; a well-known path used instead |
| `dispatcher.binary.unresolved` | WARNING | Not on `PATH` and nowhere on disk |

Every failure event carries `error_type`. That matters for the exact case in
the issue: a bare `asyncio.TimeoutError` has an empty `str()`, so without the
type name it is unnameable in a log.

The two binary-resolution warnings exist because under systemd and launchd the
unit's `PATH` is minimal, and falling through to a hard-coded path is the usual
precursor to every session failing to spawn. It used to happen silently.

## No plaintext

Prompts and agent stdout are logged as a `hash_text()` prefix plus a length,
never in the clear (#41). A test greps every emitted record for a needle
planted in both the prompt and the agent output and asserts neither appears.

## Correlation fields

`spawn_session` gained optional `repo` / `issue_number`, forwarded by the dev,
task and secops pipelines. Observability-only — they let dispatcher events be
correlated with pipeline events without re-parsing the composite session id.
The arguments are optional and keyword-only in practice, so any adapter that
does not take them still satisfies the `AgentAdapter` protocol at runtime.

## Tests

14 new tests in `tests/test_dispatcher.py` and one in `tests/test_dev_pipeline.py`,
written first. They cover each event, both binary-fallback branches, the
no-warning-when-on-PATH case, the plaintext-leak assertion, and — the issue's
stated acceptance — that the failure path emits an event carrying the exception
type.

788 passed, `ruff check src/ tests/` clean.

Operator-facing docs: new "Tracing one agent session" section in
`docs/operations.md`.