### PR TITLE
fix(poller): skip repos GitHub confirms are archived

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Archived repos are skipped instead of swept forever.** `skip_archived`
+  only ever existed in the config generator, so a repo archived after its
+  `orchestrator.yaml` entry was written kept being polled and swept — the
+  daily secops run spawned a full agent session to discover the Dependabot
+  API answers 403 for archived repos, then wrote a benign `done`. Quiet
+  enough to accumulate unnoticed; two such repos were found live.
+
+  Detection fails open by design. This check gates every piece of work the
+  daemon does, so a bug here would not skip one repo — it could silently
+  stop the orchestrator while the process looked healthy. Only a definite
+  `isArchived: true` skips: a failed lookup, timeout, auth error or
+  malformed response all mean "unknown", and unknown keeps polling.
+  Nothing derived from an error is cached, so one flaky call cannot
+  disable a repo for the daemon's lifetime.
+
+  Probes are serialised per repo, since the poller and the sweep share a
+  tracker and would otherwise both probe on a simultaneous cache miss.
+  The resume path is gated too — a repo can be archived while a session
+  sits blocked, and the answer arriving later would otherwise take the
+  lock, build a worktree and spawn the agent against it.
+
 ## [0.10.0] - 2026-09-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   sits blocked, and the answer arriving later would otherwise take the
   lock, build a worktree and spawn the agent against it.
 
+  **Known limit:** a repo archived in the window between a poll returning
+  its batch and the handlers dispatching it is still processed once.
+  Closing that would cost a lookup per dispatched issue to save a single
+  wasted session in a race measured in seconds — more machinery than the
+  defect. The next cycle catches it.
+
 ## [0.10.0] - 2026-09-08
 
 ### Added

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -1744,6 +1744,10 @@ def poller_start(
                                     else None
                                 ),
                                 question=row.get("question"),
+                                # Same tracker as the poller and the
+                                # sweep: a repo archived while a session
+                                # sat blocked must not be resumed into.
+                                archived=poller.archived_tracker,
                             )
                         elif pipeline_name == "dev":
                             # Dev resume needs the repo's branch template

--- a/src/ctrlrelay/cli.py
+++ b/src/ctrlrelay/cli.py
@@ -552,6 +552,7 @@ def run_secops(
     """Run secops pipeline on configured repos."""
     import asyncio
 
+    from ctrlrelay.core.archived import ArchivedRepoTracker
     from ctrlrelay.core.dispatcher import make_agent_dispatcher
     from ctrlrelay.core.github import GitHubCLI
     from ctrlrelay.core.state import StateDB
@@ -638,6 +639,9 @@ def run_secops(
             state_db=db,
             transport=transport,
             contexts_dir=config.paths.contexts,
+            # Fresh tracker per invocation — the manual path is one-shot,
+            # so there's nothing to cache across runs (#163).
+            archived=ArchivedRepoTracker(github=github),
         )
 
     try:
@@ -1538,6 +1542,10 @@ def poller_start(
                     state_db=state_db,
                     transport=secops_transport,
                     contexts_dir=config.paths.contexts,
+                    # Same tracker the poller uses, so one confirmed
+                    # archive is logged once and honored by both the
+                    # 120s issue poll and the daily sweep (#163).
+                    archived=poller.archived_tracker,
                 )
                 ok = sum(1 for r in results if r.success)
                 console.print(

--- a/src/ctrlrelay/core/archived.py
+++ b/src/ctrlrelay/core/archived.py
@@ -1,0 +1,108 @@
+"""Detection of archived GitHub repos, shared by the poller and the
+secops sweep (issue #163).
+
+``skip_archived`` only ever existed in the config *generator*, so a repo
+archived after its ``orchestrator.yaml`` entry was written kept being
+swept forever: secops spawned a full agent session per day that did real
+work only to discover the Dependabot alerts API answers 403 for archived
+repos. The failure was quiet — a ``done`` session with a benign summary —
+which is why it accumulated unnoticed.
+
+**Fail open.** This check gates every piece of work the daemon does, so a
+bug here doesn't skip one repo, it can silently stop the orchestrator
+doing anything while the process looks healthy. Only a definite
+``isArchived: true`` may skip a repo. A failed lookup, a timeout, an auth
+error, a malformed response or a missing field all mean "unknown", and
+unknown means the repo keeps being polled.
+
+Consequently only the *confirmed-archived* outcome is cached — mirroring
+``IssuePoller._issues_disabled_repos``. Nothing derived from an error is
+remembered, so one flaky call can't disable a repo for the daemon's
+lifetime, and the cache is in-memory so a restart re-checks everything
+and an unarchived repo recovers on its own.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any
+
+from ctrlrelay.core.github import GitHubCLI
+from ctrlrelay.core.obs import get_logger, log_event
+
+_logger = get_logger("core.archived")
+
+# Shorter than the 60s gh default: this probe runs once per repo per poll
+# cycle, and a hung lookup would delay every repo behind it. Timing out
+# just means "unknown" — the repo is polled as normal.
+ARCHIVED_PROBE_TIMEOUT_SECONDS = 20
+
+
+@dataclass
+class ArchivedRepoTracker:
+    """Answers "is this repo archived?" with a daemon-lifetime cache of
+    confirmed-archived repos only.
+
+    One instance is shared between the issue poller and the secops sweep
+    so a single confirmation (and a single log line) covers both.
+    """
+
+    github: GitHubCLI
+    # Confirmed archived — the only thing worth remembering. Held for the
+    # process lifetime; unarchiving requires an operator, so a daemon
+    # restart is a fine invalidation boundary.
+    archived_repos: set[str] = field(default_factory=set, repr=False)
+    # Repos whose last probe failed, tracked purely to suppress repeat
+    # logs. Cleared on the next successful probe so a NEW outage is still
+    # visible. This never affects the answer we return.
+    _failed_probes: set[str] = field(default_factory=set, repr=False)
+
+    async def is_archived(self, repo: str) -> bool:
+        """Return True only for a confirmed-archived repo.
+
+        Any error, timeout or ambiguous response returns False (the repo
+        is treated as active) and is not cached, so the next cycle
+        re-checks it. ``asyncio.CancelledError`` propagates so a shutdown
+        signal isn't swallowed into a fail-open answer.
+        """
+        if repo in self.archived_repos:
+            return True
+
+        try:
+            result: Any = await self.github.repo_is_archived(
+                repo, timeout=ARCHIVED_PROBE_TIMEOUT_SECONDS,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as e:
+            if repo not in self._failed_probes:
+                self._failed_probes.add(repo)
+                log_event(
+                    _logger,
+                    "poll.repo.archived_check_failed",
+                    repo=str(repo),
+                    reason=type(e).__name__,
+                    error=str(e)[:200],
+                    action="treating repo as active",
+                )
+            return False
+
+        self._failed_probes.discard(repo)
+
+        # `is True` on purpose: a truthy non-boolean (a Mock, a "true"
+        # string from a future gh format change) must not skip a repo.
+        if result is not True:
+            return False
+
+        self.archived_repos.add(repo)
+        log_event(
+            _logger,
+            "poll.repo.archived",
+            repo=str(repo),
+            action=(
+                "skipping until daemon restart — remove the entry from "
+                "orchestrator.yaml"
+            ),
+        )
+        return True

--- a/src/ctrlrelay/core/archived.py
+++ b/src/ctrlrelay/core/archived.py
@@ -57,6 +57,11 @@ class ArchivedRepoTracker:
     # logs. Cleared on the next successful probe so a NEW outage is still
     # visible. This never affects the answer we return.
     _failed_probes: set[str] = field(default_factory=set, repr=False)
+    # One lock per repo. The poller and the secops sweep share a tracker
+    # and can reach the same repo concurrently; without this both observe
+    # the cache miss before either awaits, so the "one probe, one log"
+    # contract in the docstring above is only true single-threaded.
+    _locks: dict[str, asyncio.Lock] = field(default_factory=dict, repr=False)
 
     async def is_archived(self, repo: str) -> bool:
         """Return True only for a confirmed-archived repo.
@@ -69,6 +74,16 @@ class ArchivedRepoTracker:
         if repo in self.archived_repos:
             return True
 
+        lock = self._locks.setdefault(repo, asyncio.Lock())
+        async with lock:
+            # Re-check: a concurrent caller may have confirmed it while we
+            # waited, in which case we must not probe again.
+            if repo in self.archived_repos:
+                return True
+            return await self._probe(repo)
+
+    async def _probe(self, repo: str) -> bool:
+        """One probe, holding this repo's lock."""
         try:
             result: Any = await self.github.repo_is_archived(
                 repo, timeout=ARCHIVED_PROBE_TIMEOUT_SECONDS,

--- a/src/ctrlrelay/core/github.py
+++ b/src/ctrlrelay/core/github.py
@@ -168,6 +168,36 @@ class GitHubCLI:
         output = await self._run_gh(*args, timeout=timeout)
         return json.loads(output) if output.strip() else []
 
+    async def repo_is_archived(
+        self,
+        repo: str,
+        timeout: int | None = None,
+    ) -> bool:
+        """Return whether ``repo`` is archived on GitHub.
+
+        Deliberately strict: anything that isn't a boolean ``isArchived``
+        field raises :class:`GitHubError` rather than being coerced. The
+        caller (:class:`~ctrlrelay.core.archived.ArchivedRepoTracker`)
+        gates every repo the daemon works on, so "we don't know" must
+        never be able to look like "archived" — an ambiguous answer has
+        to raise so the repo keeps being polled.
+        """
+        output = await self._run_gh(
+            "repo", "view", repo, "--json", "isArchived", timeout=timeout,
+        )
+        try:
+            data = json.loads(output)
+        except json.JSONDecodeError as e:
+            raise GitHubError(
+                f"gh repo view returned non-JSON for {repo}: {e}"
+            ) from e
+        value = data.get("isArchived") if isinstance(data, dict) else None
+        if not isinstance(value, bool):
+            raise GitHubError(
+                f"gh repo view returned no boolean isArchived for {repo}"
+            )
+        return value
+
     async def list_security_alerts(
         self,
         repo: str,

--- a/src/ctrlrelay/core/poller.py
+++ b/src/ctrlrelay/core/poller.py
@@ -9,6 +9,7 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable
 
+from ctrlrelay.core.archived import ArchivedRepoTracker
 from ctrlrelay.core.github import GitHubCLI, GitHubError
 from ctrlrelay.core.obs import get_logger, log_event
 
@@ -94,6 +95,10 @@ class IssuePoller:
     regardless of ``require_labels``. An issue that's assigned but
     missing the required label is left unmarked (not seen) so a later
     label addition still surfaces it on a subsequent poll.
+
+    Repos GitHub confirms are archived are skipped entirely, logged once
+    per daemon lifetime (see #163 and :mod:`ctrlrelay.core.archived`). A
+    repo whose archived state can't be determined is polled as normal.
     """
 
     github: GitHubCLI
@@ -115,9 +120,25 @@ class IssuePoller:
     # Resets on daemon restart so a fresh detection still runs if the repo
     # re-enables issues in the meantime.
     _issues_disabled_repos: set[str] = field(default_factory=set, repr=False)
+    # Archived-repo detection (#163). Shared with the secops sweep when the
+    # daemon passes one in, so a single confirmation covers both paths;
+    # built from ``github`` when absent. Same cache lifetime as
+    # ``_issues_disabled_repos``: confirmed-archived only, in memory, reset
+    # on restart. See ctrlrelay.core.archived for the fail-open rule.
+    archived_tracker: ArchivedRepoTracker | None = None
 
     def __post_init__(self) -> None:
+        if self.archived_tracker is None:
+            self.archived_tracker = ArchivedRepoTracker(github=self.github)
         self._load_state()
+
+    @property
+    def _archived(self) -> ArchivedRepoTracker:
+        """The tracker, guaranteed non-None (``__post_init__`` builds one
+        when the caller doesn't supply it)."""
+        if self.archived_tracker is None:
+            self.archived_tracker = ArchivedRepoTracker(github=self.github)
+        return self.archived_tracker
 
     # ------------------------------------------------------------------
     # State persistence
@@ -247,6 +268,12 @@ class IssuePoller:
             # Repos with GitHub Issues disabled will never return issues; skip
             # before the `gh` call so we don't log the same error every cycle.
             if repo in self._issues_disabled_repos:
+                continue
+            # An archived repo accepts no new work — skip it before the
+            # `gh` call. Only a confirmed archive skips; an unknown
+            # answer falls through and the repo is polled as normal
+            # (see ctrlrelay.core.archived).
+            if await self._archived.is_archived(repo):
                 continue
             # Per-repo include-labels controls the fetch strategy. With
             # no include-labels configured we keep the pre-#80
@@ -702,6 +729,8 @@ class IssuePoller:
         """
         for repo in self.repos:
             if repo in self._issues_disabled_repos:
+                continue
+            if await self._archived.is_archived(repo):
                 continue
             include_labels = self.include_labels_by_repo.get(repo, [])
             try:

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -9,6 +9,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
+from ctrlrelay.core.archived import ArchivedRepoTracker
 from ctrlrelay.core.checkpoint import CheckpointStatus
 from ctrlrelay.core.dispatcher import AgentAdapter, SessionResult
 from ctrlrelay.core.github import GitHubCLI
@@ -496,8 +497,20 @@ async def run_secops_all(
     transport: Transport | None,
     contexts_dir: Path,
     max_blocked_rounds: int = DEFAULT_MAX_BLOCKED_ROUNDS,
+    archived: ArchivedRepoTracker | None = None,
 ) -> list[PipelineResult]:
-    """Run secops pipeline on all configured repos."""
+    """Run secops pipeline on all configured repos.
+
+    ``archived`` (#163) skips repos that GitHub confirms are archived —
+    the alerts API answers 403 for them, so the sweep spends a whole
+    agent session discovering it can do nothing. Passing ``None``
+    disables the check entirely. A repo whose state can't be determined
+    is swept as normal; see :mod:`ctrlrelay.core.archived`.
+
+    One result is returned per configured repo, in order, including the
+    skipped ones — the scheduled sweep zips results against the repo
+    list to attribute its notifications.
+    """
     results = []
 
     pipeline = SecopsPipeline(
@@ -512,6 +525,19 @@ async def run_secops_all(
     for repo_config in repos:
         repo = repo_config.name
         session_id = f"secops-{repo.replace('/', '-')}-{uuid.uuid4().hex[:8]}"
+
+        # Archived repos accept no security work: the Dependabot alerts
+        # API returns 403 for them, so a sweep burns a full agent session
+        # to reach a benign "nothing to do" summary. Skip before the lock
+        # and the worktree. The tracker logs `poll.repo.archived` once so
+        # the operator knows to drop the entry from orchestrator.yaml.
+        if archived is not None and await archived.is_archived(repo):
+            results.append(PipelineResult(
+                success=True,
+                session_id=session_id,
+                summary=f"Skipped {repo}: repository is archived on GitHub",
+            ))
+            continue
 
         if not state_db.acquire_lock(repo, session_id):
             results.append(PipelineResult(

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -873,6 +873,7 @@ async def resume_secops_from_pending(
     contexts_dir: Path,
     automation: Any = None,
     question: str | None = None,
+    archived: Any = None,
 ) -> PipelineResult:
     """Resume a BLOCKED secops session using an answer that arrived via
     Telegram after the original session had already torn down.
@@ -889,6 +890,18 @@ async def resume_secops_from_pending(
     sweep skips re-asking. Optional for backwards compat with older
     callers that pre-date the persistence work.
     """
+    # The sweep gate covers new runs only. A repo can be archived while a
+    # session sits blocked, and an answer arriving afterwards would take
+    # the lock, build a worktree and spawn the agent against a repo whose
+    # Dependabot API answers 403 — the exact waste #163 removes, through
+    # a door the gate does not cover.
+    if archived is not None and await archived.is_archived(repo):
+        return PipelineResult(
+            success=True,
+            session_id=session_id,
+            summary=f"Skipped resume of {repo}: repository is archived on GitHub",
+        )
+
     if question:
         _record_decisions_from_answer(
             state_db,

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -896,10 +896,32 @@ async def resume_secops_from_pending(
     # Dependabot API answers 403 — the exact waste #163 removes, through
     # a door the gate does not cover.
     if archived is not None and await archived.is_archived(repo):
+        summary = f"Skipped resume of {repo}: repository is archived on GitHub"
+        # Close the session out. The caller only marks the
+        # pending_resumes row consumed, so returning early without this
+        # leaves the sessions row at status='blocked' with no ended_at —
+        # a resume that was handled but looks forever outstanding, in
+        # every status listing and count.
+        try:
+            state_db.execute(
+                "UPDATE sessions SET status = ?, summary = ?, ended_at = ? "
+                "WHERE id = ?",
+                ("done", summary, int(time.time()), session_id),
+            )
+            state_db.commit()
+        except Exception as e:
+            log_event(
+                _logger,
+                "secops.resume.archived_status_update_failed",
+                session_id=session_id,
+                repo=repo,
+                error_type=type(e).__name__,
+                error=str(e)[:200],
+            )
         return PipelineResult(
             success=True,
             session_id=session_id,
-            summary=f"Skipped resume of {repo}: repository is archived on GitHub",
+            summary=summary,
         )
 
     if question:

--- a/src/ctrlrelay/setup.py
+++ b/src/ctrlrelay/setup.py
@@ -375,11 +375,13 @@ def build_orchestrator_yaml(
             a(f'    - source: "{_yaml_escape(entry.source)}"')
             a(f'      target: "{_yaml_escape(entry.target)}"')
         a("")
-    a("# Repos discovered via `gh repo list`. Filters applied:")
+    a("# Repos discovered via `gh repo list`. Filters applied ONCE, here,")
+    a("# when this file was generated — not an ongoing guarantee:")
     a(
         f"# skip_archived={options.skip_archived}, "
         f"skip_forks={options.skip_forks}. Empty repos always skipped."
     )
+    a("# (A repo archived later is detected at poll time and skipped.)")
     total_repos = sum(len(rs) for rs in repos_by_owner.values())
     if total_repos == 0:
         # An empty mapping must serialize as ``repos: []``. A bare

--- a/tests/test_archived.py
+++ b/tests/test_archived.py
@@ -1,0 +1,165 @@
+"""Tests for ArchivedRepoTracker (issue #163).
+
+The tracker gates every repo the daemon works on, so the tests below
+lean hard on the fail-open rule: only a definite ``isArchived: true``
+may skip a repo, and no negative derived from an error is ever cached.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from ctrlrelay.core.archived import ArchivedRepoTracker
+from ctrlrelay.core.github import GitHubError
+
+LOGGER = "ctrlrelay.core.archived"
+
+
+class TestArchivedRepoTracker:
+    @pytest.mark.asyncio
+    async def test_confirmed_archived_is_cached_and_logged_once(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A confirmed archived repo is remembered for the tracker's
+        lifetime: one `gh` call, one `poll.repo.archived` log, even
+        across many checks."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(return_value=True)
+        tracker = ArchivedRepoTracker(github=github)
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            assert await tracker.is_archived("owner/old") is True
+            assert await tracker.is_archived("owner/old") is True
+            assert await tracker.is_archived("owner/old") is True
+
+        assert github.repo_is_archived.await_count == 1
+        archived_logs = [
+            r for r in caplog.records
+            if r.getMessage() == "poll.repo.archived"
+        ]
+        assert len(archived_logs) == 1
+        assert archived_logs[0].repo == "owner/old"
+
+    @pytest.mark.asyncio
+    async def test_active_repo_is_rechecked_and_not_cached(self) -> None:
+        """A confirmed ``isArchived: false`` must not be cached — a repo
+        archived while the daemon runs still gets detected on a later
+        cycle."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(side_effect=[False, False, True])
+        tracker = ArchivedRepoTracker(github=github)
+
+        assert await tracker.is_archived("owner/live") is False
+        assert await tracker.is_archived("owner/live") is False
+        assert await tracker.is_archived("owner/live") is True
+        assert github.repo_is_archived.await_count == 3
+
+    @pytest.mark.asyncio
+    async def test_lookup_failure_treats_repo_as_active(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A failed lookup must NOT skip the repo and must NOT be cached:
+        one flaky call would otherwise disable a repo for the whole
+        daemon lifetime."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(
+            side_effect=GitHubError("gh failed: connection reset")
+        )
+        tracker = ArchivedRepoTracker(github=github)
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            assert await tracker.is_archived("owner/flaky") is False
+            assert await tracker.is_archived("owner/flaky") is False
+
+        # Re-probed every time — nothing negative was cached.
+        assert github.repo_is_archived.await_count == 2
+        assert not any(
+            r.getMessage() == "poll.repo.archived" for r in caplog.records
+        )
+        failures = [
+            r for r in caplog.records
+            if r.getMessage() == "poll.repo.archived_check_failed"
+        ]
+        # Logged on the first failure, then deduped until a probe succeeds
+        # so a persistently unreachable repo doesn't spam every cycle.
+        assert len(failures) == 1
+        assert failures[0].repo == "owner/flaky"
+
+    @pytest.mark.asyncio
+    async def test_failure_after_success_logs_again(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """A successful probe clears the failure-dedup memory so a NEW
+        outage is still visible to the operator."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(
+            side_effect=[
+                GitHubError("boom"),
+                False,
+                GitHubError("boom again"),
+            ]
+        )
+        tracker = ArchivedRepoTracker(github=github)
+
+        with caplog.at_level(logging.INFO, logger=LOGGER):
+            await tracker.is_archived("owner/flaky")
+            await tracker.is_archived("owner/flaky")
+            await tracker.is_archived("owner/flaky")
+
+        failures = [
+            r for r in caplog.records
+            if r.getMessage() == "poll.repo.archived_check_failed"
+        ]
+        assert len(failures) == 2
+
+    @pytest.mark.asyncio
+    async def test_non_boolean_result_treated_as_active(self) -> None:
+        """A malformed response (missing field, string, None) is not a
+        confirmation — the repo keeps being polled and nothing is
+        cached."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(side_effect=[None, "true", 1])
+        tracker = ArchivedRepoTracker(github=github)
+
+        assert await tracker.is_archived("owner/weird") is False
+        assert await tracker.is_archived("owner/weird") is False
+        assert await tracker.is_archived("owner/weird") is False
+        assert tracker.archived_repos == set()
+
+    @pytest.mark.asyncio
+    async def test_timeout_treats_repo_as_active(self) -> None:
+        """A timeout is an unknown, not an archive."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(side_effect=TimeoutError())
+        tracker = ArchivedRepoTracker(github=github)
+
+        assert await tracker.is_archived("owner/slow") is False
+        assert tracker.archived_repos == set()
+
+    @pytest.mark.asyncio
+    async def test_cancellation_propagates(self) -> None:
+        """CancelledError must escape so daemon shutdown isn't swallowed
+        into a fail-open 'not archived'."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(side_effect=asyncio.CancelledError())
+        tracker = ArchivedRepoTracker(github=github)
+
+        with pytest.raises(asyncio.CancelledError):
+            await tracker.is_archived("owner/repo")
+
+    @pytest.mark.asyncio
+    async def test_fresh_tracker_recovers_unarchived_repo(self) -> None:
+        """Restart is the invalidation boundary: a new tracker (new
+        daemon) re-probes and picks the repo back up once unarchived."""
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(return_value=True)
+        old = ArchivedRepoTracker(github=github)
+        assert await old.is_archived("owner/repo") is True
+
+        github.repo_is_archived = AsyncMock(return_value=False)
+        fresh = ArchivedRepoTracker(github=github)
+        assert await fresh.is_archived("owner/repo") is False

--- a/tests/test_archived.py
+++ b/tests/test_archived.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
@@ -163,3 +164,120 @@ class TestArchivedRepoTracker:
         github.repo_is_archived = AsyncMock(return_value=False)
         fresh = ArchivedRepoTracker(github=github)
         assert await fresh.is_archived("owner/repo") is False
+
+
+class TestConcurrentProbesAreDeduplicated:
+    """The poller and the secops sweep share one tracker and can reach
+    the same repo at once. Without per-repo serialisation both observe
+    the cache miss before either awaits, so the module's "one probe, one
+    log" contract held only single-threaded."""
+
+    @pytest.mark.asyncio
+    async def test_simultaneous_callers_probe_once(self) -> None:
+        import asyncio
+
+        calls: list[str] = []
+
+        async def slow(repo: str, timeout: int | None = None) -> bool:
+            calls.append(repo)
+            await asyncio.sleep(0.05)
+            return True
+
+        github = AsyncMock()
+        github.repo_is_archived = slow
+        tracker = ArchivedRepoTracker(github=github)
+
+        results = await asyncio.gather(
+            *[tracker.is_archived("o/r") for _ in range(5)]
+        )
+
+        assert all(results)
+        assert len(calls) == 1
+
+    @pytest.mark.asyncio
+    async def test_different_repos_are_not_serialised_against_each_other(
+        self,
+    ) -> None:
+        """The lock is per repo — one slow probe must not stall the rest
+        of a 88-repo cycle."""
+        import asyncio
+
+        async def slow(repo: str, timeout: int | None = None) -> bool:
+            await asyncio.sleep(0.05)
+            return False
+
+        github = AsyncMock()
+        github.repo_is_archived = slow
+        tracker = ArchivedRepoTracker(github=github)
+
+        started = asyncio.get_event_loop().time()
+        await asyncio.gather(*[tracker.is_archived(f"o/r{i}") for i in range(10)])
+        elapsed = asyncio.get_event_loop().time() - started
+
+        # Serialised would be ~0.5s; concurrent is ~0.05s.
+        assert elapsed < 0.3
+
+
+class TestResumeIsGatedToo:
+    """The sweep gate covers new runs only. A repo can be archived while
+    a session sits blocked, and the answer arriving afterwards would take
+    the lock, build a worktree and spawn the agent against a repo whose
+    Dependabot API answers 403 — the waste #163 removes, through a door
+    the gate did not cover."""
+
+    @pytest.mark.asyncio
+    async def test_archived_repo_is_not_resumed_into(self, tmp_path: Path) -> None:
+        from ctrlrelay.pipelines.secops import resume_secops_from_pending
+
+        tracker = AsyncMock()
+        tracker.is_archived.return_value = True
+
+        state_db = MagicMock()
+        worktree = AsyncMock()
+
+        result = await resume_secops_from_pending(
+            session_id="secops-o-r-1",
+            repo="o/r",
+            answer="yes",
+            dispatcher=AsyncMock(),
+            github=AsyncMock(),
+            worktree=worktree,
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path,
+            archived=tracker,
+        )
+
+        assert result.success
+        assert "archived" in result.summary.lower()
+        state_db.acquire_lock.assert_not_called()
+        worktree.create_worktree.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_an_active_repo_still_resumes(self, tmp_path: Path) -> None:
+        """The gate must not swallow ordinary resumes."""
+        from ctrlrelay.pipelines.secops import resume_secops_from_pending
+
+        tracker = AsyncMock()
+        tracker.is_archived.return_value = False
+
+        state_db = MagicMock()
+        state_db.acquire_lock.return_value = False  # stop right after the gate
+
+        result = await resume_secops_from_pending(
+            session_id="secops-o-r-1",
+            repo="o/r",
+            answer="yes",
+            dispatcher=AsyncMock(),
+            github=AsyncMock(),
+            worktree=AsyncMock(),
+            dashboard=None,
+            state_db=state_db,
+            transport=None,
+            contexts_dir=tmp_path,
+            archived=tracker,
+        )
+
+        state_db.acquire_lock.assert_called_once()
+        assert "archived" not in (result.summary or "").lower()

--- a/tests/test_archived.py
+++ b/tests/test_archived.py
@@ -254,6 +254,20 @@ class TestResumeIsGatedToo:
         state_db.acquire_lock.assert_not_called()
         worktree.create_worktree.assert_not_awaited()
 
+        # The session must be closed out. The caller only marks the
+        # pending_resumes row consumed, so an early return that skips
+        # this leaves the row at status='blocked' with no ended_at —
+        # handled, but forever outstanding in every status listing.
+        updates = [
+            c for c in state_db.execute.call_args_list
+            if c.args and "UPDATE sessions" in c.args[0]
+        ]
+        assert updates, "archived resume must write a terminal session state"
+        params = updates[0].args[1]
+        assert params[0] == "done"
+        assert "archived" in params[1].lower()
+        assert params[2] is not None  # ended_at
+
     @pytest.mark.asyncio
     async def test_an_active_repo_still_resumes(self, tmp_path: Path) -> None:
         """The gate must not swallow ordinary resumes."""

--- a/tests/test_github.py
+++ b/tests/test_github.py
@@ -549,3 +549,61 @@ class TestGitHubCLI:
             commands = [" ".join(a) for a in all_args]
             assert any("comment" in c for c in commands)
             assert any("close" in c for c in commands)
+
+
+class TestRepoIsArchived:
+    """Issue #163: one cheap `gh repo view --json isArchived` call, and a
+    hard rule that anything other than a boolean answer raises so the
+    caller can fail open."""
+
+    @pytest.mark.asyncio
+    async def test_returns_true_for_archived_repo(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = json.dumps({"isArchived": True})
+            gh = GitHubCLI()
+            assert await gh.repo_is_archived("owner/repo") is True
+
+        args = mock_run.call_args.args
+        assert args == ("repo", "view", "owner/repo", "--json", "isArchived")
+
+    @pytest.mark.asyncio
+    async def test_returns_false_for_active_repo(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = json.dumps({"isArchived": False})
+            gh = GitHubCLI()
+            assert await gh.repo_is_archived("owner/repo") is False
+
+    @pytest.mark.asyncio
+    async def test_missing_field_raises(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI, GitHubError
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = json.dumps({"name": "repo"})
+            gh = GitHubCLI()
+            with pytest.raises(GitHubError):
+                await gh.repo_is_archived("owner/repo")
+
+    @pytest.mark.asyncio
+    async def test_non_json_output_raises(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI, GitHubError
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = "not json at all"
+            gh = GitHubCLI()
+            with pytest.raises(GitHubError):
+                await gh.repo_is_archived("owner/repo")
+
+    @pytest.mark.asyncio
+    async def test_timeout_is_forwarded(self) -> None:
+        from ctrlrelay.core.github import GitHubCLI
+
+        with patch("ctrlrelay.core.github.GitHubCLI._run_gh") as mock_run:
+            mock_run.return_value = json.dumps({"isArchived": False})
+            gh = GitHubCLI()
+            await gh.repo_is_archived("owner/repo", timeout=15)
+
+        assert mock_run.call_args.kwargs["timeout"] == 15

--- a/tests/test_poller.py
+++ b/tests/test_poller.py
@@ -1981,3 +1981,192 @@ class TestRequireLabelsFilter:
         await poller.seed_current()
 
         assert 6 not in poller.seen_issues.get("owner/repo-a", set())
+
+
+class TestArchivedRepoSkip:
+    """Issue #163: a repo archived after its config entry was generated
+    is swept forever. The poller must detect it, skip it, and say so
+    once — while never skipping a repo whose state it couldn't
+    determine."""
+
+    @pytest.mark.asyncio
+    async def test_poll_skips_archived_repo_and_logs_once(
+        self, tmp_path: Path, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[make_issue(1, assignees=["alice"])]
+        )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("alice", "alice")]
+        )
+
+        async def archived(repo: str, **kwargs):
+            return repo == "owner/archived"
+
+        mock_github.repo_is_archived = AsyncMock(side_effect=archived)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/archived", "owner/live"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        with caplog.at_level(logging.INFO, logger="ctrlrelay.core.archived"):
+            first = await poller.poll()
+            await poller.poll()
+
+        # Only the live repo was ever queried for issues.
+        polled = [c.args[0] for c in mock_github.list_assigned_issues.call_args_list]
+        assert polled == ["owner/live", "owner/live"]
+        assert [r["repo"] for r in first] == ["owner/live"]
+
+        archived_logs = [
+            r for r in caplog.records if r.getMessage() == "poll.repo.archived"
+        ]
+        assert len(archived_logs) == 1
+        assert archived_logs[0].repo == "owner/archived"
+
+    @pytest.mark.asyncio
+    async def test_poll_continues_when_archived_lookup_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Fail open: an erroring archived-lookup must never skip a repo.
+        A bug here would silently stop the whole daemon doing work."""
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[make_issue(7, assignees=["alice"])]
+        )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("alice", "alice")]
+        )
+        mock_github.repo_is_archived = AsyncMock(
+            side_effect=GitHubError("gh failed: HTTP 502")
+        )
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        results = await poller.poll()
+
+        assert [r["issue"]["number"] for r in results] == [7]
+        assert poller.archived_tracker.archived_repos == set()
+
+    @pytest.mark.asyncio
+    async def test_seed_current_skips_archived_repo(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[make_issue(3, assignees=["alice"])]
+        )
+        mock_github.repo_is_archived = AsyncMock(return_value=True)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/archived"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        await poller.seed_current()
+
+        mock_github.list_assigned_issues.assert_not_awaited()
+        assert poller.seen_issues == {}
+
+    @pytest.mark.asyncio
+    async def test_seed_current_continues_when_lookup_fails(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[make_issue(3, assignees=["alice"])]
+        )
+        mock_github.repo_is_archived = AsyncMock(side_effect=OSError("boom"))
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=tmp_path / "poller_state.json",
+        )
+
+        await poller.seed_current()
+
+        assert poller.seen_issues == {"owner/repo-a": {3}}
+
+    @pytest.mark.asyncio
+    async def test_restart_picks_up_unarchived_repo(
+        self, tmp_path: Path
+    ) -> None:
+        """Cache lifetime is the daemon lifetime: a fresh poller re-probes
+        and resumes an un-archived repo."""
+        from ctrlrelay.core.poller import IssuePoller
+
+        state = tmp_path / "poller_state.json"
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(
+            return_value=[make_issue(9, assignees=["alice"])]
+        )
+        mock_github.list_assignment_events = AsyncMock(
+            return_value=[make_assigned_event("alice", "alice")]
+        )
+        mock_github.repo_is_archived = AsyncMock(return_value=True)
+
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state,
+        )
+        assert await poller.poll() == []
+
+        mock_github.repo_is_archived = AsyncMock(return_value=False)
+        restarted = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=state,
+        )
+        assert [r["issue"]["number"] for r in await restarted.poll()] == [9]
+
+    @pytest.mark.asyncio
+    async def test_shared_tracker_is_used_when_supplied(
+        self, tmp_path: Path
+    ) -> None:
+        """The daemon hands the same tracker to the poller and the secops
+        sweep so one confirmation covers both."""
+        from ctrlrelay.core.archived import ArchivedRepoTracker
+        from ctrlrelay.core.poller import IssuePoller
+
+        mock_github = MagicMock()
+        mock_github.list_assigned_issues = AsyncMock(return_value=[])
+        mock_github.repo_is_archived = AsyncMock(return_value=True)
+
+        tracker = ArchivedRepoTracker(github=mock_github)
+        poller = IssuePoller(
+            github=mock_github,
+            username="alice",
+            repos=["owner/repo-a"],
+            state_file=tmp_path / "poller_state.json",
+            archived_tracker=tracker,
+        )
+
+        await poller.poll()
+
+        assert poller.archived_tracker is tracker
+        assert tracker.archived_repos == {"owner/repo-a"}

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -1632,3 +1632,115 @@ class TestNonOperatorPRsAreOutOfScope:
 
         assert "confirm no action wanted" in lower
         assert "answer changes what you do next" in lower
+
+
+class TestSecopsSkipsArchivedRepos:
+    """Issue #163: a full agent session per day against an archived repo
+    does real work to discover it can do nothing (the Dependabot alerts
+    API answers 403). Skip it before spending the session."""
+
+    def _repo(self, name: str) -> MagicMock:
+        repo = MagicMock()
+        repo.name = name
+        repo.automation = None
+        return repo
+
+    @pytest.mark.asyncio
+    async def test_archived_repo_is_skipped_without_a_session(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.archived import ArchivedRepoTracker
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(
+            side_effect=lambda repo, **kw: repo == "owner/archived"
+        )
+        dispatcher = AsyncMock()
+        worktree = AsyncMock()
+        worktree.create_worktree.return_value = tmp_path / "worktree"
+        worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+        db = MagicMock()
+        db.acquire_lock.return_value = False  # forces an early, cheap exit
+
+        results = await run_secops_all(
+            repos=[self._repo("owner/archived"), self._repo("owner/live")],
+            dispatcher=dispatcher,
+            github=github,
+            worktree=worktree,
+            dashboard=None,
+            state_db=db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+            archived=ArchivedRepoTracker(github=github),
+        )
+
+        # One result per configured repo, in order — the scheduled sweep
+        # zips results against config.repos to attribute notifications.
+        assert len(results) == 2
+        assert "archived" in results[0].summary
+        # The archived repo never reached the lock / worktree / agent.
+        assert [c.args[0] for c in db.acquire_lock.call_args_list] == [
+            "owner/live"
+        ]
+        worktree.create_worktree.assert_not_awaited()
+        dispatcher.spawn_session.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_repo_still_swept_when_archived_lookup_fails(
+        self, tmp_path: Path
+    ) -> None:
+        """Fail open — an unknown archived state must not cancel the sweep."""
+        from ctrlrelay.core.archived import ArchivedRepoTracker
+        from ctrlrelay.core.github import GitHubError
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(
+            side_effect=GitHubError("gh failed: HTTP 502")
+        )
+        db = MagicMock()
+        db.acquire_lock.return_value = False
+
+        results = await run_secops_all(
+            repos=[self._repo("owner/live")],
+            dispatcher=AsyncMock(),
+            github=github,
+            worktree=AsyncMock(),
+            dashboard=None,
+            state_db=db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+            archived=ArchivedRepoTracker(github=github),
+        )
+
+        assert len(results) == 1
+        db.acquire_lock.assert_called_once()
+        assert "archived" not in (results[0].summary or "")
+
+    @pytest.mark.asyncio
+    async def test_no_tracker_means_no_extra_gh_calls(
+        self, tmp_path: Path
+    ) -> None:
+        """``archived=None`` keeps the pre-#163 behaviour for callers that
+        don't wire a tracker."""
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        github = MagicMock()
+        github.repo_is_archived = AsyncMock(return_value=True)
+        db = MagicMock()
+        db.acquire_lock.return_value = False
+
+        results = await run_secops_all(
+            repos=[self._repo("owner/live")],
+            dispatcher=AsyncMock(),
+            github=github,
+            worktree=AsyncMock(),
+            dashboard=None,
+            state_db=db,
+            transport=None,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        github.repo_is_archived.assert_not_awaited()
+        assert len(results) == 1


### PR DESCRIPTION
Closes #163

## What was wrong

`skip_archived` only ever existed in `src/ctrlrelay/setup.py`, the config *generator*. Nothing re-checked it, so a repo archived after its `orchestrator.yaml` entry was written kept being swept forever: secops spawned a full agent session per repo per day that did real work only to find the Dependabot alerts API answers 403 for archived repos, ending in a benign "repo is archived" summary. A quiet failure that accumulates unnoticed.

## What this does

- `ArchivedRepoTracker` (`src/ctrlrelay/core/archived.py`), shared by the issue poll and the secops sweep, plus `GitHubCLI.repo_is_archived` — one `gh repo view <repo> --json isArchived` call.
- A confirmed-archived repo is skipped by **both** paths and logged once per daemon lifetime as `poll.repo.archived`, naming the repo so the operator knows to remove the entry.
- The daemon hands the poller's tracker to the scheduled sweep, so one confirmation and one log line cover both.

## Fail open

This check gates every piece of work the daemon does, so only a definite `isArchived: true` may skip a repo:

- A failed lookup, timeout, auth error, malformed response or missing field all mean "unknown" — and unknown keeps polling.
- `repo_is_archived` raises rather than coercing a non-boolean answer; the tracker's `result is True` check means a truthy non-boolean (a future gh format change) can't skip anything either.
- Only the confirmed-archived outcome is cached, mirroring `_issues_disabled_repos`. Nothing derived from an error is remembered, so one flaky call can't disable a repo for the daemon's lifetime.
- The cache is in-memory, so a restart re-checks everything and an unarchived repo recovers on its own.
- A separate set dedupes repeat lookup-failure logs (so a persistently unreachable repo doesn't spam every 120s cycle) without ever affecting the answer.

`run_secops_all` still returns one result per configured repo, in order, including skipped ones — the scheduled sweep zips results against the repo list to attribute its notifications, so dropping entries would misattribute blocked questions.

The generated-config header now says the filters were applied once at generation time rather than reading as an ongoing guarantee.

## Tests

TDD, 20 new tests across `tests/test_archived.py`, `tests/test_poller.py`, `tests/test_secops_pipeline.py`, `tests/test_github.py`, covering each acceptance point:

- confirmed-archived is skipped by poll, seed and the secops sweep, logged exactly once across cycles
- **an erroring/failing lookup does not cause a skip** — poll returns the issue, the sweep still runs the repo
- no negative from an error path is cached (the probe is re-run every cycle)
- a confirmed `isArchived: false` isn't cached either, so a mid-lifetime archive is still caught
- a fresh poller (restart) picks an unarchived repo back up
- `CancelledError` propagates instead of degrading into a fail-open answer

Full suite: 898 passed, ruff clean.