### PR TITLE
fix(obs): stop logging questions that were never posted, and their text

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lives in `is_ambiguous_delivery` next to the library that defines the
   taxonomy. `TransportTimeoutError` subclasses
   `TransportUnknownDeliveryError` subclasses `TransportError`, so
-  existing handlers are unaffected.
+  existing handlers are unaffected. The bridge's ERROR response carries
+  which of the two it was (`telegram_delivery_unknown` vs
+  `telegram_api_error`) rather than letting the transport re-derive it —
+  the transport cannot see the Telegram exception, so a generic error
+  forced it to assume the worst and contradict the bridge's own record
+  for the same `request_id`.
+
+  **Known limit:** python-telegram-bot raises `TimedOut` for an HTTPX
+  connection-pool timeout too, where the request was never sent. That
+  case is currently reported as unknown rather than as the definite
+  non-delivery it is. Separating it means matching on library internals,
+  which is more fragile than the mislabelling is harmful.
 
 - **`dev.question.posted` no longer claims a delivery that never
   happened.** The transport logged it before writing to the socket and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **A slow post is no longer logged as a failed one.** The bridge ACKs
+  only after Telegram has accepted a question, so a post slower than the
+  transport's wait meant the transport timed out first and logged
+  `dev.question.post_failed` while the bridge logged
+  `dev.question.posted` for the same request — a false claim in the
+  opposite direction to the one being fixed. A timeout now emits
+  `dev.question.post_unknown`, because the outcome genuinely is unknown;
+  a write that actually failed keeps the definite `post_failed`.
+  `TransportTimeoutError` subclasses `TransportError`, so existing
+  handlers are unaffected.
+
 - **`dev.question.posted` no longer claims a delivery that never
   happened.** The transport logged it before writing to the socket and the
   bridge logged it before calling Telegram, so a failed write or a Telegram

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- **`dev.question.posted` no longer claims a delivery that never
+  happened.** The transport logged it before writing to the socket and the
+  bridge logged it before calling Telegram, so a failed write or a Telegram
+  outage still left a record saying the operator had been asked. The
+  transport now emits it on the bridge's ACK — the only signal that says
+  the question actually reached Telegram — and the bridge emits it after
+  the API accepts the message, tagged with `telegram_msg_id`. Both sides
+  emit `dev.question.post_failed` (with `reason` and a truncated `error`)
+  on the failure path instead. A question that is posted and then goes
+  unanswered still logs only `posted`: the delivery succeeded, the operator
+  just did not reply.
+- **Questions and operator answers are no longer written to logs in
+  plaintext.** Every event already carried `question_hash` / `answer_hash`,
+  and then defeated it by logging the raw text in the field next door.
+  These records go to stdout and are captured into `~/.ctrlrelay/logs` and
+  the systemd journal, so free-text operator replies — and questions that
+  now enumerate every open PR in a repo — persisted there indefinitely with
+  no retention policy tuned for that content. The hash and length remain,
+  which is enough to correlate the same question across the poller and
+  bridge logs. A test walks the source and fails on any `log_event()` call
+  that passes a raw payload field.
 - **A broken `gh` install no longer reports itself as "network
   unavailable".** `subprocess.run` raising `OSError` means the child could
   not be exec'd — a non-executable binary, a bad path, a wrong

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opposite direction to the one being fixed. A timeout now emits
   `dev.question.post_unknown`, because the outcome genuinely is unknown;
   a write that actually failed keeps the definite `post_failed`.
-  `TransportTimeoutError` subclasses `TransportError`, so existing
-  handlers are unaffected.
+  Delivery is only ever confirmed by the far side's acknowledgement;
+  everything else divides into "the bytes provably never left" (a
+  definite failure) and "they may have" (unknown). A `drain()` failure
+  is unknown — `write()` had already handed the data over — and on the
+  bridge, a Telegram timeout or bare transport error is unknown too,
+  while `BadRequest`/`Forbidden`/`InvalidToken` are Telegram answering
+  "no". Note `BadRequest` subclasses `NetworkError` in
+  python-telegram-bot, so that check cannot be a plain isinstance; it
+  lives in `is_ambiguous_delivery` next to the library that defines the
+  taxonomy. `TransportTimeoutError` subclasses
+  `TransportUnknownDeliveryError` subclasses `TransportError`, so
+  existing handlers are unaffected.
 
 - **`dev.question.posted` no longer claims a delivery that never
   happened.** The transport logged it before writing to the socket and the

--- a/docs/operations.md
+++ b/docs/operations.md
@@ -333,6 +333,29 @@ The events it emits:
 Prompts and agent output never appear in plaintext: only a short SHA-256
 prefix and a length are logged.
 
+### Blocked-question events
+
+When a session blocks on a question, the transport and the bridge each emit
+their own record:
+
+| Event | When |
+|---|---|
+| `dev.question.posted` | The question reached the operator. The transport emits it on the bridge's ACK; the bridge emits it once the Telegram API has accepted the message, and adds `telegram_msg_id`. |
+| `dev.question.post_failed` | Delivery failed. Carries `reason` (`send_failed`, `bridge_error`, or the exception class on the bridge side) and a truncated `error`. |
+| `dev.answer.received` | The operator's reply came back. |
+
+Neither the question nor the answer is written to the log. Each event carries
+`question_hash` / `question_length` (or `answer_hash` / `answer_length`)
+instead — the hash is stable, so it still joins the poller's record to the
+bridge's record for the same question:
+
+```bash
+grep 44509098fa6eeaf3 ~/.ctrlrelay/logs/*.log | jq -c '{ts, logger, event}'
+```
+
+This matters because these files and the systemd journal have no retention
+policy tuned for human-entered content, and operator replies are free text.
+
 ## Inspecting state
 
 ### `ctrlrelay status`

--- a/src/ctrlrelay/bridge/server.py
+++ b/src/ctrlrelay/bridge/server.py
@@ -389,7 +389,16 @@ class BridgeServer:
                 return BridgeMessage(
                     op=BridgeOp.ERROR,
                     request_id=msg.request_id,
-                    error="telegram_api_error",
+                    # Carry the classification instead of letting the
+                    # other side re-derive it: the transport cannot see
+                    # the Telegram exception, so a generic ERROR forced
+                    # it to assume the worst and contradict the
+                    # post_unknown just logged here for the same request.
+                    error=(
+                        "telegram_delivery_unknown"
+                        if unknown
+                        else "telegram_api_error"
+                    ),
                     message=str(e),
                 )
 

--- a/src/ctrlrelay/bridge/server.py
+++ b/src/ctrlrelay/bridge/server.py
@@ -298,6 +298,23 @@ class BridgeServer:
                 )
 
         if msg.op == BridgeOp.ASK:
+            question = msg.question or ""
+            # Hash + length only: these records land in the journal and in
+            # poller.log, so the question text itself would persist there in
+            # plaintext indefinitely. The hash still joins this event to the
+            # client's own dev.question.posted. Built outside the try so the
+            # failure path can always describe what failed.
+            post_fields = {
+                "session_id": msg.session_id,
+                "repo": msg.repo,
+                "issue_number": msg.issue_number,
+                "transport": "telegram",
+                "destination": f"telegram:chat={self.chat_id}",
+                "request_id": msg.request_id,
+                "question_length": len(question),
+                "question_hash": hash_text(question),
+                "options": msg.options,
+            }
             try:
                 assert self._telegram is not None
                 # Start the expiry clock before the Telegram round trip, not
@@ -308,21 +325,6 @@ class BridgeServer:
                 # reply-to in that window writes the answer into a dead
                 # request.
                 received_at = time.monotonic()
-                question = msg.question or ""
-                log_event(
-                    _logger,
-                    "dev.question.posted",
-                    session_id=msg.session_id,
-                    repo=msg.repo,
-                    issue_number=msg.issue_number,
-                    transport="telegram",
-                    destination=f"telegram:chat={self.chat_id}",
-                    request_id=msg.request_id,
-                    question=question,
-                    question_length=len(question),
-                    question_hash=hash_text(question),
-                    options=msg.options,
-                )
                 telegram_msg_id = await self._telegram.ask(
                     format_question(
                         question,
@@ -350,11 +352,26 @@ class BridgeServer:
                     "bridge: ASK posted request_id=%s telegram_msg_id=%s",
                     msg.request_id, telegram_msg_id,
                 )
+                # Emitted here, not before the send: until Telegram has
+                # accepted the message there is nothing posted to claim.
+                log_event(
+                    _logger,
+                    "dev.question.posted",
+                    **post_fields,
+                    telegram_msg_id=telegram_msg_id,
+                )
                 return BridgeMessage(
                     op=BridgeOp.ACK, request_id=msg.request_id, status="pending",
                 )
             except Exception as e:
                 _log.warning("bridge: ASK failed, request_id=%s err=%s", msg.request_id, e)
+                log_event(
+                    _logger,
+                    "dev.question.post_failed",
+                    **post_fields,
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                )
                 return BridgeMessage(
                     op=BridgeOp.ERROR,
                     request_id=msg.request_id,
@@ -473,7 +490,6 @@ class BridgeServer:
             request_id=match.request_id,
             telegram_msg_id=match.telegram_msg_id,
             reply_to_message_id=reply_to_message_id,
-            answer=text,
             answer_length=len(text),
             answer_hash=hash_text(text),
         )

--- a/src/ctrlrelay/bridge/server.py
+++ b/src/ctrlrelay/bridge/server.py
@@ -19,7 +19,10 @@ from ctrlrelay.bridge.protocol import (
     parse_message,
     serialize_message,
 )
-from ctrlrelay.bridge.telegram_handler import TelegramHandler
+from ctrlrelay.bridge.telegram_handler import (
+    TelegramHandler,
+    is_ambiguous_delivery,
+)
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
 
 if TYPE_CHECKING:
@@ -365,9 +368,20 @@ class BridgeServer:
                 )
             except Exception as e:
                 _log.warning("bridge: ASK failed, request_id=%s err=%s", msg.request_id, e)
+                # Same rule as the transport: only claim a definite
+                # failure when Telegram actually answered. A timeout or a
+                # bare transport error can be raised after Telegram
+                # accepted the message, in which case the question IS on
+                # the operator's phone and "post_failed" is a lie.
+                #
+                # The taxonomy is not intuitive, so it lives next to the
+                # library that defines it — see is_ambiguous_delivery.
+                unknown = is_ambiguous_delivery(e)
                 log_event(
                     _logger,
-                    "dev.question.post_failed",
+                    "dev.question.post_unknown"
+                    if unknown
+                    else "dev.question.post_failed",
                     **post_fields,
                     reason=type(e).__name__,
                     error=str(e)[:200],

--- a/src/ctrlrelay/bridge/telegram_handler.py
+++ b/src/ctrlrelay/bridge/telegram_handler.py
@@ -7,11 +7,30 @@ import logging
 from typing import Awaitable, Callable
 
 from telegram import Bot, ReplyKeyboardMarkup, ReplyKeyboardRemove
+from telegram.error import NetworkError, TimedOut
 
 _log = logging.getLogger(__name__)
 
 IncomingMessageHandler = Callable[[str, int | None], Awaitable[None]]
 
+
+
+def is_ambiguous_delivery(exc: BaseException) -> bool:
+    """True when a send may have reached Telegram despite raising.
+
+    Delivery is only confirmed by a response. A timeout or a bare
+    transport error can be raised *after* Telegram accepted the message,
+    so calling those a failed post would put a lie in the log while the
+    question sits on the operator's phone.
+
+    The taxonomy is not intuitive and is worth stating: `BadRequest`
+    subclasses `NetworkError` here, so `isinstance(exc, NetworkError)`
+    would sweep definite rejections into the ambiguous bucket. Only
+    `TimedOut` and a bare `NetworkError` are genuinely unknown —
+    `BadRequest`, `Forbidden`, `InvalidToken` and the rest are Telegram
+    answering "no".
+    """
+    return isinstance(exc, TimedOut) or type(exc) is NetworkError
 
 class TelegramHandler:
     """Handles Telegram Bot API communication — outbound (send/ask) and

--- a/src/ctrlrelay/transports/base.py
+++ b/src/ctrlrelay/transports/base.py
@@ -9,14 +9,24 @@ class TransportError(Exception):
     """Raised when transport operations fail."""
 
 
-class TransportTimeoutError(TransportError):
-    """Raised when a request was sent but no reply arrived in time.
+class TransportUnknownDeliveryError(TransportError):
+    """Raised when a request may or may not have been delivered.
 
-    Distinct from its parent because the outcomes differ: a write that
-    failed is a known non-delivery, whereas a timeout leaves delivery
-    genuinely unknown — the bridge may still post the question after we
-    stop waiting. Subclasses TransportError so existing handlers are
-    unaffected.
+    Delivery is only ever *confirmed* by the far side's acknowledgement.
+    Everything else divides in two: we know the bytes never left (a
+    definite failure), or we do not (unknown). Enumerating individual
+    ambiguous cases does not converge — the honest discriminator is
+    whether anything was written at all.
+
+    Subclasses TransportError so existing handlers are unaffected.
+    """
+
+
+class TransportTimeoutError(TransportUnknownDeliveryError):
+    """Sent, but no reply arrived in time.
+
+    A specific unknown: the request went out and the far side may still
+    act on it after we stop waiting.
     """
 
 

--- a/src/ctrlrelay/transports/base.py
+++ b/src/ctrlrelay/transports/base.py
@@ -9,6 +9,17 @@ class TransportError(Exception):
     """Raised when transport operations fail."""
 
 
+class TransportTimeoutError(TransportError):
+    """Raised when a request was sent but no reply arrived in time.
+
+    Distinct from its parent because the outcomes differ: a write that
+    failed is a known non-delivery, whereas a timeout leaves delivery
+    genuinely unknown — the bridge may still post the question after we
+    stop waiting. Subclasses TransportError so existing handlers are
+    unaffected.
+    """
+
+
 @runtime_checkable
 class Transport(Protocol):
     """Protocol for orchestrator-to-human communication.

--- a/src/ctrlrelay/transports/file_mock.py
+++ b/src/ctrlrelay/transports/file_mock.py
@@ -57,6 +57,9 @@ class FileMockTransport:
         with self.outbox.open("a") as f:
             f.write(f"[{timestamp}] QUESTION: {question}{opts}\n")
 
+        # Logged only after the outbox write, and without the question text:
+        # hash + length are enough to correlate, and keep operator content
+        # out of the log stream.
         log_event(
             _logger,
             "dev.question.posted",
@@ -65,7 +68,6 @@ class FileMockTransport:
             issue_number=issue_number,
             transport="file_mock",
             destination=str(self.outbox),
-            question=question,
             question_length=len(question),
             question_hash=hash_text(question),
             options=options,
@@ -85,7 +87,6 @@ class FileMockTransport:
                     repo=repo,
                     issue_number=issue_number,
                     transport="file_mock",
-                    answer=answer,
                     answer_length=len(answer),
                     answer_hash=hash_text(answer),
                     elapsed_ms=int((time.monotonic() - sent_at) * 1000),

--- a/src/ctrlrelay/transports/socket_client.py
+++ b/src/ctrlrelay/transports/socket_client.py
@@ -247,9 +247,16 @@ class SocketTransport:
 
         if response.op == BridgeOp.ERROR:
             if not posted:
+                # The bridge knows whether Telegram answered; we do not.
+                # Re-deriving it here is what produced contradictory
+                # pairs — post_unknown on the bridge, post_failed on the
+                # transport, same request_id.
+                bridge_unknown = response.error == "telegram_delivery_unknown"
                 log_event(
                     _logger,
-                    "dev.question.post_failed",
+                    "dev.question.post_unknown"
+                    if bridge_unknown
+                    else "dev.question.post_failed",
                     **common,
                     reason="bridge_error",
                     error=str(response.message)[:200],

--- a/src/ctrlrelay/transports/socket_client.py
+++ b/src/ctrlrelay/transports/socket_client.py
@@ -16,7 +16,7 @@ from ctrlrelay.bridge.protocol import (
     serialize_message,
 )
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
-from ctrlrelay.transports.base import TransportError
+from ctrlrelay.transports.base import TransportError, TransportTimeoutError
 
 _logger = get_logger("transport.socket")
 
@@ -122,7 +122,7 @@ class SocketTransport:
             await self._send_message(msg)
             return await asyncio.wait_for(future, timeout=timeout)
         except asyncio.TimeoutError as e:
-            raise TransportError("Timeout waiting for response") from e
+            raise TransportTimeoutError("Timeout waiting for response") from e
         finally:
             self._pending.pop(msg.request_id, None)
             self._on_ack.pop(msg.request_id, None)
@@ -204,11 +204,21 @@ class SocketTransport:
             response = await self._send_and_wait(msg, timeout, on_ack=_mark_posted)
         except Exception as e:
             if not posted:
+                # A timeout is not a failed delivery. The bridge ACKs only
+                # after Telegram has accepted the message, so a post slower
+                # than our wait leaves us timing out first and the bridge
+                # succeeding afterwards — logging "post_failed" there would
+                # contradict the bridge's own "posted", which is the same
+                # false-claim problem this change exists to remove, just
+                # pointing the other way.
+                timed_out = isinstance(e, TransportTimeoutError)
                 log_event(
                     _logger,
-                    "dev.question.post_failed",
+                    "dev.question.post_unknown"
+                    if timed_out
+                    else "dev.question.post_failed",
                     **common,
-                    reason="send_failed",
+                    reason="timeout_no_ack" if timed_out else "send_failed",
                     error=str(e)[:200],
                 )
             raise

--- a/src/ctrlrelay/transports/socket_client.py
+++ b/src/ctrlrelay/transports/socket_client.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 
 from ctrlrelay.bridge.protocol import (
@@ -38,6 +39,7 @@ class SocketTransport:
         self._reader: asyncio.StreamReader | None = None
         self._writer: asyncio.StreamWriter | None = None
         self._pending: dict[str, asyncio.Future[BridgeMessage]] = {}
+        self._on_ack: dict[str, Callable[[], None]] = {}
         self._receive_task: asyncio.Task | None = None
 
     @property
@@ -75,6 +77,12 @@ class SocketTransport:
                         # waiting. Terminal ACKs (status="sent" from SEND)
                         # remain the final response and resolve normally.
                         if msg.op == BridgeOp.ACK and msg.status == "pending":
+                            # This ACK is also the only proof the bridge got
+                            # the question in front of the operator, so it is
+                            # what "posted" is allowed to mean.
+                            callback = self._on_ack.get(msg.request_id)
+                            if callback is not None:
+                                callback()
                             continue
                         self._pending[msg.request_id].set_result(msg)
                 except ProtocolError:
@@ -91,11 +99,24 @@ class SocketTransport:
         self._writer.write(data)
         await self._writer.drain()
 
-    async def _send_and_wait(self, msg: BridgeMessage, timeout: int) -> BridgeMessage:
-        """Send message and wait for response."""
+    async def _send_and_wait(
+        self,
+        msg: BridgeMessage,
+        timeout: int,
+        *,
+        on_ack: Callable[[], None] | None = None,
+    ) -> BridgeMessage:
+        """Send message and wait for response.
+
+        ``on_ack`` fires from the receive loop when the bridge sends its
+        intermediate ACK — the point at which the request is known to have
+        been accepted, as opposed to merely written to the socket.
+        """
         assert msg.request_id is not None
         future: asyncio.Future[BridgeMessage] = asyncio.get_event_loop().create_future()
         self._pending[msg.request_id] = future
+        if on_ack is not None:
+            self._on_ack[msg.request_id] = on_ack
 
         try:
             await self._send_message(msg)
@@ -104,6 +125,7 @@ class SocketTransport:
             raise TransportError("Timeout waiting for response") from e
         finally:
             self._pending.pop(msg.request_id, None)
+            self._on_ack.pop(msg.request_id, None)
 
     async def send(
         self,
@@ -150,27 +172,62 @@ class SocketTransport:
             issue_number=issue_number,
         )
 
-        log_event(
-            _logger,
-            "dev.question.posted",
-            session_id=session_id,
-            repo=repo,
-            issue_number=issue_number,
-            transport="socket",
-            destination=str(self.socket_path),
-            request_id=request_id,
-            question=question,
-            question_length=len(question),
-            question_hash=hash_text(question),
-            options=options,
-        )
+        # The question itself never reaches the log stream: these records go
+        # to stdout and are captured into ~/.ctrlrelay/logs, where operator
+        # content would sit in plaintext with no retention policy. The hash
+        # is enough to correlate one question across poller and bridge.
+        common = {
+            "session_id": session_id,
+            "repo": repo,
+            "issue_number": issue_number,
+            "transport": "socket",
+            "destination": str(self.socket_path),
+            "request_id": request_id,
+            "question_length": len(question),
+            "question_hash": hash_text(question),
+            "options": options,
+        }
+
+        posted = False
+
+        def _mark_posted() -> None:
+            # Fired by the receive loop on the bridge's ACK, which is the
+            # first moment the question is known to have reached Telegram.
+            # Logging before the write would claim a delivery that a failed
+            # socket write or a Telegram outage never made.
+            nonlocal posted
+            posted = True
+            log_event(_logger, "dev.question.posted", **common)
 
         sent_at = time.monotonic()
-        response = await self._send_and_wait(msg, timeout)
+        try:
+            response = await self._send_and_wait(msg, timeout, on_ack=_mark_posted)
+        except Exception as e:
+            if not posted:
+                log_event(
+                    _logger,
+                    "dev.question.post_failed",
+                    **common,
+                    reason="send_failed",
+                    error=str(e)[:200],
+                )
+            raise
 
         if response.op == BridgeOp.ERROR:
+            if not posted:
+                log_event(
+                    _logger,
+                    "dev.question.post_failed",
+                    **common,
+                    reason="bridge_error",
+                    error=str(response.message)[:200],
+                )
             raise TransportError(f"Bridge error: {response.message}")
         if response.op == BridgeOp.ANSWER and response.answer:
+            if not posted:
+                # An answer proves the question was posted even if the ACK
+                # never arrived (older bridge, or the ACK was lost).
+                _mark_posted()
             log_event(
                 _logger,
                 "dev.answer.received",
@@ -179,7 +236,6 @@ class SocketTransport:
                 issue_number=issue_number,
                 transport="socket",
                 request_id=request_id,
-                answer=response.answer,
                 answer_length=len(response.answer),
                 answer_hash=hash_text(response.answer),
                 elapsed_ms=int((time.monotonic() - sent_at) * 1000),

--- a/src/ctrlrelay/transports/socket_client.py
+++ b/src/ctrlrelay/transports/socket_client.py
@@ -16,7 +16,11 @@ from ctrlrelay.bridge.protocol import (
     serialize_message,
 )
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
-from ctrlrelay.transports.base import TransportError, TransportTimeoutError
+from ctrlrelay.transports.base import (
+    TransportError,
+    TransportTimeoutError,
+    TransportUnknownDeliveryError,
+)
 
 _logger = get_logger("transport.socket")
 
@@ -91,13 +95,27 @@ class SocketTransport:
             pass
 
     async def _send_message(self, msg: BridgeMessage) -> None:
-        """Send message to bridge."""
+        """Send message to bridge.
+
+        Raises ``TransportError`` while nothing has been written — a
+        definite non-delivery — and ``TransportUnknownDeliveryError``
+        once bytes may have reached the far side. `drain()` failing does
+        not mean the bridge never saw the request: `write()` has already
+        handed the data to the transport, so the ASK may well have been
+        received and acted on.
+        """
         if not self.connected:
             raise TransportError("Transport not connected")
         assert self._writer is not None
         data = serialize_message(msg).encode()
-        self._writer.write(data)
-        await self._writer.drain()
+        try:
+            self._writer.write(data)
+        except Exception as e:
+            raise TransportError(f"Write failed: {e}") from e
+        try:
+            await self._writer.drain()
+        except Exception as e:
+            raise TransportUnknownDeliveryError(f"Drain failed: {e}") from e
 
     async def _send_and_wait(
         self,
@@ -211,14 +229,18 @@ class SocketTransport:
                 # contradict the bridge's own "posted", which is the same
                 # false-claim problem this change exists to remove, just
                 # pointing the other way.
-                timed_out = isinstance(e, TransportTimeoutError)
+                # Only claim a definite failure when the request
+                # provably never left. Anything past the write is
+                # unknown: no ACK arrived, but the bridge may have
+                # received and acted on it regardless.
+                unknown = isinstance(e, TransportUnknownDeliveryError)
                 log_event(
                     _logger,
                     "dev.question.post_unknown"
-                    if timed_out
+                    if unknown
                     else "dev.question.post_failed",
                     **common,
-                    reason="timeout_no_ack" if timed_out else "send_failed",
+                    reason=type(e).__name__ if unknown else "send_failed",
                     error=str(e)[:200],
                 )
             raise

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -313,3 +313,544 @@ class TestSessionResumeLogging:
         assert r.__dict__["repo"] == "o/r"
         assert r.__dict__["issue_number"] == 3
         assert r.__dict__["pipeline"] == "dev"
+
+
+class TestSocketTransportDeliverySemantics:
+    """dev.question.posted must never claim a delivery that did not happen."""
+
+    @staticmethod
+    async def _stub_server(socket_path, responses):
+        """Serve one ASK, replying with each message in ``responses``."""
+        import asyncio
+
+        from ctrlrelay.bridge.protocol import parse_message, serialize_message
+
+        async def handle(reader, writer):
+            try:
+                line = await reader.readline()
+                if not line:
+                    return
+                msg = parse_message(line.decode())
+                for build in responses:
+                    writer.write(serialize_message(build(msg)).encode())
+                    await writer.drain()
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+        return await asyncio.start_unix_server(handle, path=str(socket_path))
+
+    @pytest.mark.asyncio
+    async def test_send_failure_logs_post_failed_and_not_posted(
+        self, caplog
+    ) -> None:
+        """A socket write that never happens must not log a posted question."""
+        import tempfile
+        from pathlib import Path
+
+        from ctrlrelay.transports.base import TransportError
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        # Never connected: _send_message raises before anything reaches a bridge.
+        transport = SocketTransport(Path(tempfile.mkdtemp()) / "absent.sock")
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            with pytest.raises(TransportError):
+                await transport.ask("Deploy to prod?", timeout=1, session_id="s-1")
+
+        names = [
+            r.getMessage()
+            for r in caplog.records
+            if r.name.startswith("ctrlrelay")
+        ]
+        assert "dev.question.posted" not in names
+        assert "dev.question.post_failed" in names
+
+        failed = next(
+            r
+            for r in caplog.records
+            if r.getMessage() == "dev.question.post_failed"
+        )
+        assert failed.__dict__["session_id"] == "s-1"
+        assert failed.__dict__["transport"] == "socket"
+        assert failed.__dict__["reason"] == "send_failed"
+        assert "question" not in failed.__dict__
+
+    @pytest.mark.asyncio
+    async def test_bridge_error_logs_post_failed_and_not_posted(
+        self, caplog
+    ) -> None:
+        """A bridge that rejects the ASK must not leave a posted event behind."""
+        import shutil
+        import tempfile
+        from pathlib import Path
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
+        from ctrlrelay.transports.base import TransportError
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        tmp_dir = Path(tempfile.mkdtemp())
+        server = await self._stub_server(
+            tmp_dir / "t.sock",
+            [
+                lambda m: BridgeMessage(
+                    op=BridgeOp.ERROR,
+                    request_id=m.request_id,
+                    error="telegram_api_error",
+                    message="boom",
+                )
+            ],
+        )
+        try:
+            transport = SocketTransport(tmp_dir / "t.sock")
+            await transport.connect()
+
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                with pytest.raises(TransportError):
+                    await transport.ask("Deploy?", timeout=5, session_id="s-2")
+
+            names = [
+                r.getMessage()
+                for r in caplog.records
+                if r.name.startswith("ctrlrelay")
+            ]
+            assert "dev.question.posted" not in names
+            assert "dev.question.post_failed" in names
+
+            failed = next(
+                r
+                for r in caplog.records
+                if r.getMessage() == "dev.question.post_failed"
+            )
+            assert failed.__dict__["reason"] == "bridge_error"
+
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_timeout_after_ack_keeps_posted_and_adds_no_failure(
+        self, caplog
+    ) -> None:
+        """Once the bridge acknowledges, an unanswered question is still posted."""
+        import shutil
+        import tempfile
+        from pathlib import Path
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
+        from ctrlrelay.transports.base import TransportError
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        tmp_dir = Path(tempfile.mkdtemp())
+        server = await self._stub_server(
+            tmp_dir / "t.sock",
+            [
+                lambda m: BridgeMessage(
+                    op=BridgeOp.ACK, request_id=m.request_id, status="pending"
+                )
+            ],
+        )
+        try:
+            transport = SocketTransport(tmp_dir / "t.sock")
+            await transport.connect()
+
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                with pytest.raises(TransportError):
+                    await transport.ask("Deploy?", timeout=1, session_id="s-3")
+
+            names = [
+                r.getMessage()
+                for r in caplog.records
+                if r.name.startswith("ctrlrelay")
+            ]
+            assert "dev.question.posted" in names
+            assert "dev.question.post_failed" not in names
+
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_posted_precedes_answer_received(self, caplog) -> None:
+        """The ACK is the confirmation, so posted lands before the answer."""
+        import shutil
+        import tempfile
+        from pathlib import Path
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        tmp_dir = Path(tempfile.mkdtemp())
+        server = await self._stub_server(
+            tmp_dir / "t.sock",
+            [
+                lambda m: BridgeMessage(
+                    op=BridgeOp.ACK, request_id=m.request_id, status="pending"
+                ),
+                lambda m: BridgeMessage(
+                    op=BridgeOp.ANSWER, request_id=m.request_id, answer="yes"
+                ),
+            ],
+        )
+        try:
+            transport = SocketTransport(tmp_dir / "t.sock")
+            await transport.connect()
+
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                assert await transport.ask("Deploy?", timeout=5) == "yes"
+
+            names = [
+                r.getMessage()
+                for r in caplog.records
+                if r.name.startswith("ctrlrelay")
+            ]
+            assert names.index("dev.question.posted") < names.index(
+                "dev.answer.received"
+            )
+
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+
+class TestBridgeServerDeliverySemantics:
+    @pytest.mark.asyncio
+    async def test_telegram_failure_logs_post_failed_and_not_posted(
+        self, caplog
+    ) -> None:
+        """TelegramHandler.ask blowing up must not log a posted question."""
+        import asyncio
+        import shutil
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp, serialize_message
+        from ctrlrelay.bridge.server import BridgeServer
+
+        d = tempfile.mkdtemp()
+        socket_path = Path(d) / "b.sock"
+
+        mock_handler = AsyncMock()
+        mock_handler.ask = AsyncMock(side_effect=RuntimeError("telegram down"))
+
+        try:
+            with patch(
+                "ctrlrelay.bridge.server.TelegramHandler", return_value=mock_handler
+            ):
+                server = BridgeServer(
+                    socket_path=socket_path, bot_token="x", chat_id=12345
+                )
+                task = asyncio.create_task(server.start())
+                await asyncio.sleep(0.1)
+
+                reader, writer = await asyncio.open_unix_connection(str(socket_path))
+
+                caplog.clear()
+                with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                    writer.write(
+                        serialize_message(
+                            BridgeMessage(
+                                op=BridgeOp.ASK,
+                                request_id="r-1",
+                                question="Continue?",
+                                session_id="dev-o-r-1-a",
+                                repo="o/r",
+                                issue_number=1,
+                            )
+                        ).encode()
+                    )
+                    await writer.drain()
+                    await asyncio.wait_for(reader.readline(), timeout=1)
+
+                names = [
+                    r.getMessage()
+                    for r in caplog.records
+                    if r.name.startswith("ctrlrelay.bridge")
+                ]
+                assert "dev.question.posted" not in names
+                assert "dev.question.post_failed" in names
+
+                failed = next(
+                    r
+                    for r in caplog.records
+                    if r.getMessage() == "dev.question.post_failed"
+                )
+                assert failed.__dict__["session_id"] == "dev-o-r-1-a"
+                assert failed.__dict__["transport"] == "telegram"
+                assert failed.__dict__["reason"] == "RuntimeError"
+                assert "question" not in failed.__dict__
+
+                writer.close()
+                await writer.wait_closed()
+                await server.stop()
+                task.cancel()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_posted_carries_telegram_msg_id(self, caplog) -> None:
+        """Posted after the send means the Telegram message id is known."""
+        import asyncio
+        import shutil
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp, serialize_message
+        from ctrlrelay.bridge.server import BridgeServer
+
+        d = tempfile.mkdtemp()
+        socket_path = Path(d) / "b.sock"
+
+        mock_handler = AsyncMock()
+        mock_handler.ask = AsyncMock(return_value=99)
+
+        try:
+            with patch(
+                "ctrlrelay.bridge.server.TelegramHandler", return_value=mock_handler
+            ):
+                server = BridgeServer(
+                    socket_path=socket_path, bot_token="x", chat_id=12345
+                )
+                task = asyncio.create_task(server.start())
+                await asyncio.sleep(0.1)
+
+                reader, writer = await asyncio.open_unix_connection(str(socket_path))
+
+                caplog.clear()
+                with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                    writer.write(
+                        serialize_message(
+                            BridgeMessage(
+                                op=BridgeOp.ASK,
+                                request_id="r-1",
+                                question="Continue?",
+                                session_id="dev-o-r-1-a",
+                            )
+                        ).encode()
+                    )
+                    await writer.drain()
+                    await asyncio.wait_for(reader.readline(), timeout=1)
+
+                posted = next(
+                    r
+                    for r in caplog.records
+                    if r.getMessage() == "dev.question.posted"
+                )
+                assert posted.__dict__["telegram_msg_id"] == 99
+
+                writer.close()
+                await writer.wait_closed()
+                await server.stop()
+                task.cancel()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)
+
+
+class TestSensitivePayloadsAreNotLogged:
+    """Questions and answers are operator content; logs keep hash + length only."""
+
+    # Field names that would carry raw human-entered content into the log
+    # stream. ``*_hash`` / ``*_length`` derivatives are the supported path.
+    FORBIDDEN_FIELDS = frozenset(
+        {"question", "answer", "prompt", "text", "body", "stdout", "stderr"}
+    )
+
+    def test_no_log_event_call_passes_raw_sensitive_fields(self) -> None:
+        """Static guard: no ``log_event(..., question=...)`` anywhere in src."""
+        import ast
+        from pathlib import Path
+
+        import ctrlrelay
+
+        src_root = Path(ctrlrelay.__file__).resolve().parent
+        offenders: list[str] = []
+        for path in sorted(src_root.rglob("*.py")):
+            tree = ast.parse(path.read_text(encoding="utf-8"))
+            for node in ast.walk(tree):
+                if not isinstance(node, ast.Call):
+                    continue
+                if getattr(node.func, "id", None) != "log_event":
+                    continue
+                for kw in node.keywords:
+                    if kw.arg in self.FORBIDDEN_FIELDS:
+                        offenders.append(f"{path.name}:{node.lineno} {kw.arg}=")
+        assert not offenders, (
+            "log_event must not carry raw sensitive payloads; "
+            f"use hash_text()/len() instead: {offenders}"
+        )
+
+    @pytest.mark.asyncio
+    async def test_file_mock_logs_hash_not_plaintext(
+        self, tmp_path, caplog
+    ) -> None:
+        from ctrlrelay.core.obs import hash_text
+        from ctrlrelay.transports.file_mock import FileMockTransport
+
+        inbox = tmp_path / "inbox.txt"
+        outbox = tmp_path / "outbox.txt"
+        inbox.write_text("ship it\n")
+        outbox.touch()
+
+        transport = FileMockTransport(inbox=inbox, outbox=outbox)
+
+        caplog.clear()
+        with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+            assert await transport.ask("Secret plan?", timeout=5) == "ship it"
+
+        posted = next(
+            r for r in caplog.records if r.getMessage() == "dev.question.posted"
+        )
+        assert "question" not in posted.__dict__
+        assert posted.__dict__["question_hash"] == hash_text("Secret plan?")
+        assert posted.__dict__["question_length"] == len("Secret plan?")
+
+        received = next(
+            r for r in caplog.records if r.getMessage() == "dev.answer.received"
+        )
+        assert "answer" not in received.__dict__
+        assert received.__dict__["answer_hash"] == hash_text("ship it")
+        assert received.__dict__["answer_length"] == len("ship it")
+
+    @pytest.mark.asyncio
+    async def test_socket_transport_logs_hash_not_plaintext(self, caplog) -> None:
+        import asyncio
+        import shutil
+        import tempfile
+        from pathlib import Path
+
+        from ctrlrelay.bridge.protocol import (
+            BridgeMessage,
+            BridgeOp,
+            parse_message,
+            serialize_message,
+        )
+        from ctrlrelay.core.obs import hash_text
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        tmp_dir = Path(tempfile.mkdtemp())
+
+        async def handle(reader, writer):
+            try:
+                line = await reader.readline()
+                if not line:
+                    return
+                msg = parse_message(line.decode())
+                writer.write(
+                    serialize_message(
+                        BridgeMessage(
+                            op=BridgeOp.ANSWER,
+                            request_id=msg.request_id,
+                            answer="go ahead",
+                        )
+                    ).encode()
+                )
+                await writer.drain()
+            finally:
+                writer.close()
+                await writer.wait_closed()
+
+        server = await asyncio.start_unix_server(
+            handle, path=str(tmp_dir / "t.sock")
+        )
+        try:
+            transport = SocketTransport(tmp_dir / "t.sock")
+            await transport.connect()
+
+            caplog.clear()
+            with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                await transport.ask("Secret plan?", timeout=5)
+
+            posted = next(
+                r for r in caplog.records if r.getMessage() == "dev.question.posted"
+            )
+            assert "question" not in posted.__dict__
+            assert posted.__dict__["question_hash"] == hash_text("Secret plan?")
+
+            received = next(
+                r for r in caplog.records if r.getMessage() == "dev.answer.received"
+            )
+            assert "answer" not in received.__dict__
+            assert received.__dict__["answer_hash"] == hash_text("go ahead")
+
+            await transport.close()
+        finally:
+            server.close()
+            await server.wait_closed()
+            shutil.rmtree(tmp_dir, ignore_errors=True)
+
+    @pytest.mark.asyncio
+    async def test_bridge_answer_logs_hash_not_plaintext(self, caplog) -> None:
+        """The Telegram reply path logs the answer's hash, never its text."""
+        import asyncio
+        import shutil
+        import tempfile
+        from pathlib import Path
+        from unittest.mock import AsyncMock, patch
+
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp, serialize_message
+        from ctrlrelay.bridge.server import BridgeServer
+        from ctrlrelay.core.obs import hash_text
+
+        d = tempfile.mkdtemp()
+        socket_path = Path(d) / "b.sock"
+
+        mock_handler = AsyncMock()
+        mock_handler.ask = AsyncMock(return_value=99)
+
+        try:
+            with patch(
+                "ctrlrelay.bridge.server.TelegramHandler", return_value=mock_handler
+            ):
+                server = BridgeServer(
+                    socket_path=socket_path, bot_token="x", chat_id=12345
+                )
+                task = asyncio.create_task(server.start())
+                await asyncio.sleep(0.1)
+
+                reader, writer = await asyncio.open_unix_connection(str(socket_path))
+                writer.write(
+                    serialize_message(
+                        BridgeMessage(
+                            op=BridgeOp.ASK,
+                            request_id="r-1",
+                            question="Continue?",
+                            session_id="dev-o-r-1-a",
+                        )
+                    ).encode()
+                )
+                await writer.drain()
+                await asyncio.wait_for(reader.readline(), timeout=1)
+
+                caplog.clear()
+                with caplog.at_level(logging.INFO, logger="ctrlrelay"):
+                    await server._on_telegram_reply("my private answer", 99)
+
+                received = next(
+                    r
+                    for r in caplog.records
+                    if r.getMessage() == "dev.answer.received"
+                )
+                assert "answer" not in received.__dict__
+                assert received.__dict__["answer_hash"] == hash_text(
+                    "my private answer"
+                )
+                assert received.__dict__["answer_length"] == len("my private answer")
+
+                writer.close()
+                await writer.wait_closed()
+                await server.stop()
+                task.cancel()
+        finally:
+            shutil.rmtree(d, ignore_errors=True)

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -915,3 +915,78 @@ class TestTimeoutIsNotClaimedAsFailedDelivery:
         from ctrlrelay.transports.base import TransportError, TransportTimeoutError
 
         assert issubclass(TransportTimeoutError, TransportError)
+
+
+class TestOnlyDefiniteFailuresAreCalledFailures:
+    """Delivery is only ever confirmed by the far side. Everything else
+    splits in two: the bytes provably never left (definite failure), or
+    they may have (unknown). Enumerating ambiguous cases one at a time
+    does not converge — the discriminator is whether anything was
+    written."""
+
+    @pytest.mark.asyncio
+    async def test_drain_failure_is_unknown_not_failed(
+        self, tmp_path: Path
+    ) -> None:
+        """`write()` already handed the bytes to the transport, so the
+        bridge may have received and acted on the ASK."""
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = MagicMock()
+        transport._writer.is_closing.return_value = False
+        transport._writer.drain = AsyncMock(side_effect=ConnectionResetError())
+
+        with patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(Exception):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_unknown" in events
+        assert "dev.question.post_failed" not in events
+
+    @pytest.mark.asyncio
+    async def test_never_connected_is_a_definite_failure(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = None
+
+        with patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(Exception):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_failed" in events
+        assert "dev.question.post_unknown" not in events
+
+
+class TestTelegramAmbiguityTaxonomy:
+    """`BadRequest` subclasses `NetworkError` in python-telegram-bot, so
+    a plain isinstance check against NetworkError would sweep definite
+    rejections into the ambiguous bucket."""
+
+    def test_timeouts_and_bare_network_errors_are_ambiguous(self) -> None:
+        from telegram.error import NetworkError, TimedOut
+
+        from ctrlrelay.bridge.telegram_handler import is_ambiguous_delivery
+
+        assert is_ambiguous_delivery(TimedOut())
+        assert is_ambiguous_delivery(NetworkError("connection dropped"))
+
+    def test_telegram_saying_no_is_definite(self) -> None:
+        from telegram.error import BadRequest, Forbidden, InvalidToken
+
+        from ctrlrelay.bridge.telegram_handler import is_ambiguous_delivery
+
+        assert not is_ambiguous_delivery(BadRequest("chat not found"))
+        assert not is_ambiguous_delivery(Forbidden("bot was blocked"))
+        assert not is_ambiguous_delivery(InvalidToken())
+
+    def test_badrequest_really_does_subclass_networkerror(self) -> None:
+        """Guards the reason the helper cannot be a simple isinstance."""
+        from telegram.error import BadRequest, NetworkError
+
+        assert issubclass(BadRequest, NetworkError)

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 import io
 import json
 import logging
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -854,3 +856,62 @@ class TestSensitivePayloadsAreNotLogged:
                 task.cancel()
         finally:
             shutil.rmtree(d, ignore_errors=True)
+
+
+class TestTimeoutIsNotClaimedAsFailedDelivery:
+    """The bridge ACKs only after Telegram has accepted the message. A
+    post slower than our wait means we time out first and the bridge
+    succeeds afterwards — so logging `post_failed` there contradicts the
+    bridge's own `posted`. That is the same false claim this change
+    removes, pointing the other way."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_logs_unknown_not_failed(self, tmp_path: Path) -> None:
+        import asyncio
+
+        from ctrlrelay.transports.base import TransportTimeoutError
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = MagicMock()
+        transport._writer.is_closing.return_value = False
+        transport._writer.drain = AsyncMock()
+
+        async def _never_answers(*_a: object, **_kw: object) -> None:
+            raise asyncio.TimeoutError()
+
+        with patch(
+            "ctrlrelay.transports.socket_client.asyncio.wait_for", _never_answers
+        ), patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(TransportTimeoutError):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_unknown" in events
+        assert "dev.question.post_failed" not in events
+
+    @pytest.mark.asyncio
+    async def test_a_real_write_failure_still_reports_failed(
+        self, tmp_path: Path
+    ) -> None:
+        """A write that failed is a known non-delivery — that one keeps
+        its definite label."""
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = None  # connected is False -> _send_message raises
+
+        with patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(Exception):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_failed" in events
+        assert "dev.question.post_unknown" not in events
+
+    def test_timeout_is_catchable_as_transport_error(self) -> None:
+        """Existing handlers filter on TransportError and must keep
+        working."""
+        from ctrlrelay.transports.base import TransportError, TransportTimeoutError
+
+        assert issubclass(TransportTimeoutError, TransportError)

--- a/tests/test_obs.py
+++ b/tests/test_obs.py
@@ -990,3 +990,72 @@ class TestTelegramAmbiguityTaxonomy:
         from telegram.error import BadRequest, NetworkError
 
         assert issubclass(BadRequest, NetworkError)
+
+
+class TestBridgeClassificationIsNotReDerived:
+    """The transport cannot see the Telegram exception, so a generic
+    ERROR forced it to assume the worst — producing contradictory pairs
+    for one request_id: post_unknown from the bridge, post_failed from
+    the transport. The classification travels in the response instead."""
+
+    @pytest.mark.asyncio
+    async def test_bridge_saying_unknown_is_believed(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = MagicMock()
+        transport._writer.is_closing.return_value = False
+        transport._writer.drain = AsyncMock()
+
+        async def _bridge_says_unknown(*_a: object, **_kw: object) -> BridgeMessage:
+            return BridgeMessage(
+                op=BridgeOp.ERROR,
+                request_id="r-1",
+                error="telegram_delivery_unknown",
+                message="Timed out",
+            )
+
+        with patch(
+            "ctrlrelay.transports.socket_client.asyncio.wait_for",
+            _bridge_says_unknown,
+        ), patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(Exception):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_unknown" in events
+        assert "dev.question.post_failed" not in events
+
+    @pytest.mark.asyncio
+    async def test_a_definite_bridge_rejection_stays_failed(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
+        from ctrlrelay.transports.socket_client import SocketTransport
+
+        transport = SocketTransport(socket_path=tmp_path / "s.sock")
+        transport._writer = MagicMock()
+        transport._writer.is_closing.return_value = False
+        transport._writer.drain = AsyncMock()
+
+        async def _bridge_says_rejected(*_a: object, **_kw: object) -> BridgeMessage:
+            return BridgeMessage(
+                op=BridgeOp.ERROR,
+                request_id="r-1",
+                error="telegram_api_error",
+                message="chat not found",
+            )
+
+        with patch(
+            "ctrlrelay.transports.socket_client.asyncio.wait_for",
+            _bridge_says_rejected,
+        ), patch("ctrlrelay.transports.socket_client.log_event") as log:
+            with pytest.raises(Exception):
+                await transport.ask("approve #1?", session_id="s", repo="o/r")
+
+        events = [c.args[1] for c in log.call_args_list if len(c.args) > 1]
+        assert "dev.question.post_failed" in events
+        assert "dev.question.post_unknown" not in events

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -299,7 +299,7 @@ class TestAskTimeoutIsConfigurable:
         t = SocketTransport(tmp_path / "x.sock", ask_timeout_seconds=4242)
         captured: dict = {}
 
-        async def fake_send_and_wait(msg, timeout):
+        async def fake_send_and_wait(msg, timeout, **kwargs):
             captured["timeout"] = timeout
             from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
 
@@ -321,7 +321,7 @@ class TestAskTimeoutIsConfigurable:
         t = SocketTransport(tmp_path / "x.sock", ask_timeout_seconds=4242)
         captured: dict = {}
 
-        async def fake_send_and_wait(msg, timeout):
+        async def fake_send_and_wait(msg, timeout, **kwargs):
             captured["timeout"] = timeout
             from ctrlrelay.bridge.protocol import BridgeMessage, BridgeOp
 


### PR DESCRIPTION
Closes #41.

## Item 1 — `dev.question.posted` preceded delivery

`SocketTransport.ask()` logged the event before the socket write, and
`BridgeServer` logged it before calling `TelegramHandler.ask()`. A failed
write or a Telegram outage still left a record claiming the operator had
been asked.

- The transport now emits `dev.question.posted` from the bridge's
  `ACK(status="pending")` — the only signal that means the question actually
  reached Telegram. `_send_and_wait()` gained an `on_ack` hook for this.
- The bridge emits it after the Telegram API accepts, and includes
  `telegram_msg_id`.
- Both sides emit `dev.question.post_failed` on the failure path, carrying
  `reason` (`send_failed`, `bridge_error`, or the exception class) and a
  truncated `error`.

Two behaviours worth calling out: a question that is posted and then times
out unanswered still logs only `posted` — the delivery worked, the operator
just did not reply. And an `ANSWER` arriving without a preceding ACK is
itself proof of delivery, so a bridge that skips the ACK still logs
`posted`.

## Item 2 — question and answer text in the logs

Every event already computed `question_hash` / `answer_hash` and then
defeated it by logging the raw text in the field beside it. All six call
sites now log hash + length only. The hash is stable, so it still joins the
poller's record to the bridge's record for the same question.

## Tests

- Failed-delivery regressions: send failure, bridge `ERROR`, and Telegram
  raising — each asserts `post_failed` is present and `posted` is absent.
- Timeout after ACK asserts the reverse: `posted` stays, no `post_failed`.
- Ordering test: `posted` lands before `answer.received`.
- Redaction tests per transport, asserting `question_hash == hash_text(...)`
  and no `question` / `answer` key on the record.
- A static guard walks `src/` with `ast` and fails on any `log_event()` call
  passing a raw payload field, so a new call site cannot reintroduce this.

`docs/operations.md` gains a "Blocked-question events" table.

867 tests pass; `ruff check src/ tests/` clean.

Two pre-existing stubs in `tests/test_transport.py` took `(msg, timeout)`
positionally and now accept `**kwargs` for the new keyword-only `on_ack`.