### PR TITLE
fix(cli): say which gh failure actually happened at startup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   observability-only — they let dispatcher events be correlated with
   pipeline events without re-parsing the composite session id.
 
+### Fixed
+
+- **Startup no longer blames your GitHub auth when you are offline.**
+  `poller start` probes `gh api user` before it does anything else, and
+  every way that probe can fail — unplugged network, expired token, a
+  500 from the API — exits 1, so the CLI printed
+  `Command '[...]' returned non-zero exit status 1.` for all of them.
+  A new `core/network.py` classifies the failure from gh's own stderr
+  into network / auth / rate-limit / API-error (plus "gh not
+  installed"), and the CLI prints the matching message —
+  `Network unavailable — could not reach api.github.com` in yellow when
+  it is transient, a pointer to `gh auth status` when the credentials are the
+  problem, the HTTP status when the API answered. gh's raw stderr is
+  still printed underneath.
+
 ## [0.9.0] - 2026-09-07
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   operator to check their wifi while their `gh` install is broken. Only a
   hung `gh` (timeout) still reads as connectivity — there the child
   launched and then stopped responding.
+- **`broken pipe` now reads as a network failure.** A peer that vanished
+  mid-write carries none of the other network markers, so it fell through
+  to a generic API error — a miss of the classifier's own purpose. Bare
+  `EOF` is deliberately still not matched: `gh` passes API response
+  bodies through verbatim, so matching it would misclassify real API
+  errors as outages, the same mistake in the other direction.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A broken `gh` install no longer reports itself as "network
+  unavailable".** `subprocess.run` raising `OSError` means the child could
+  not be exec'd — a non-executable binary, a bad path, a wrong
+  architecture. Python does no networking here, `gh` does, so an `OSError`
+  raised on our side can never mean offline. Reporting it that way was the
+  exact misdiagnosis this classification exists to prevent: it sends the
+  operator to check their wifi while their `gh` install is broken. Only a
+  hung `gh` (timeout) still reads as connectivity — there the child
+  launched and then stopped responding.
+
 ### Added
 
 - **The dispatcher now logs.** `core/dispatcher.py` is the module that

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `EOF` is deliberately still not matched: `gh` passes API response
   bodies through verbatim, so matching it would misclassify real API
   errors as outages, the same mistake in the other direction.
+- **A resource limit is no longer blamed on the `gh` install.** `EMFILE`
+  and `ENOMEM` also reach the classifier as `OSError` from a failed spawn,
+  but answering those with "install GitHub CLI" is the same misdirection
+  wearing a different hat. Only exec-family errnos say the install is
+  broken; the rest surface the errno.
+- **Go transport failures are no longer reported as API errors.** `gh`
+  renders a failed round-trip as `Get "https://…": <cause>`, which by
+  construction means no HTTP response arrived — so `EOF`, `http2: client
+  connection lost`, `request canceled` and `remote error: tls: handshake
+  failure` were all landing as "GitHub API call failed". Matching the
+  shape rather than each wording catches the family; a real API error
+  carries `(HTTP nnn)` instead and is unaffected. `read tcp …: connection
+  timed out` (a link dropped mid-request) is matched too.
+- **TLS trust failures are no longer called transient.** An untrusted CA
+  or a skewed clock is a persistent local problem, and "retry later" can
+  never fix it. These now report as `tls_trust` with remediation pointing
+  at the CA bundle and the system clock. A certificate valid for the
+  wrong host stays a network failure — that is the captive-portal case.
+- **`gh` stderr is escaped before Rich renders it.** Stderr containing
+  bracketed text (e.g. `[/docs]`) raised `MarkupError`, replacing the
+  diagnostic with a traceback and skipping the exit — losing the raw
+  detail the line exists to show.
+- **The startup `gh` probe is time-bounded.** Without a timeout a hung
+  `gh` wedged `poller start` indefinitely, and the one exception branch
+  that really does mean connectivity could never fire.
 
 ### Added
 

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -5,6 +5,7 @@ from pathlib import Path
 
 import typer
 from rich.console import Console
+from rich.markup import escape as rich_escape
 from rich.table import Table
 
 from ctrlrelay import __version__
@@ -12,6 +13,10 @@ from ctrlrelay.core.config import ConfigError, load_config, resolve_config_path
 from ctrlrelay.core.github import GitHubCLI, GitHubError
 from ctrlrelay.core.pr_verifier import PRVerifier
 from ctrlrelay.core.question_expiry import expire_stale_questions
+
+# Startup probe cap. `GitHubCLI` uses 60s for ordinary calls; this one
+# gates daemon startup, so a hung gh must not wedge it indefinitely.
+_GH_PROBE_TIMEOUT_SECONDS = 60
 
 app = typer.Typer(
     name="ctrlrelay",
@@ -1035,6 +1040,10 @@ def poller_start(
                 capture_output=True,
                 text=True,
                 check=True,
+                # Without this a hung gh hangs `poller start` forever, and
+                # the TimeoutExpired branch of the classifier — the one
+                # case that really does mean connectivity — can never fire.
+                timeout=_GH_PROBE_TIMEOUT_SECONDS,
             )
             username = result.stdout.strip()
         except (subprocess.SubprocessError, OSError) as e:
@@ -1050,7 +1059,14 @@ def poller_start(
                 f"{failure.message}"
             )
             if failure.stderr:
-                console.print(f"[dim]gh: {failure.stderr}[/dim]")
+                # gh's stderr is arbitrary text and Rich parses [...] as
+                # markup: a stderr containing something like "[/docs]"
+                # raises MarkupError, which replaces the diagnostic with a
+                # traceback and skips the exit — losing exactly the detail
+                # this line exists to show.
+                console.print(
+                    f"[dim]gh: {rich_escape(failure.stderr)}[/dim]"
+                )
             raise typer.Exit(1)
 
         if not username:

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1037,8 +1037,20 @@ def poller_start(
                 check=True,
             )
             username = result.stdout.strip()
-        except subprocess.CalledProcessError as e:
-            console.print(f"[red]Failed to get GitHub username:[/red] {e}")
+        except (subprocess.SubprocessError, OSError) as e:
+            # `gh` exits 1 for offline, expired-token and API-error alike,
+            # so classify from its stderr — otherwise operators debug auth
+            # when the laptop is simply offline (#32).
+            from ctrlrelay.core.network import gh_failure_from_exception
+
+            failure = gh_failure_from_exception(e)
+            color = "yellow" if failure.is_transient else "red"
+            console.print(
+                f"[{color}]Could not determine GitHub username:[/{color}] "
+                f"{failure.message}"
+            )
+            if failure.stderr:
+                console.print(f"[dim]gh: {failure.stderr}[/dim]")
             raise typer.Exit(1)
 
         if not username:

--- a/src/ctrlrelay/core/network.py
+++ b/src/ctrlrelay/core/network.py
@@ -11,6 +11,7 @@ stderr text rather than the exit code.
 
 from __future__ import annotations
 
+import errno
 import re
 import subprocess
 from dataclasses import dataclass
@@ -25,6 +26,7 @@ class GhFailureKind(str, Enum):
     RATE_LIMITED = "rate_limited"
     API_ERROR = "api_error"
     GH_MISSING = "gh_missing"
+    TLS_TRUST = "tls_trust"
 
 
 # Ordered most-specific-first within each group; matched case-insensitively
@@ -37,6 +39,7 @@ _NETWORK_PATTERNS = (
     "network is unreachable",
     "no route to host",
     "connection refused",
+    "connection timed out",
     "connection reset by peer",
     # A peer that vanished mid-write. Deliberately not matching bare
     # "EOF" alongside it: gh passes API response bodies through verbatim
@@ -55,6 +58,32 @@ _NETWORK_PATTERNS = (
     "check your internet connection",
 )
 
+# errnos `subprocess.run` raises when it cannot EXEC the child — the file
+# is absent, unreadable, a directory, or the wrong architecture. These
+# say "your gh install is broken". Resource-exhaustion errnos (EMFILE,
+# ENOMEM, EAGAIN) also surface as OSError here but mean nothing of the
+# sort, and telling that operator to install GitHub CLI sends them the
+# wrong way.
+_EXEC_FAILURE_ERRNOS = frozenset(
+    e for e in (
+        errno.ENOENT, errno.EACCES, errno.EPERM, errno.ENOEXEC,
+        errno.EISDIR, errno.ENOTDIR, errno.ELOOP,
+        errno.ENAMETOOLONG, errno.ETXTBSY,
+    )
+)
+
+# Persistent local trust problems, not outages: a corporate MITM proxy
+# without its CA installed, or a clock skewed far enough to invalidate a
+# valid certificate. "Retry later" is wrong advice for both. A cert valid
+# for the wrong host IS usually a captive portal, so that stays network.
+_TLS_TRUST_PATTERNS = (
+    "certificate signed by unknown authority",
+    "certificate has expired or is not yet valid",
+    "unable to get local issuer certificate",
+    "self-signed certificate",
+    "self signed certificate",
+)
+
 _RATE_LIMIT_PATTERNS = (
     "rate limit exceeded",
     "secondary rate limit",
@@ -67,7 +96,6 @@ _AUTH_PATTERNS = (
     "requires authentication",
     "gh auth login",
     "not logged in",
-    "no such host is authenticated",
     "authentication failed",
     "http 401",
     "required scopes",
@@ -108,9 +136,36 @@ def _decode(stderr: str | bytes | None) -> str:
     return stderr.strip()
 
 
+# Go renders a failed HTTP round-trip as `*url.Error`:
+#   Get "https://api.github.com/user": <cause>
+# By construction that means NO HTTP response was received, so it can
+# never be an API error — whatever the cause reads like. `gh api` prints
+# a real API error in the other shape entirely, `gh: <msg> (HTTP nnn)`,
+# so the two do not overlap. Keying on the shape catches the whole family
+# (EOF, http2 connection lost, request canceled, remote error: tls: …)
+# instead of chasing each new wording as a string.
+_URL_ERROR_RE = re.compile(r'^(?:get|post|put|patch|delete|head)\s+"https?://', re.I)
+
+
+def _is_transport_failure(text: str) -> bool:
+    """True when the text is Go's url.Error shape — request issued, no
+    response received."""
+    return any(
+        _URL_ERROR_RE.match(line.strip())
+        for line in text.splitlines()
+        if line.strip()
+    )
+
+
 def _kind_for(text: str) -> GhFailureKind:
     lowered = text.lower()
+    # Checked before the network patterns: these strings contain
+    # "x509:", but retrying never fixes a CA bundle or a skewed clock.
+    if any(pattern in lowered for pattern in _TLS_TRUST_PATTERNS):
+        return GhFailureKind.TLS_TRUST
     if any(pattern in lowered for pattern in _NETWORK_PATTERNS):
+        return GhFailureKind.NETWORK_UNAVAILABLE
+    if _is_transport_failure(text):
         return GhFailureKind.NETWORK_UNAVAILABLE
     # Rate-limit bodies mention authentication ("Authenticated requests get
     # a higher rate limit"), so they have to be matched before auth.
@@ -136,6 +191,13 @@ def _message_for(kind: GhFailureKind, status: int | None) -> str:
         return (
             "GitHub credentials rejected — run `gh auth status` "
             "(then `gh auth login`) and retry."
+        )
+    if kind is GhFailureKind.TLS_TRUST:
+        return (
+            "TLS certificate not trusted — the connection to api.github.com "
+            "was intercepted or the certificate could not be verified. "
+            "Install your proxy's CA certificate, or check the system clock. "
+            "Retrying will not help."
         )
     if kind is GhFailureKind.GH_MISSING:
         return (
@@ -190,17 +252,26 @@ def gh_failure_from_exception(exc: BaseException) -> GhFailure:
             stderr=str(exc),
         )
     if isinstance(exc, OSError):
-        # Everything else OSError-shaped comes from `subprocess.run`
-        # failing to EXEC the child — PermissionError on a non-executable
-        # binary, IsADirectoryError on a bad path, OSError(8) on a wrong
-        # architecture. Python is not doing the networking here, gh is,
-        # so an OSError raised on our side can never mean "offline".
-        # Reporting it as such is the exact misdiagnosis this module
-        # exists to prevent: it sends the operator to check their wifi
-        # while their gh install is broken.
+        # An OSError here came from `subprocess.run` failing to launch the
+        # child. Python is not doing the networking — gh is — so it can
+        # never mean "offline"; reporting it that way is the exact
+        # misdiagnosis this module exists to prevent.
+        #
+        # But only the EXEC-shaped errnos mean the install is broken. A
+        # process-table or memory limit (EMFILE, ENOMEM, EAGAIN) also
+        # lands here, and answering that with "install GitHub CLI" is
+        # just the same misdirection wearing a different hat. Fall
+        # through for those: the caller still prints the raw errno text,
+        # which is the actionable part.
+        if exc.errno in _EXEC_FAILURE_ERRNOS:
+            return GhFailure(
+                kind=GhFailureKind.GH_MISSING,
+                message=_message_for(GhFailureKind.GH_MISSING, None),
+                stderr=str(exc),
+            )
         return GhFailure(
-            kind=GhFailureKind.GH_MISSING,
-            message=_message_for(GhFailureKind.GH_MISSING, None),
+            kind=GhFailureKind.API_ERROR,
+            message=f"Could not run `gh`: {exc}",
             stderr=str(exc),
         )
     return classify_gh_failure(str(exc))

--- a/src/ctrlrelay/core/network.py
+++ b/src/ctrlrelay/core/network.py
@@ -134,8 +134,8 @@ def _message_for(kind: GhFailureKind, status: int | None) -> str:
         )
     if kind is GhFailureKind.GH_MISSING:
         return (
-            "The `gh` CLI was not found — install GitHub CLI and make sure "
-            "it is on PATH."
+            "The `gh` CLI could not be run — install GitHub CLI, make sure "
+            "it is on PATH, and check the file is executable."
         )
     if status is not None:
         return f"GitHub API returned an error (HTTP {status})."
@@ -176,10 +176,26 @@ def gh_failure_from_exception(exc: BaseException) -> GhFailure:
         )
     if isinstance(exc, subprocess.CalledProcessError):
         return classify_gh_failure(exc.stderr, returncode=exc.returncode)
-    if isinstance(exc, (subprocess.TimeoutExpired, TimeoutError, OSError)):
+    if isinstance(exc, (subprocess.TimeoutExpired, TimeoutError)):
+        # A hung gh is the one exception shape that really does suggest
+        # connectivity: the child launched and then stopped responding.
         return GhFailure(
             kind=GhFailureKind.NETWORK_UNAVAILABLE,
             message=_message_for(GhFailureKind.NETWORK_UNAVAILABLE, None),
+            stderr=str(exc),
+        )
+    if isinstance(exc, OSError):
+        # Everything else OSError-shaped comes from `subprocess.run`
+        # failing to EXEC the child — PermissionError on a non-executable
+        # binary, IsADirectoryError on a bad path, OSError(8) on a wrong
+        # architecture. Python is not doing the networking here, gh is,
+        # so an OSError raised on our side can never mean "offline".
+        # Reporting it as such is the exact misdiagnosis this module
+        # exists to prevent: it sends the operator to check their wifi
+        # while their gh install is broken.
+        return GhFailure(
+            kind=GhFailureKind.GH_MISSING,
+            message=_message_for(GhFailureKind.GH_MISSING, None),
             stderr=str(exc),
         )
     return classify_gh_failure(str(exc))

--- a/src/ctrlrelay/core/network.py
+++ b/src/ctrlrelay/core/network.py
@@ -38,6 +38,11 @@ _NETWORK_PATTERNS = (
     "no route to host",
     "connection refused",
     "connection reset by peer",
+    # A peer that vanished mid-write. Deliberately not matching bare
+    # "EOF" alongside it: gh passes API response bodies through verbatim
+    # and "EOF" is common enough in them to misclassify real API errors
+    # as outages, which is the mistake in the other direction.
+    "broken pipe",
     "i/o timeout",
     "tls handshake",
     "x509:",

--- a/src/ctrlrelay/core/network.py
+++ b/src/ctrlrelay/core/network.py
@@ -1,0 +1,185 @@
+"""Classify `gh` subprocess failures so operators get an actionable message.
+
+`gh` exits 1 for everything: an unplugged network cable, an expired token
+and a 500 from the API all surface as
+``returned non-zero exit status 1``. That sends operators debugging auth
+when the real problem is that the laptop is offline (#32).
+
+`gh` does write clear wording to stderr, so classification keys off the
+stderr text rather than the exit code.
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+from dataclasses import dataclass
+from enum import Enum
+
+
+class GhFailureKind(str, Enum):
+    """What actually went wrong behind a non-zero `gh` exit."""
+
+    NETWORK_UNAVAILABLE = "network_unavailable"
+    AUTH = "auth"
+    RATE_LIMITED = "rate_limited"
+    API_ERROR = "api_error"
+    GH_MISSING = "gh_missing"
+
+
+# Ordered most-specific-first within each group; matched case-insensitively
+# against gh's stderr. Network patterns cover gh's own wording plus the Go
+# net/http and OpenSSL strings it passes through verbatim.
+_NETWORK_PATTERNS = (
+    "error connecting to",
+    "dial tcp",
+    "no such host",
+    "network is unreachable",
+    "no route to host",
+    "connection refused",
+    "connection reset by peer",
+    "i/o timeout",
+    "tls handshake",
+    "x509:",
+    "certificate signed by",
+    "context deadline exceeded",
+    "temporary failure in name resolution",
+    "name resolution",
+    "proxyconnect tcp",
+    "server misbehaving",
+    "check your internet connection",
+)
+
+_RATE_LIMIT_PATTERNS = (
+    "rate limit exceeded",
+    "secondary rate limit",
+    "too many requests",
+    "http 429",
+)
+
+_AUTH_PATTERNS = (
+    "bad credentials",
+    "requires authentication",
+    "gh auth login",
+    "not logged in",
+    "no such host is authenticated",
+    "authentication failed",
+    "http 401",
+    "required scopes",
+    "needs the '",
+    "token has not been granted",
+    "gh_token",
+    "github_token",
+)
+
+_HTTP_STATUS_RE = re.compile(r"\(?\bHTTP (\d{3})\b\)?", re.IGNORECASE)
+
+
+@dataclass(frozen=True)
+class GhFailure:
+    """A classified `gh` failure plus the raw evidence behind it."""
+
+    kind: GhFailureKind
+    message: str
+    stderr: str = ""
+    returncode: int | None = None
+    status: int | None = None
+
+    @property
+    def is_transient(self) -> bool:
+        """True when retrying later could plausibly succeed without the
+        operator changing anything."""
+        return self.kind in (
+            GhFailureKind.NETWORK_UNAVAILABLE,
+            GhFailureKind.RATE_LIMITED,
+        )
+
+
+def _decode(stderr: str | bytes | None) -> str:
+    if stderr is None:
+        return ""
+    if isinstance(stderr, bytes):
+        stderr = stderr.decode("utf-8", errors="replace")
+    return stderr.strip()
+
+
+def _kind_for(text: str) -> GhFailureKind:
+    lowered = text.lower()
+    if any(pattern in lowered for pattern in _NETWORK_PATTERNS):
+        return GhFailureKind.NETWORK_UNAVAILABLE
+    # Rate-limit bodies mention authentication ("Authenticated requests get
+    # a higher rate limit"), so they have to be matched before auth.
+    if any(pattern in lowered for pattern in _RATE_LIMIT_PATTERNS):
+        return GhFailureKind.RATE_LIMITED
+    if any(pattern in lowered for pattern in _AUTH_PATTERNS):
+        return GhFailureKind.AUTH
+    return GhFailureKind.API_ERROR
+
+
+def _message_for(kind: GhFailureKind, status: int | None) -> str:
+    if kind is GhFailureKind.NETWORK_UNAVAILABLE:
+        return (
+            "Network unavailable — could not reach api.github.com. "
+            "Check connectivity or https://githubstatus.com, then retry."
+        )
+    if kind is GhFailureKind.RATE_LIMITED:
+        return (
+            "GitHub rate limit exceeded — wait for the limit to reset, "
+            "then retry."
+        )
+    if kind is GhFailureKind.AUTH:
+        return (
+            "GitHub credentials rejected — run `gh auth status` "
+            "(then `gh auth login`) and retry."
+        )
+    if kind is GhFailureKind.GH_MISSING:
+        return (
+            "The `gh` CLI was not found — install GitHub CLI and make sure "
+            "it is on PATH."
+        )
+    if status is not None:
+        return f"GitHub API returned an error (HTTP {status})."
+    return "GitHub API call failed."
+
+
+def classify_gh_failure(
+    stderr: str | bytes | None, returncode: int | None = None
+) -> GhFailure:
+    """Classify one `gh` failure from the stderr it wrote."""
+    text = _decode(stderr)
+    kind = _kind_for(text)
+    match = _HTTP_STATUS_RE.search(text)
+    status = int(match.group(1)) if match else None
+    return GhFailure(
+        kind=kind,
+        message=_message_for(kind, status),
+        stderr=text,
+        returncode=returncode,
+        status=status,
+    )
+
+
+def gh_failure_from_exception(exc: BaseException) -> GhFailure:
+    """Classify whatever a `gh` subprocess call raised.
+
+    Handles the three things `subprocess.run(..., check=True)` can throw at
+    a caller: a non-zero exit, a missing binary, and a timeout — plus bare
+    `OSError` for socket-level failures raised by Python rather than gh.
+    """
+    if isinstance(exc, FileNotFoundError):
+        # Checked before OSError: a missing gh is a setup problem, and
+        # calling it "offline" would send operators the wrong way.
+        return GhFailure(
+            kind=GhFailureKind.GH_MISSING,
+            message=_message_for(GhFailureKind.GH_MISSING, None),
+            stderr=str(exc),
+        )
+    if isinstance(exc, subprocess.CalledProcessError):
+        return classify_gh_failure(exc.stderr, returncode=exc.returncode)
+    if isinstance(exc, (subprocess.TimeoutExpired, TimeoutError, OSError)):
+        return GhFailure(
+            kind=GhFailureKind.NETWORK_UNAVAILABLE,
+            message=_message_for(GhFailureKind.NETWORK_UNAVAILABLE, None),
+            stderr=str(exc),
+        )
+    return classify_gh_failure(str(exc))

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -671,3 +671,107 @@ class TestPollerStartForeground:
             "execution must proceed past the PID-file guard into the poll "
             "setup path"
         )
+
+
+def _squash(text: str) -> str:
+    """Strip ANSI and collapse whitespace, so assertions survive Rich's
+    line wrapping at the runner's terminal width."""
+    return " ".join(_plain(text).split())
+
+
+class TestPollerStartGhProbeErrors:
+    """Regression for #32: the startup `gh api user` probe must say what
+    actually went wrong — offline vs unauthenticated vs API error — instead
+    of dumping `Command '[...]' returned non-zero exit status 1.`"""
+
+    def _run_with_gh_stderr(self, config: Path, stderr: str) -> str:
+        exc = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "api", "user", "--jq", ".login"],
+            stderr=stderr,
+        )
+        with (
+            patch("ctrlrelay.core.github._find_gh", return_value="gh"),
+            patch("subprocess.run", side_effect=exc),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "poller",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(config),
+                ],
+            )
+        assert result.exit_code == 1
+        return _squash(result.output)
+
+    def test_offline_reports_network_not_auth(
+        self, telegram_config: Path
+    ) -> None:
+        output = self._run_with_gh_stderr(
+            telegram_config,
+            "error connecting to api.github.com\n"
+            "check your internet connection or https://githubstatus.com",
+        )
+        assert "Network unavailable" in output
+        assert "returned non-zero exit status" not in output
+        assert "gh auth" not in output
+
+    def test_unauthenticated_points_at_gh_auth_status(
+        self, telegram_config: Path
+    ) -> None:
+        output = self._run_with_gh_stderr(
+            telegram_config, "gh: Bad credentials (HTTP 401)"
+        )
+        assert "gh auth status" in output
+        assert "Network unavailable" not in output
+
+    def test_api_error_surfaces_the_status(
+        self, telegram_config: Path
+    ) -> None:
+        output = self._run_with_gh_stderr(
+            telegram_config, "gh: Server Error (HTTP 500)"
+        )
+        assert "500" in output
+        assert "Network unavailable" not in output
+
+    def test_rate_limit_is_named(self, telegram_config: Path) -> None:
+        output = self._run_with_gh_stderr(
+            telegram_config, "gh: API rate limit exceeded (HTTP 403)"
+        )
+        assert "rate limit" in output.lower()
+
+    def test_gh_stderr_is_still_shown(self, telegram_config: Path) -> None:
+        """The classification is a headline, not a replacement — gh's own
+        wording still has to reach the operator."""
+        output = self._run_with_gh_stderr(
+            telegram_config, "gh: Server Error (HTTP 500)"
+        )
+        assert "Server Error" in output
+
+    def test_missing_gh_binary_is_reported(
+        self, telegram_config: Path
+    ) -> None:
+        with (
+            patch("ctrlrelay.core.github._find_gh", return_value="gh"),
+            patch(
+                "subprocess.run",
+                side_effect=FileNotFoundError(2, "No such file or directory"),
+            ),
+        ):
+            result = runner.invoke(
+                app,
+                [
+                    "poller",
+                    "start",
+                    "--foreground",
+                    "--config",
+                    str(telegram_config),
+                ],
+            )
+        assert result.exit_code == 1
+        output = _squash(result.output)
+        assert "gh" in output
+        assert "Traceback" not in output

--- a/tests/test_cli_start.py
+++ b/tests/test_cli_start.py
@@ -775,3 +775,35 @@ class TestPollerStartGhProbeErrors:
         output = _squash(result.output)
         assert "gh" in output
         assert "Traceback" not in output
+
+
+class TestGhStderrIsNotParsedAsMarkup:
+    """`gh` stderr is arbitrary text and Rich parses `[...]` as markup. A
+    stderr containing something like `[/docs]` raised MarkupError, which
+    replaced the diagnostic with a traceback and skipped the exit — losing
+    exactly the raw detail that line exists to show."""
+
+    def test_stderr_with_markup_like_text_still_renders(self) -> None:
+        from rich.console import Console
+
+        from ctrlrelay.cli import rich_escape
+
+        stderr = "gh: Bad credentials (HTTP 401) see [/docs] for details"
+        console = Console(file=__import__("io").StringIO(), no_color=True)
+
+        # The unescaped form is what used to blow up.
+        with pytest.raises(Exception):
+            console.print(f"[dim]gh: {stderr}[/dim]")
+
+        console.print(f"[dim]gh: {rich_escape(stderr)}[/dim]")
+        rendered = console.file.getvalue()
+
+        assert "[/docs]" in rendered
+        assert "Bad credentials" in rendered
+
+    def test_the_probe_is_time_bounded(self) -> None:
+        """Without a timeout a hung gh wedges `poller start` forever, and
+        the classifier's TimeoutExpired branch can never fire."""
+        from ctrlrelay.cli import _GH_PROBE_TIMEOUT_SECONDS
+
+        assert _GH_PROBE_TIMEOUT_SECONDS > 0

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -26,8 +26,6 @@ NETWORK_STDERR = [
     'Get "https://api.github.com/user": dial tcp 140.82.121.5:443: '
     "connect: no route to host",
     'Post "https://api.github.com/graphql": net/http: TLS handshake timeout',
-    'Get "https://api.github.com/user": x509: certificate signed by '
-    "unknown authority",
     'Get "https://api.github.com/user": context deadline exceeded '
     "(Client.Timeout exceeded while awaiting headers)",
     "read tcp 10.0.0.2:52344->140.82.121.5:443: connection reset by peer",
@@ -198,7 +196,11 @@ class TestFromException:
         failure = gh_failure_from_exception(
             OSError(101, "Network is unreachable")
         )
-        assert failure.kind is GhFailureKind.GH_MISSING
+        # ENETUNREACH is not an exec-family errno, so this is not blamed
+        # on the install either — but the invariant that matters is that
+        # it is never reported as connectivity.
+        assert failure.kind is not GhFailureKind.NETWORK_UNAVAILABLE
+        assert "network unavailable" not in failure.message.lower()
 
     def test_timeout_expired_is_network_unavailable(self) -> None:
         exc = subprocess.TimeoutExpired(cmd=["gh", "api", "user"], timeout=30)
@@ -291,3 +293,113 @@ class TestPeerVanishedMidWrite:
         )
 
         assert failure.kind is GhFailureKind.API_ERROR
+
+    def test_resource_exhaustion_is_not_blamed_on_the_gh_install(self) -> None:
+        """EMFILE/ENOMEM also reach us as OSError from a failed spawn, but
+        answering those with "install GitHub CLI" is the same misdirection
+        wearing a different hat. Surface the errno instead."""
+        from ctrlrelay.core.network import GhFailureKind, gh_failure_from_exception
+
+        for exc in (
+            OSError(24, "Too many open files"),
+            OSError(12, "Cannot allocate memory"),
+        ):
+            failure = gh_failure_from_exception(exc)
+
+            assert failure.kind is not GhFailureKind.GH_MISSING
+            assert "install" not in failure.message.lower()
+            assert str(exc.errno) in failure.message or exc.strerror in failure.message
+
+
+class TestTlsTrustIsNotAnOutage:
+    """A CA-trust failure or a skewed clock is a persistent local problem.
+    Reporting it as "network unavailable — retry" is advice that can never
+    work: the operator retries forever behind a corporate proxy whose CA
+    they simply have not installed."""
+
+    @pytest.mark.parametrize(
+        "stderr",
+        [
+            'Get "https://api.github.com/user": x509: certificate signed by '
+            "unknown authority",
+            'Get "https://api.github.com/user": x509: certificate has expired '
+            "or is not yet valid",
+            "SSL certificate problem: unable to get local issuer certificate",
+        ],
+        ids=["unknown-ca", "expired-or-skewed-clock", "no-local-issuer"],
+    )
+    def test_trust_failures_are_not_transient(self, stderr: str) -> None:
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(stderr, returncode=1)
+
+        assert failure.kind is GhFailureKind.TLS_TRUST
+        assert failure.is_transient is False
+        assert "retry" not in failure.message.lower().replace(
+            "retrying will not help", ""
+        )
+
+    def test_a_cert_for_the_wrong_host_stays_a_network_problem(self) -> None:
+        """A certificate valid for someone else is the captive-portal
+        signature — that really is connectivity, and it clears itself."""
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            'Get "https://api.github.com/user": x509: certificate is valid '
+            "for portal.hotel.example, not api.github.com",
+            returncode=1,
+        )
+
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+        assert failure.is_transient is True
+
+
+class TestTransportFailuresNeverReadAsApiErrors:
+    """Go renders a failed round-trip as `Get "url": <cause>`, which by
+    construction means no HTTP response arrived. `gh api` prints a real
+    API error in the other shape entirely, `gh: <msg> (HTTP nnn)`. Keying
+    on the shape catches the whole family instead of chasing each new
+    wording as a string."""
+
+    @pytest.mark.parametrize(
+        "cause",
+        [
+            "EOF",
+            "unexpected EOF",
+            "http2: client connection lost",
+            "net/http: request canceled while waiting for connection",
+            "remote error: tls: handshake failure",
+        ],
+    )
+    def test_url_error_shape_is_a_network_failure(self, cause: str) -> None:
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            f'Get "https://api.github.com/user": {cause}', returncode=1
+        )
+
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+
+    def test_an_api_error_mentioning_eof_is_still_an_api_error(self) -> None:
+        """The shape is what separates them, not the word: a real API
+        error carries `(HTTP nnn)` and no url.Error prefix."""
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            "gh: Validation failed, unexpected EOF in body (HTTP 422)",
+            returncode=1,
+        )
+
+        assert failure.kind is GhFailureKind.API_ERROR
+
+    def test_established_socket_timeout_is_a_network_failure(self) -> None:
+        """ETIMEDOUT on an open socket — a link dropped mid-request."""
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            "read tcp 10.0.0.2:52344->140.82.121.5:443: read: "
+            "connection timed out",
+            returncode=1,
+        )
+
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -262,3 +262,32 @@ class TestExecFailuresAreNotReportedAsOffline:
 
         assert "could not be run" in message
         assert "executable" in message
+
+
+class TestPeerVanishedMidWrite:
+    """`write tcp …: write: broken pipe` is a connectivity failure that
+    contains none of the other network markers, so it fell through to
+    API_ERROR — a miss of this classifier's own purpose."""
+
+    def test_broken_pipe_reads_as_a_network_failure(self) -> None:
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            "write tcp 10.0.0.5:52341->140.82.114.6:443: write: broken pipe",
+            returncode=1,
+        )
+
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+
+    def test_eof_in_an_api_body_is_not_treated_as_an_outage(self) -> None:
+        """The reason bare "EOF" is deliberately not a network pattern:
+        gh passes API response bodies through verbatim, so matching it
+        would misclassify real API errors as outages — the same mistake
+        in the other direction."""
+        from ctrlrelay.core.network import GhFailureKind, classify_gh_failure
+
+        failure = classify_gh_failure(
+            "HTTP 422: Validation failed, unexpected EOF in body", returncode=1
+        )
+
+        assert failure.kind is GhFailureKind.API_ERROR

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -188,13 +188,17 @@ class TestFromException:
         assert failure.kind is GhFailureKind.API_ERROR
         assert failure.returncode == 1
 
-    def test_os_error_is_network_unavailable(self) -> None:
-        """A DNS/socket failure raised by Python itself (not gh) is still
-        an offline signal."""
+    def test_os_error_points_at_the_gh_install_not_the_network(self) -> None:
+        """`subprocess.run` raising OSError means the child could not be
+        EXEC'd. Python does no networking here — gh does — so even an
+        errno that reads like connectivity (ENETUNREACH) reached us
+        because the spawn failed, not because a socket did. Calling it
+        "offline" sends the operator to check their wifi while their gh
+        install is broken."""
         failure = gh_failure_from_exception(
             OSError(101, "Network is unreachable")
         )
-        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+        assert failure.kind is GhFailureKind.GH_MISSING
 
     def test_timeout_expired_is_network_unavailable(self) -> None:
         exc = subprocess.TimeoutExpired(cmd=["gh", "api", "user"], timeout=30)
@@ -210,3 +214,51 @@ class TestFromException:
         )
         assert failure.kind is GhFailureKind.GH_MISSING
         assert "gh" in failure.message
+
+
+class TestExecFailuresAreNotReportedAsOffline:
+    """`subprocess.run` raising OSError means the child could not be
+    EXEC'd — Python is not doing the networking here, gh is. Classifying
+    those as NETWORK_UNAVAILABLE is the exact misdiagnosis this module
+    exists to prevent: it sends the operator to check their wifi while
+    their gh install is broken."""
+
+    @pytest.mark.parametrize(
+        "exc",
+        [
+            PermissionError(13, "Permission denied"),
+            IsADirectoryError(21, "Is a directory"),
+            NotADirectoryError(20, "Not a directory"),
+            OSError(8, "Exec format error"),
+        ],
+        ids=["not-executable", "is-a-directory", "bad-path", "wrong-arch"],
+    )
+    def test_exec_failure_points_at_the_install(self, exc: OSError) -> None:
+        from ctrlrelay.core.network import GhFailureKind, gh_failure_from_exception
+
+        failure = gh_failure_from_exception(exc)
+
+        assert failure.kind is GhFailureKind.GH_MISSING
+        assert "network" not in failure.message.lower()
+        assert "connectivity" not in failure.message.lower()
+
+    def test_a_hung_gh_still_reads_as_a_network_problem(self) -> None:
+        """The one exception shape that really does suggest connectivity:
+        the child launched and then stopped responding."""
+        from ctrlrelay.core.network import GhFailureKind, gh_failure_from_exception
+
+        assert (
+            gh_failure_from_exception(TimeoutError("timed out")).kind
+            is GhFailureKind.NETWORK_UNAVAILABLE
+        )
+
+    def test_missing_binary_message_covers_unusable_not_just_absent(self) -> None:
+        """A gh that exists but cannot run is not 'not found'."""
+        from ctrlrelay.core.network import gh_failure_from_exception
+
+        message = gh_failure_from_exception(
+            PermissionError(13, "Permission denied")
+        ).message
+
+        assert "could not be run" in message
+        assert "executable" in message

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,212 @@
+"""Tests for the gh failure classifier (`ctrlrelay.core.network`)."""
+
+from __future__ import annotations
+
+import subprocess
+
+import pytest
+
+from ctrlrelay.core.network import (
+    GhFailureKind,
+    classify_gh_failure,
+    gh_failure_from_exception,
+)
+
+# Representative stderr strings. The offline one is gh's own wording,
+# copied from a real poll cycle on a disconnected laptop.
+NETWORK_STDERR = [
+    (
+        "error connecting to api.github.com\n"
+        "check your internet connection or https://githubstatus.com"
+    ),
+    'Get "https://api.github.com/user": dial tcp: lookup api.github.com: '
+    "no such host",
+    'Get "https://api.github.com/user": dial tcp 140.82.121.5:443: '
+    "connect: network is unreachable",
+    'Get "https://api.github.com/user": dial tcp 140.82.121.5:443: '
+    "connect: no route to host",
+    'Post "https://api.github.com/graphql": net/http: TLS handshake timeout',
+    'Get "https://api.github.com/user": x509: certificate signed by '
+    "unknown authority",
+    'Get "https://api.github.com/user": context deadline exceeded '
+    "(Client.Timeout exceeded while awaiting headers)",
+    "read tcp 10.0.0.2:52344->140.82.121.5:443: connection reset by peer",
+    "Temporary failure in name resolution",
+]
+
+AUTH_STDERR = [
+    "gh: Bad credentials (HTTP 401)",
+    "gh: Requires authentication (HTTP 401)",
+    "To get started with GitHub CLI, please run:  gh auth login",
+    "error: not logged into any GitHub hosts. Run gh auth login to authenticate.",
+    "gh: This API operation needs the 'read:org' scope. "
+    "Please make sure your token has the required scopes.",
+]
+
+RATE_LIMIT_STDERR = [
+    "gh: API rate limit exceeded for user ID 12345. (HTTP 403)",
+    "gh: You have exceeded a secondary rate limit (HTTP 403)",
+    "gh: Too Many Requests (HTTP 429)",
+]
+
+API_ERROR_STDERR = [
+    "gh: Not Found (HTTP 404)",
+    "gh: Server Error (HTTP 500)",
+    "gh: Validation Failed (HTTP 422)",
+    "some unfamiliar failure",
+    "",
+]
+
+
+class TestClassification:
+    @pytest.mark.parametrize("stderr", NETWORK_STDERR)
+    def test_network_failures(self, stderr: str) -> None:
+        failure = classify_gh_failure(stderr, returncode=1)
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+
+    @pytest.mark.parametrize("stderr", AUTH_STDERR)
+    def test_auth_failures(self, stderr: str) -> None:
+        failure = classify_gh_failure(stderr, returncode=1)
+        assert failure.kind is GhFailureKind.AUTH
+
+    @pytest.mark.parametrize("stderr", RATE_LIMIT_STDERR)
+    def test_rate_limit_failures(self, stderr: str) -> None:
+        failure = classify_gh_failure(stderr, returncode=1)
+        assert failure.kind is GhFailureKind.RATE_LIMITED
+
+    @pytest.mark.parametrize("stderr", API_ERROR_STDERR)
+    def test_other_failures_are_api_errors(self, stderr: str) -> None:
+        failure = classify_gh_failure(stderr, returncode=1)
+        assert failure.kind is GhFailureKind.API_ERROR
+
+    def test_rate_limit_wins_over_auth(self) -> None:
+        """A 403 rate-limit body mentions the authenticated user; it must
+        still classify as rate limiting, not as an auth problem."""
+        stderr = (
+            "gh: API rate limit exceeded for user ID 1. "
+            "Authenticated requests get a higher rate limit. (HTTP 403)"
+        )
+        assert (
+            classify_gh_failure(stderr, returncode=1).kind
+            is GhFailureKind.RATE_LIMITED
+        )
+
+    def test_network_wins_over_api_status(self) -> None:
+        """A connection error that happens to carry a status-looking string
+        is still a network failure."""
+        stderr = "error connecting to api.github.com (HTTP 000)"
+        assert (
+            classify_gh_failure(stderr, returncode=1).kind
+            is GhFailureKind.NETWORK_UNAVAILABLE
+        )
+
+    def test_classification_is_case_insensitive(self) -> None:
+        assert (
+            classify_gh_failure("ERROR CONNECTING TO API.GITHUB.COM").kind
+            is GhFailureKind.NETWORK_UNAVAILABLE
+        )
+
+    def test_bytes_stderr_is_decoded(self) -> None:
+        failure = classify_gh_failure(b"gh: Bad credentials (HTTP 401)")
+        assert failure.kind is GhFailureKind.AUTH
+
+    def test_none_stderr_is_api_error(self) -> None:
+        failure = classify_gh_failure(None, returncode=1)
+        assert failure.kind is GhFailureKind.API_ERROR
+        assert failure.stderr == ""
+
+
+class TestFailureDetails:
+    def test_http_status_is_extracted(self) -> None:
+        failure = classify_gh_failure("gh: Server Error (HTTP 500)")
+        assert failure.status == 500
+
+    def test_no_http_status_is_none(self) -> None:
+        failure = classify_gh_failure("error connecting to api.github.com")
+        assert failure.status is None
+
+    def test_returncode_is_carried(self) -> None:
+        assert classify_gh_failure("boom", returncode=2).returncode == 2
+
+    def test_stderr_is_stripped_and_kept(self) -> None:
+        failure = classify_gh_failure("  gh: Not Found (HTTP 404)\n")
+        assert failure.stderr == "gh: Not Found (HTTP 404)"
+
+
+class TestMessages:
+    def test_network_message_says_offline_not_auth(self) -> None:
+        message = classify_gh_failure(
+            "error connecting to api.github.com"
+        ).message
+        assert "network" in message.lower()
+        assert "auth" not in message.lower()
+
+    def test_auth_message_suggests_gh_auth_status(self) -> None:
+        message = classify_gh_failure("gh: Bad credentials (HTTP 401)").message
+        assert "gh auth status" in message
+
+    def test_rate_limit_message_mentions_rate_limit(self) -> None:
+        message = classify_gh_failure(
+            "gh: API rate limit exceeded (HTTP 403)"
+        ).message
+        assert "rate limit" in message.lower()
+
+    def test_api_error_message_surfaces_status(self) -> None:
+        message = classify_gh_failure("gh: Server Error (HTTP 500)").message
+        assert "500" in message
+
+    def test_api_error_message_without_status_still_readable(self) -> None:
+        message = classify_gh_failure("weird thing happened").message
+        assert message
+        assert "GitHub API" in message
+
+
+class TestFromException:
+    def test_called_process_error_with_text_stderr(self) -> None:
+        exc = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "api", "user"],
+            stderr="error connecting to api.github.com",
+        )
+        failure = gh_failure_from_exception(exc)
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+        assert failure.returncode == 1
+
+    def test_called_process_error_with_bytes_stderr(self) -> None:
+        exc = subprocess.CalledProcessError(
+            returncode=1,
+            cmd=["gh", "api", "user"],
+            stderr=b"gh: Bad credentials (HTTP 401)",
+        )
+        assert gh_failure_from_exception(exc).kind is GhFailureKind.AUTH
+
+    def test_called_process_error_without_stderr(self) -> None:
+        exc = subprocess.CalledProcessError(
+            returncode=1, cmd=["gh", "api", "user"]
+        )
+        failure = gh_failure_from_exception(exc)
+        assert failure.kind is GhFailureKind.API_ERROR
+        assert failure.returncode == 1
+
+    def test_os_error_is_network_unavailable(self) -> None:
+        """A DNS/socket failure raised by Python itself (not gh) is still
+        an offline signal."""
+        failure = gh_failure_from_exception(
+            OSError(101, "Network is unreachable")
+        )
+        assert failure.kind is GhFailureKind.NETWORK_UNAVAILABLE
+
+    def test_timeout_expired_is_network_unavailable(self) -> None:
+        exc = subprocess.TimeoutExpired(cmd=["gh", "api", "user"], timeout=30)
+        assert (
+            gh_failure_from_exception(exc).kind
+            is GhFailureKind.NETWORK_UNAVAILABLE
+        )
+
+    def test_file_not_found_is_not_swallowed_as_network(self) -> None:
+        """gh missing from PATH is a setup problem, not connectivity."""
+        failure = gh_failure_from_exception(
+            FileNotFoundError(2, "No such file or directory")
+        )
+        assert failure.kind is GhFailureKind.GH_MISSING
+        assert "gh" in failure.message


### PR DESCRIPTION
Closes #32

## Problem

`poller start` probes `gh api user --jq .login` before it does anything
else. `gh` exits 1 for every kind of failure — unplugged network, expired
token, a 500 from the API — and the handler printed the raw exception:

```
Failed to get GitHub username: Command '['/opt/homebrew/bin/gh', 'api', 'user', '--jq', '.login']' returned non-zero exit status 1.
```

That reads like broken auth regardless of cause, and the most common cause
is simply being offline.

## Change

`src/ctrlrelay/core/network.py` classifies a `gh` failure from the stderr
`gh` itself writes:

| kind | example stderr |
| --- | --- |
| `NETWORK_UNAVAILABLE` | `error connecting to api.github.com`, `dial tcp: lookup api.github.com: no such host`, TLS handshake / x509 failures |
| `RATE_LIMITED` | `API rate limit exceeded ... (HTTP 403)`, `HTTP 429` |
| `AUTH` | `Bad credentials (HTTP 401)`, `not logged into any GitHub hosts` |
| `API_ERROR` | anything else non-zero, with the HTTP status surfaced |
| `GH_MISSING` | `gh` not on PATH (`FileNotFoundError`) |

Rate limiting is matched before auth, because a 403 rate-limit body says
"Authenticated requests get a higher rate limit" and would otherwise be
misread as an auth problem.

The startup site prints the matching message — yellow when the cause is
transient, red otherwise — and still prints gh's own stderr underneath, so
nothing is hidden.

## Scope

Narrowed per the issue discussion. The async `gh` wrapper already raises a
typed `GitHubError` carrying gh's stderr, and the poller renders it as a
structured `poll.repo.skipped` event with a per-repo failure counter, so
those paths already read correctly and are untouched. Retry/backoff and
offline queuing remain out of scope.

## Tests

- `tests/test_network.py` — 42 cases over the classifier: every branch with
  representative stderr strings, precedence (rate limit over auth, network
  over an HTTP status), bytes/None stderr, HTTP status extraction, and
  exception mapping for `CalledProcessError` / `TimeoutExpired` / `OSError`
  / `FileNotFoundError`.
- `tests/test_cli_start.py::TestPollerStartGhProbeErrors` — drives
  `poller start --foreground` with a mocked `subprocess.run` and asserts the
  offline case never says "auth", the auth case points at `gh auth status`,
  the API case surfaces the status, and the raw
  `returned non-zero exit status` string is gone.

Full suite: 836 passed. `ruff check src/ tests/` clean.

## After merge

Touches `src/` — restart the launchd / systemd services per
`docs/operations.md`.