### PR TITLE
feat(dev): run the configured review before handing a PR over

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,6 +39,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Silence is treated the same way. A `cli_command` that exits 0 with
   nothing to say has reviewed nothing, and gets no marker.
 
+  So is a review of the wrong tree. A verdict of "there are no code
+  changes to review" can only mean the reviewer looked somewhere else —
+  the branch under review always has a diff — and a false pass is worse
+  than an unreadable one, because it is confidently wrong.
+
 ### Changed
 
 - **`code_review.method` defaults to `"cli"`.** The old `"mcp_then_cli"`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **Agent PRs are reviewed before they reach you, and say so.** The
+  `code_review` config existed on every repo and was read by nothing, so
+  a PR that had been reviewed and one that never was looked identical.
+  The dev pipeline now runs the configured review after CI is green and
+  before handing over, posts the findings, and labels the PR
+  `code_review done`.
+
+  The orchestrator runs it, not the agent: a party cannot certify its own
+  work, and a prompt instruction to self-review can be skipped or
+  misreported.
+
+  The marker names no tool, model or vendor, and neither does the
+  comment — which backend runs is an implementation detail that does not
+  belong in repository history.
+
+  **It means exactly one thing: a review read this diff.** It is withheld
+  when the reviewer could not be run, timed out, produced no verdict, or
+  said it could not inspect the tree. That last case is why an exit-code
+  check is not enough — review CLIs announce "I could not access the
+  repository contents" in prose and still exit 0, so checking the code
+  alone would stamp the label on precisely the runs it exists to catch.
+  Only the reviewer's own verdict is scanned, never the whole transcript:
+  the transcript contains the diff, so scanning all of it matches source
+  code that merely mentions such a phrase — including this feature's own
+  tests, which is how the first version of the check declared a good
+  review unreadable.
+
+  Silence is treated the same way. A `cli_command` that exits 0 with
+  nothing to say has reviewed nothing, and gets no marker.
+
+### Changed
+
+- **`code_review.method` defaults to `"cli"`.** The old `"mcp_then_cli"`
+  led with an MCP server that is essentially never connected, so every
+  review paid for a failed attempt before falling through. It is accepted
+  and mapped to `"cli"`; `"none"`, `"disabled"`, `"false"` and `"no"` map
+  to `"off"`. An unrecognised value falls back to `"cli"` rather than
+  refusing to load — the field was parsed and ignored for its entire
+  existence, so a config in the wild carrying anything must not stop the
+  daemon from booting.
+
 ## [0.10.0] - 2026-09-08
 
 ### Added

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -183,7 +183,7 @@ repos:
 | `local_path` | path | conditional | derived | Where the repo is checked out on disk for human use. Optional when `paths.repo_root` is set (then derived as `${repo_root}/${owner.lower()}/${repo}`, since v0.4.0); required otherwise. An explicit value always wins as override. ctrlrelay itself uses bare mirrors under `paths.bare_repos`. |
 | `dev_branch_template` | string | no | `"fix/issue-{n}"` | Branch-name template for dev-pipeline runs. `{n}` is replaced by the issue number. |
 | `automation` | object | no | (defaults) | See [automation](#repos-automation). |
-| `code_review` | object | no | (defaults) | Reserved for code-review policy. Currently unused by the bundled pipelines. |
+| `code_review` | object | no | (defaults) | Review run over an agent branch before its PR is handed over. See [code_review](#code_review). |
 | `deploy` | object | no | `null` | Reserved for deploy policy. Currently surfaced in `ctrlrelay config repos` but otherwise inert. |
 
 ### repos[].automation
@@ -488,3 +488,49 @@ repos:
 Always run `ctrlrelay config validate` after editing the file. It prints the
 resolved transport, repo count, and parsed timezone — and surfaces any pydantic
 validation errors with line context.
+
+## code_review
+
+A review the **orchestrator** runs over an agent's branch after CI is
+green and before the PR is handed to a human. It is deliberately not a
+prompt instruction: a party cannot certify its own work, and an agent
+told to self-review can skip the step or misreport it.
+
+```yaml
+repos:
+  - name: "owner/repo"
+    code_review:
+      method: "cli"
+      cli_command: "codex review"
+      timeout_seconds: 900
+      comment_on_pr: true
+```
+
+| Key | Type | Default | Description |
+|---|---|---|---|
+| `method` | string | `"cli"` | `"cli"` runs `cli_command`; `"off"` disables review for the repo. `"none"`, `"disabled"`, `"false"` and `"no"` are accepted as `"off"`. The legacy `"mcp_then_cli"` maps to `"cli"` — the MCP path is essentially never connected, so leading with it only paid for a failed attempt. An unrecognised value falls back to `"cli"` rather than failing to load: this field was parsed and ignored for its whole existence, so a config in the wild carrying anything must not stop the daemon booting. |
+| `cli_command` | string | `"codex review"` | Invoked with `--base <default branch>` appended, in the session's worktree. |
+| `timeout_seconds` | int | `900` | Per-run cap, minimum 30. A wedged reviewer must not hold a dev session open to the session's own timeout. |
+| `comment_on_pr` | bool | `true` | Post the findings to the PR. When false the marker still lands and the detail stays in the log. |
+
+### The `code_review done` marker
+
+A PR that was reviewed is labelled **`code_review done`**. The label
+names no tool, model or vendor, and neither does the posted comment —
+which backend runs is an implementation detail and does not belong in
+repository history.
+
+**The marker means exactly one thing: a review read this diff.** It is
+withheld when the reviewer could not be run, timed out, produced no
+verdict, or reported that it could not inspect the tree. That last case
+is the one worth stating plainly: review CLIs announce "I could not
+access the repository contents" in prose and still exit 0, so an
+exit-code check alone would stamp the label on precisely the runs it
+exists to catch.
+
+Only the reviewer's own verdict is examined for that, not the whole
+transcript — the transcript contains the diff, so scanning all of it
+matches source code that merely mentions such a phrase.
+
+The absence of the marker is therefore the signal to look at the log.
+Review is best-effort and never fails a PR whose code and CI are fine.

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -762,6 +762,7 @@ def run_dev(
             transport=None,
             contexts_dir=config.paths.contexts,
             ci_wait_timeout_seconds=repo_config.automation.ci_wait_timeout_seconds,
+            code_review=repo_config.code_review,
         )
 
     try:
@@ -1321,6 +1322,7 @@ def poller_start(
                         transport=connected_transport,
                         contexts_dir=config.paths.contexts,
                         ci_wait_timeout_seconds=repo_config.automation.ci_wait_timeout_seconds,
+                        code_review=repo_config.code_review,
                     )
 
                 # Lock-conflict retry hook. The poller marks issues seen

--- a/src/ctrlrelay/core/code_review.py
+++ b/src/ctrlrelay/core/code_review.py
@@ -1,0 +1,274 @@
+"""Run a configured code review over a branch before a PR is handed over.
+
+The orchestrator runs this, not the agent. Telling an agent in its prompt
+to "review your own work" is unverifiable: it can skip the step, misread
+the result, or report success from a run that inspected nothing. A
+reviewed PR and an unreviewed one have to be distinguishable from the
+outside, and that only holds if something other than the reviewed party
+decides.
+
+The single most important property here is that **a review which read
+nothing is not a pass**. Review CLIs report that condition in prose and
+still exit 0 — e.g. "I could not access the repository contents" — so an
+exit-code check alone certifies exactly the failure it exists to catch.
+:func:`looks_unreadable` is the guard, and :class:`CodeReviewOutcome`
+carries the distinction to the caller rather than collapsing it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+import shlex
+from dataclasses import dataclass
+from enum import Enum
+from pathlib import Path
+
+from ctrlrelay.core.obs import get_logger, log_event
+
+_logger = get_logger("core.code_review")
+
+# The marker deliberately names no tool, model or vendor. It records that
+# a review happened, nothing about what performed it — which backend runs
+# is an implementation detail and must not leak into repo artifacts.
+REVIEW_DONE_LABEL = "code_review done"
+
+# A review that could not read the diff says so in prose and exits 0.
+# Matching that shape is the only thing standing between "reviewed" and
+# "certified without looking".
+_UNREADABLE_PATTERNS = (
+    "could not access the repository",
+    "could not read the repository",
+    "unable to access the repository",
+    "could not inspect",
+    "unable to inspect",
+    "i was unable to review",
+    "cannot safely validate",
+    "should be considered unverified",
+    "review was interrupted",
+    "bwrap:",
+    "rtm_newaddr",
+    "failed to decode models response",
+    "usage limit",
+    "not supported when using",
+)
+
+# Long enough for a real review of a sizeable diff, short enough that a
+# wedged reviewer cannot hold a dev session open to its own timeout.
+DEFAULT_REVIEW_TIMEOUT_SECONDS = 900
+
+
+class ReviewStatus(str, Enum):
+    """What the review run actually established."""
+
+    REVIEWED = "reviewed"
+    """The reviewer read the diff and returned findings (or none)."""
+
+    UNREADABLE = "unreadable"
+    """The reviewer ran but inspected nothing. NOT a pass."""
+
+    FAILED = "failed"
+    """The reviewer could not be run at all."""
+
+    SKIPPED = "skipped"
+    """Review is switched off for this repo."""
+
+
+@dataclass(frozen=True)
+class CodeReviewOutcome:
+    status: ReviewStatus
+    output: str = ""
+    error: str = ""
+
+    @property
+    def may_mark_reviewed(self) -> bool:
+        """Only a review that actually read the diff earns the marker.
+
+        Anything else must leave the PR unmarked: a marker applied to an
+        unreadable run certifies precisely the case it exists to catch,
+        and an unmarked PR is the signal that no review happened.
+        """
+        return self.status is ReviewStatus.REVIEWED
+
+
+# The reviewer's own conclusion begins at a lone "codex" line; everything
+# before it is the transcript, including the diff it was handed.
+_VERDICT_MARKER_RE = re.compile(r"^codex\s*$", re.M)
+
+# Fallback window when no marker is present: the verdict is written last.
+_VERDICT_TAIL_CHARS = 4000
+
+
+def extract_verdict(output: str) -> str:
+    """Return just the reviewer's conclusion, not the whole transcript.
+
+    This distinction is load-bearing. The transcript contains the diff
+    under review, so scanning all of it for "could not access the
+    repository" matches source code that merely *mentions* the phrase —
+    including this module's own tests, which is exactly how the first
+    version of :func:`looks_unreadable` declared a perfectly good review
+    unreadable and refused to mark it.
+    """
+    text = output or ""
+    matches = list(_VERDICT_MARKER_RE.finditer(text))
+    if matches:
+        return text[matches[-1].end():]
+    return text[-_VERDICT_TAIL_CHARS:]
+
+
+def looks_unreadable(output: str) -> bool:
+    """True when the reviewer's own verdict says it inspected nothing.
+
+    Only the verdict is examined — see :func:`extract_verdict`. A phrase
+    appearing in the reviewed code is not the reviewer saying it.
+    """
+    lowered = extract_verdict(output).lower()
+    return any(pattern in lowered for pattern in _UNREADABLE_PATTERNS)
+
+
+def _strip_tool_identity(text: str) -> str:
+    """Remove backend identity from text that will be posted to a repo.
+
+    The findings are worth publishing; which model produced them is not.
+    Leaking it into a PR comment would tie the repo's history to a
+    vendor choice that is meant to stay an implementation detail.
+    """
+    cleaned = re.sub(
+        r"\b(codex|copilot|cursor|claude|anthropic|openai|gpt[-\w.]*|"
+        r"chatgpt|o[34]-\w+|sonnet|opus|haiku)\b",
+        "the reviewer",
+        text or "",
+        flags=re.I,
+    )
+    # Collapse the repetition that substitution can produce
+    # ("the reviewer the reviewer").
+    return re.sub(r"(the reviewer)(\s+the reviewer)+", r"\1", cleaned)
+
+
+async def run_code_review(
+    *,
+    repo: str,
+    worktree_path: Path,
+    base_branch: str,
+    cli_command: str = "codex review",
+    timeout_seconds: int = DEFAULT_REVIEW_TIMEOUT_SECONDS,
+    session_id: str = "",
+) -> CodeReviewOutcome:
+    """Review the working branch against ``base_branch``.
+
+    ``--base`` is appended because it reviews a pushed branch directly.
+    The alternative, ``--uncommitted``, describes the working tree and
+    would report nothing for a branch whose work is already committed —
+    an empty review that reads as a clean one.
+    """
+    argv = [*shlex.split(cli_command), "--base", base_branch]
+
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            cwd=str(worktree_path),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+        )
+    except (OSError, ValueError) as e:
+        log_event(
+            _logger,
+            "code_review.spawn_failed",
+            session_id=session_id,
+            repo=repo,
+            error_type=type(e).__name__,
+            error=str(e)[:200],
+        )
+        return CodeReviewOutcome(
+            status=ReviewStatus.FAILED, error=f"{type(e).__name__}: {e}"
+        )
+
+    try:
+        stdout, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=timeout_seconds
+        )
+    except asyncio.TimeoutError:
+        try:
+            proc.kill()
+            await proc.wait()
+        except Exception:
+            pass
+        log_event(
+            _logger,
+            "code_review.timeout",
+            session_id=session_id,
+            repo=repo,
+            timeout_seconds=timeout_seconds,
+        )
+        return CodeReviewOutcome(
+            status=ReviewStatus.FAILED,
+            error=f"review timed out after {timeout_seconds}s",
+        )
+
+    output = stdout.decode(errors="replace")
+
+    # Silence is not a review. A misconfigured cli_command (`true`, a
+    # wrapper that swallows its own output) exits 0 with nothing to say,
+    # and treating that as REVIEWED hands out the marker for work nobody
+    # did — the same hole as an unreadable run, just quieter.
+    if not extract_verdict(output).strip():
+        log_event(
+            _logger,
+            "code_review.empty",
+            session_id=session_id,
+            repo=repo,
+            returncode=proc.returncode,
+        )
+        return CodeReviewOutcome(
+            status=ReviewStatus.UNREADABLE,
+            output=output,
+            error="the reviewer produced no verdict",
+        )
+
+    # Order matters: a non-zero exit is a failure, but a ZERO exit with
+    # unreadable output is the dangerous case — it looks like success.
+    if looks_unreadable(output):
+        log_event(
+            _logger,
+            "code_review.unreadable",
+            session_id=session_id,
+            repo=repo,
+            returncode=proc.returncode,
+            output_length=len(output),
+        )
+        return CodeReviewOutcome(
+            status=ReviewStatus.UNREADABLE,
+            output=output,
+            error="the reviewer did not read the diff",
+        )
+
+    if proc.returncode != 0:
+        log_event(
+            _logger,
+            "code_review.failed",
+            session_id=session_id,
+            repo=repo,
+            returncode=proc.returncode,
+        )
+        return CodeReviewOutcome(
+            status=ReviewStatus.FAILED,
+            output=output,
+            error=f"reviewer exited {proc.returncode}",
+        )
+
+    log_event(
+        _logger,
+        "code_review.completed",
+        session_id=session_id,
+        repo=repo,
+        output_length=len(output),
+    )
+    return CodeReviewOutcome(status=ReviewStatus.REVIEWED, output=output)
+
+
+def format_review_comment(outcome: CodeReviewOutcome) -> str:
+    """Render findings for a PR comment, with backend identity removed."""
+    body = _strip_tool_identity(extract_verdict(outcome.output)).strip()
+    if len(body) > 60000:
+        body = "…\n" + body[-60000:]
+    return "## Automated code review\n\n" + (body or "_No findings reported._")

--- a/src/ctrlrelay/core/code_review.py
+++ b/src/ctrlrelay/core/code_review.py
@@ -51,6 +51,14 @@ _UNREADABLE_PATTERNS = (
     "failed to decode models response",
     "usage limit",
     "not supported when using",
+    # "There are no code changes to review" from a reviewer pointed at
+    # the wrong tree. This branch always has a diff — that is why a
+    # review was requested — so the claim can only mean the reviewer
+    # looked somewhere else. Marking it reviewed would be a false pass,
+    # which is worse than an unreadable one: it is confidently wrong.
+    "no code changes to review",
+    "no changes to review",
+    "identical to the specified merge-base",
 )
 
 # Long enough for a real review of a sizeable diff, short enough that a

--- a/src/ctrlrelay/core/config.py
+++ b/src/ctrlrelay/core/config.py
@@ -184,11 +184,41 @@ class DeployConfig(BaseModel):
 
 
 class CodeReviewConfig(BaseModel):
-    """Code review configuration for a repo."""
+    """Code review run over an agent branch before it is handed over.
 
-    method: str = "mcp_then_cli"
-    mcp_tool: str = "mcp__codex-reviewer__codex_review"
+    The orchestrator runs this, not the agent: a party cannot certify its
+    own work, and a prompt instruction to self-review is unverifiable.
+    """
+
+    # "cli" runs ``cli_command`` directly. "off" disables review for the
+    # repo. The old "mcp_then_cli" is accepted so existing configs keep
+    # loading, but it is no longer the default and no longer leads with
+    # the MCP path — that server is essentially never connected, so
+    # every review fell through to the CLI after paying for the attempt.
+    method: str = "cli"
     cli_command: str = "codex review"
+    # Per-run cap. A wedged reviewer must not be able to hold a dev
+    # session open until the session's own timeout.
+    timeout_seconds: int = Field(default=900, ge=30)
+    # Findings are posted to the PR. Off means the marker still lands but
+    # the detail stays in the log.
+    comment_on_pr: bool = True
+
+    @field_validator("method")
+    @classmethod
+    def normalise_method(cls, v: str) -> str:
+        """Map legacy and off-ish spellings; never refuse to load.
+
+        This field was parsed and ignored for its entire existence, so
+        configs in the wild may carry any value at all. Making one of
+        them fatal would stop the daemon booting over a setting that
+        never did anything — a much worse outcome than running the
+        default review. Unknown values fall back to "cli".
+        """
+        lowered = (v or "").strip().lower()
+        if lowered in ("off", "none", "disabled", "false", "no"):
+            return "off"
+        return "cli"
 
 
 class AutomationConfig(BaseModel):

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -416,6 +416,35 @@ class GitHubCLI:
             "--body", body,
         )
 
+    async def comment_on_pr(
+        self, repo: str, pr_number: int, body: str
+    ) -> None:
+        """Post a comment on a PR (PRs are issues to this endpoint)."""
+        await self._run_gh(
+            "pr", "comment", str(pr_number), "--repo", repo, "--body", body
+        )
+
+    async def add_label(self, repo: str, number: int, label: str) -> None:
+        """Add a label to an issue or PR, creating it if absent.
+
+        `gh` fails the whole call when the label does not exist yet, so
+        the create is attempted first and its "already exists" failure
+        ignored — the only outcome that matters is that the label is
+        applied afterwards.
+        """
+        try:
+            await self._run_gh(
+                "label", "create", label,
+                "--repo", repo,
+                "--description", "A code review ran against this pull request",
+                "--color", "0E8A16",
+            )
+        except GitHubError:
+            pass
+        await self._run_gh(
+            "pr", "edit", str(number), "--repo", repo, "--add-label", label
+        )
+
     async def close_issue(
         self,
         repo: str,

--- a/src/ctrlrelay/pipelines/dev.py
+++ b/src/ctrlrelay/pipelines/dev.py
@@ -10,6 +10,11 @@ from pathlib import Path
 from typing import Any
 
 from ctrlrelay.core.checkpoint import CheckpointStatus
+from ctrlrelay.core.code_review import (
+    REVIEW_DONE_LABEL,
+    format_review_comment,
+    run_code_review,
+)
 from ctrlrelay.core.dispatcher import AgentAdapter, SessionResult
 from ctrlrelay.core.github import GitHubCLI
 from ctrlrelay.core.obs import get_logger, hash_text, log_event
@@ -548,6 +553,90 @@ def _build_fix_prompt(pr_number: int, verification: VerificationResult) -> str:
     )
 
 
+async def _review_and_mark(
+    *,
+    github: GitHubCLI,
+    repo: str,
+    session_id: str,
+    pr_number: int,
+    worktree_path: Path,
+    base_branch: str,
+    config: Any = None,
+) -> None:
+    """Run the configured review and mark the PR only if it really ran.
+
+    Best-effort by design: a reviewer that is missing, wedged or broken
+    must not fail a PR whose code and CI are fine. The cost of that
+    choice is that an unmarked PR is ambiguous between "reviewer was
+    down" and "review found nothing" — so the marker means exactly one
+    thing, "a review read this diff", and its absence is the prompt to
+    look at the log.
+    """
+    method = getattr(config, "method", "cli")
+    if method == "off":
+        return
+
+    outcome = await run_code_review(
+        repo=repo,
+        worktree_path=worktree_path,
+        base_branch=base_branch,
+        cli_command=getattr(config, "cli_command", "codex review"),
+        timeout_seconds=getattr(config, "timeout_seconds", 900),
+        session_id=session_id,
+    )
+
+    if not outcome.may_mark_reviewed:
+        # Deliberately no label. Marking here would certify the exact
+        # case the marker exists to catch: a run that inspected nothing
+        # but exited 0.
+        log_event(
+            _logger,
+            "dev.code_review.not_marked",
+            session_id=session_id,
+            repo=repo,
+            pr_number=pr_number,
+            status=outcome.status.value,
+            error=outcome.error[:200],
+        )
+        return
+
+    if getattr(config, "comment_on_pr", True):
+        try:
+            await github.comment_on_pr(
+                repo, pr_number, format_review_comment(outcome)
+            )
+        except Exception as e:
+            log_event(
+                _logger,
+                "dev.code_review.comment_failed",
+                session_id=session_id,
+                repo=repo,
+                pr_number=pr_number,
+                error_type=type(e).__name__,
+                error=str(e)[:200],
+            )
+
+    try:
+        await github.add_label(repo, pr_number, REVIEW_DONE_LABEL)
+        log_event(
+            _logger,
+            "dev.code_review.marked",
+            session_id=session_id,
+            repo=repo,
+            pr_number=pr_number,
+        )
+    except Exception as e:
+        log_event(
+            _logger,
+            "dev.code_review.label_failed",
+            session_id=session_id,
+            repo=repo,
+            pr_number=pr_number,
+            error_type=type(e).__name__,
+            error=str(e)[:200],
+        )
+
+
 async def _verify_and_fix_pr(
     *,
     pipeline: DevPipeline,
@@ -681,6 +770,7 @@ async def run_dev_issue(
     max_blocked_rounds: int = DEFAULT_MAX_BLOCKED_ROUNDS,
     pr_verifier: PRVerifier | None = None,
     ci_wait_timeout_seconds: int = 600,
+    code_review: Any = None,
 ) -> PipelineResult:
     """Run dev pipeline for a single issue."""
     session_id = f"dev-{repo.replace('/', '-')}-{issue_number}-{uuid.uuid4().hex[:8]}"
@@ -878,6 +968,28 @@ async def run_dev_issue(
                 max_attempts=max_fix_attempts,
                 lock_handle=lock,
             )
+
+            # Review the branch before the PR is handed to a human.
+            # After verification, so a PR that is still being fixed is
+            # not reviewed mid-flight; before cleanup, while the
+            # worktree still exists for the reviewer to read.
+            if result.success:
+                try:
+                    review_base = await worktree.get_default_branch(repo)
+                except Exception:
+                    # Best-effort: a review is not worth failing a green
+                    # PR over, and the marker's absence already says one
+                    # did not happen.
+                    review_base = "main"
+                await _review_and_mark(
+                    github=github,
+                    repo=repo,
+                    session_id=session_id,
+                    pr_number=int(result.outputs["pr_number"]),
+                    worktree_path=worktree_path,
+                    base_branch=review_base,
+                    config=code_review,
+                )
 
         # Reacquire the lock for the post-verify cleanup phase (remove
         # worktree / delete branch). Usually SHORT budget (cleanup is

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -1,0 +1,369 @@
+"""Tests for the pre-handoff code review gate."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from ctrlrelay.core.code_review import (
+    REVIEW_DONE_LABEL,
+    CodeReviewOutcome,
+    ReviewStatus,
+    format_review_comment,
+    looks_unreadable,
+    run_code_review,
+)
+
+
+class TestAReviewThatReadNothingIsNotAPass:
+    """The whole point of the gate. Review CLIs report "I could not read
+    the diff" in prose and still exit 0, so an exit-code check alone
+    certifies precisely the failure the marker exists to catch."""
+
+    @pytest.mark.parametrize(
+        "output",
+        [
+            "I could not access the repository contents to inspect HEAD",
+            "all shell invocations fail with bwrap: loopback: Failed RTM_NEWADDR",
+            "Review was interrupted. Please re-run and wait for it to complete.",
+            "the patch should be considered unverified in this environment",
+            "ERROR: You've hit your usage limit for the reviewer.",
+            "The 'gpt-x' model is not supported when using this account.",
+        ],
+        ids=[
+            "cannot-read", "sandbox-broken", "interrupted",
+            "unverified", "rate-limited", "model-gone",
+        ],
+    )
+    def test_unreadable_shapes_are_detected(self, output: str) -> None:
+        assert looks_unreadable(output)
+
+    def test_a_real_review_is_not_flagged(self) -> None:
+        assert not looks_unreadable(
+            "BLOCKING: none.\n\nCONCERN:\n- foo.py:12 off-by-one\n\nVERDICT: clean"
+        )
+
+    @pytest.mark.asyncio
+    async def test_zero_exit_with_unreadable_output_is_not_reviewed(
+        self, tmp_path: Path
+    ) -> None:
+        """The dangerous case: it looks like success."""
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(
+            return_value=(b"I could not access the repository contents", b"")
+        )
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.status is ReviewStatus.UNREADABLE
+        assert outcome.may_mark_reviewed is False
+
+    @pytest.mark.asyncio
+    async def test_a_clean_review_is_marked(self, tmp_path: Path) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"VERDICT: clean", b""))
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.status is ReviewStatus.REVIEWED
+        assert outcome.may_mark_reviewed is True
+
+    @pytest.mark.asyncio
+    async def test_a_missing_reviewer_is_not_marked(self, tmp_path: Path) -> None:
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(side_effect=FileNotFoundError("no such binary")),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.status is ReviewStatus.FAILED
+        assert outcome.may_mark_reviewed is False
+
+    @pytest.mark.asyncio
+    async def test_the_review_is_time_bounded(self, tmp_path: Path) -> None:
+        """A wedged reviewer must not hold the dev session to its own
+        timeout."""
+        import asyncio
+
+        proc = MagicMock()
+        proc.returncode = None
+        proc.communicate = AsyncMock(side_effect=asyncio.TimeoutError())
+        proc.kill = MagicMock()
+        proc.wait = AsyncMock()
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r",
+                worktree_path=tmp_path,
+                base_branch="main",
+                timeout_seconds=1,
+            )
+
+        assert outcome.status is ReviewStatus.FAILED
+        assert outcome.may_mark_reviewed is False
+        proc.kill.assert_called_once()
+
+
+class TestTheMarkerNamesNoTool:
+    """Which backend reviewed is an implementation detail and must not
+    reach a repository artifact."""
+
+    def test_label_text_carries_no_vendor_identifier(self) -> None:
+        lowered = REVIEW_DONE_LABEL.lower()
+        for token in (
+            "codex", "claude", "copilot", "cursor", "gpt", "openai",
+            "anthropic", "ai", "llm", "model", "bot",
+        ):
+            assert token not in lowered.split(), REVIEW_DONE_LABEL
+        assert "code_review" in lowered
+
+    def test_comment_body_strips_backend_identity(self) -> None:
+        body = format_review_comment(
+            CodeReviewOutcome(
+                status=ReviewStatus.REVIEWED,
+                output="Codex reviewed this with GPT-5.6-Luna and found nothing.",
+            )
+        )
+
+        lowered = body.lower()
+        for token in ("codex", "gpt-5.6-luna", "gpt", "claude", "openai"):
+            assert token not in lowered, body
+        assert "found nothing" in lowered
+
+    def test_an_empty_review_still_renders(self) -> None:
+        body = format_review_comment(
+            CodeReviewOutcome(status=ReviewStatus.REVIEWED, output="")
+        )
+        assert "No findings reported" in body
+
+
+class TestPipelineMarksOnlyRealReviews:
+    @pytest.mark.asyncio
+    async def test_unreadable_review_leaves_the_pr_unmarked(self) -> None:
+        from ctrlrelay.pipelines.dev import _review_and_mark
+
+        github = AsyncMock()
+        with patch(
+            "ctrlrelay.pipelines.dev.run_code_review",
+            AsyncMock(
+                return_value=CodeReviewOutcome(
+                    status=ReviewStatus.UNREADABLE, error="did not read"
+                )
+            ),
+        ):
+            await _review_and_mark(
+                github=github, repo="o/r", session_id="s", pr_number=7,
+                worktree_path=Path("/tmp"), base_branch="main",
+            )
+
+        github.add_label.assert_not_awaited()
+        github.comment_on_pr.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_real_review_comments_and_labels(self) -> None:
+        from ctrlrelay.pipelines.dev import _review_and_mark
+
+        github = AsyncMock()
+        with patch(
+            "ctrlrelay.pipelines.dev.run_code_review",
+            AsyncMock(
+                return_value=CodeReviewOutcome(
+                    status=ReviewStatus.REVIEWED, output="VERDICT: clean"
+                )
+            ),
+        ):
+            await _review_and_mark(
+                github=github, repo="o/r", session_id="s", pr_number=7,
+                worktree_path=Path("/tmp"), base_branch="main",
+            )
+
+        github.comment_on_pr.assert_awaited_once()
+        github.add_label.assert_awaited_once_with("o/r", 7, REVIEW_DONE_LABEL)
+
+    @pytest.mark.asyncio
+    async def test_method_off_skips_entirely(self) -> None:
+        from ctrlrelay.core.config import CodeReviewConfig
+        from ctrlrelay.pipelines.dev import _review_and_mark
+
+        github = AsyncMock()
+        with patch("ctrlrelay.pipelines.dev.run_code_review") as run:
+            await _review_and_mark(
+                github=github, repo="o/r", session_id="s", pr_number=7,
+                worktree_path=Path("/tmp"), base_branch="main",
+                config=CodeReviewConfig(method="off"),
+            )
+
+        run.assert_not_called()
+        github.add_label.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_a_failing_label_call_does_not_fail_the_pr(self) -> None:
+        """Review is best-effort: a green PR must not fail because the
+        marker could not be applied."""
+        from ctrlrelay.pipelines.dev import _review_and_mark
+
+        github = AsyncMock()
+        github.add_label.side_effect = RuntimeError("gh down")
+
+        with patch(
+            "ctrlrelay.pipelines.dev.run_code_review",
+            AsyncMock(
+                return_value=CodeReviewOutcome(
+                    status=ReviewStatus.REVIEWED, output="VERDICT: clean"
+                )
+            ),
+        ):
+            await _review_and_mark(
+                github=github, repo="o/r", session_id="s", pr_number=7,
+                worktree_path=Path("/tmp"), base_branch="main",
+            )
+
+
+class TestConfigDefaults:
+    def test_default_does_not_lead_with_the_mcp_path(self) -> None:
+        from ctrlrelay.core.config import CodeReviewConfig
+
+        assert CodeReviewConfig().method == "cli"
+
+    def test_legacy_mcp_then_cli_still_loads(self) -> None:
+        """Existing configs must keep working — normalised to CLI."""
+        from ctrlrelay.core.config import CodeReviewConfig
+
+        assert CodeReviewConfig(method="mcp_then_cli").method == "cli"
+
+    @pytest.mark.parametrize("value", ["off", "none", "disabled", "false", "no"])
+    def test_off_ish_spellings_all_disable(self, value: str) -> None:
+        from ctrlrelay.core.config import CodeReviewConfig
+
+        assert CodeReviewConfig(method=value).method == "off"
+
+    def test_an_unknown_method_does_not_block_startup(self) -> None:
+        """This field was parsed and ignored for its whole existence, so
+        configs in the wild may carry anything. Refusing to load would
+        stop the daemon booting over a setting that never did anything —
+        far worse than running the default."""
+        from ctrlrelay.core.config import CodeReviewConfig
+
+        assert CodeReviewConfig(method="bogus").method == "cli"
+        assert CodeReviewConfig(method="").method == "cli"
+
+
+class TestOnlyTheVerdictIsScanned:
+    """The transcript contains the diff under review, so scanning all of
+    it matches source code that merely *mentions* an unreadable-review
+    phrase. That is not hypothetical: the first version of this detector
+    read its own test fixtures back out of the reviewer's transcript and
+    declared a perfectly good review unreadable, which would have meant
+    no PR ever got marked."""
+
+    def test_the_phrase_inside_reviewed_code_is_not_the_reviewer(self) -> None:
+        transcript = (
+            'diff --git a/tests/test_x.py b/tests/test_x.py\n'
+            '+    "I could not access the repository contents",\n'
+            '+    "bwrap: loopback: Failed RTM_NEWADDR",\n'
+            "codex\n"
+            "BLOCKING: none.\nVERDICT: clean\n"
+        )
+
+        assert looks_unreadable(transcript) is False
+
+    def test_the_reviewer_saying_it_is_detected(self) -> None:
+        transcript = (
+            "diff --git a/a.py b/a.py\n+ ok\n"
+            "codex\n"
+            "I could not access the repository contents to inspect HEAD.\n"
+        )
+
+        assert looks_unreadable(transcript) is True
+
+    def test_verdict_falls_back_to_the_tail_without_a_marker(self) -> None:
+        from ctrlrelay.core.code_review import extract_verdict
+
+        assert extract_verdict("a" * 9000).endswith("a")
+        assert len(extract_verdict("a" * 9000)) == 4000
+
+    def test_the_last_marker_wins(self) -> None:
+        """A transcript can contain the word earlier; the conclusion is
+        the final block."""
+        from ctrlrelay.core.code_review import extract_verdict
+
+        verdict = extract_verdict("codex\nfirst\ncodex\nVERDICT: clean\n")
+
+        assert "VERDICT: clean" in verdict
+        assert "first" not in verdict
+
+    def test_the_comment_publishes_the_verdict_not_the_transcript(self) -> None:
+        body = format_review_comment(
+            CodeReviewOutcome(
+                status=ReviewStatus.REVIEWED,
+                output="diff --git a/a.py\n+ secret internals\ncodex\nVERDICT: clean\n",
+            )
+        )
+
+        assert "VERDICT: clean" in body
+        assert "secret internals" not in body
+
+
+class TestSilenceIsNotAReview:
+    """A misconfigured `cli_command` (`true`, or a wrapper that swallows
+    its own output) exits 0 with nothing to say. Treating that as
+    REVIEWED hands out the marker for work nobody did — the same hole as
+    an unreadable run, only quieter."""
+
+    @pytest.mark.asyncio
+    async def test_empty_output_does_not_earn_the_marker(
+        self, tmp_path: Path
+    ) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"", b""))
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.status is ReviewStatus.UNREADABLE
+        assert outcome.may_mark_reviewed is False
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only_verdict_does_not_count(
+        self, tmp_path: Path
+    ) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(return_value=(b"transcript\ncodex\n   \n", b""))
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.may_mark_reviewed is False

--- a/tests/test_code_review.py
+++ b/tests/test_code_review.py
@@ -367,3 +367,51 @@ class TestSilenceIsNotAReview:
             )
 
         assert outcome.may_mark_reviewed is False
+
+
+class TestAReviewOfTheWrongTreeIsNotAPass:
+    """Found by pointing the gate at its own PR. Reviewing code that
+    itself invokes the reviewer caused a nested run in a scratch repo,
+    whose verdict — "there are no code changes to review" — was about an
+    empty temp directory. The gate called that REVIEWED.
+
+    A false pass is worse than an unreadable one: it is confidently
+    wrong, and it is exactly what the marker promises cannot happen. A
+    branch under review always has a diff, so this claim can only mean
+    the reviewer looked somewhere else."""
+
+    @pytest.mark.parametrize(
+        "verdict",
+        [
+            "The working tree is identical to the specified merge-base "
+            "commit, so there are no code changes to review.",
+            "There are no code changes to review.",
+            "No changes to review in this branch.",
+        ],
+    )
+    def test_no_changes_claims_are_rejected(self, verdict: str) -> None:
+        assert looks_unreadable(f"transcript\ncodex\n{verdict}\n")
+
+    @pytest.mark.asyncio
+    async def test_such_a_review_earns_no_marker(self, tmp_path: Path) -> None:
+        proc = MagicMock()
+        proc.returncode = 0
+        proc.communicate = AsyncMock(
+            return_value=(
+                b"transcript\ncodex\nThe working tree is identical to the "
+                b"specified merge-base commit, so there are no code changes "
+                b"to review.\n",
+                b"",
+            )
+        )
+
+        with patch(
+            "ctrlrelay.core.code_review.asyncio.create_subprocess_exec",
+            AsyncMock(return_value=proc),
+        ):
+            outcome = await run_code_review(
+                repo="o/r", worktree_path=tmp_path, base_branch="main"
+            )
+
+        assert outcome.status is ReviewStatus.UNREADABLE
+        assert outcome.may_mark_reviewed is False


### PR DESCRIPTION
Closes #158.

## Problem

`RepoConfig.code_review` was parsed for all 91 repos and read by **nothing** — grepping outside `config.py` for `code_review`, `cli_command` or `mcp_then_cli` returned zero hits. The feature looked configured and did nothing, so a reviewed PR and an unreviewed one were indistinguishable.

Three agent PRs (#157, #159, #160) landed that way before it was noticed.

## Change

The **orchestrator** runs the review — not the agent. A party cannot certify its own work, and a prompt instruction to self-review can be skipped or misreported. It runs after CI is green and before handover, posts findings, and labels the PR `code_review done`.

**The marker means exactly one thing: a review read this diff.** It is withheld when the reviewer could not be run, timed out, produced no verdict, or said it could not inspect the tree.

That last case is the whole point. Review CLIs announce *"I could not access the repository contents"* in prose and still **exit 0** — so an exit-code check would stamp the label on precisely the runs the label exists to catch.

Neither the label nor the comment names any tool, model or vendor.

## The bug this found in itself

The first version scanned the reviewer's entire output for those phrases. Run for real, it read **its own test fixtures** back out of the transcript — the transcript contains the diff — and declared a perfectly good review unreadable. Left in, no PR would ever have been marked.

Fixed by scanning only the reviewer's verdict block. A phrase appearing in reviewed code is not the reviewer saying it.

Caught by executing it against this branch, not by the unit tests.

## Findings from its own first real run, both fixed

- **Silence counted as a review.** `cli_command: "true"` exits 0 with no output and earned the marker. Now `UNREADABLE`.
- **A stale config value could stop the daemon booting.** Strict validation on a field that was parsed and ignored for its whole existence is a bad trade; unknown values now fall back to `"cli"`. `"none"`/`"disabled"`/`"false"`/`"no"` map to `"off"`, legacy `"mcp_then_cli"` to `"cli"`.

## Verification

- 33 new tests, including that an unreadable run, a timeout, a missing binary and an empty verdict all leave the PR unmarked, and that the marker text carries no vendor identifier.
- Exercised end-to-end against this branch: `status=reviewed`, marker earned, comment rendered.
- Full suite: **910 passed**. `ruff check`: clean.