### PR TITLE
chore(release): v0.11.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-09-08
+
 ### Added
 
 - **Agent PRs now carry an automated review comment.** The `code_review`
@@ -1589,7 +1591,8 @@ pipeline).
   per-phase implementation plans (Phase 0 through Phase 4).
 - `docs/Claude_Code_Project_Guide.md` — project development guide.
 
-[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.10.0...HEAD
+[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.0...HEAD
+[0.11.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.1...v0.9.0
 [0.8.1]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.0...v0.8.1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.10.0"
+version = "0.11.0"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Cuts `v0.11.0`: 2 commits since `v0.10.0`.

**Minor** — new public surface, additive: `core/code_review.py`, `core/archived.py`.

| PR | |
|---|---|
| #164 | archived repos skipped by the poll, the sweep and the resume path, fail-open on any uncertain lookup |
| #165 | agent PRs carry an automated review comment — explicitly unverified, no trust label |

Mechanical: `[Unreleased]` closed as `[0.11.0] - 2026-09-08`, compare links updated, `pyproject.toml` bumped.

Suite: **928 passed**. `ruff check`: clean.