### PR TITLE
fix(secops): confirm on Telegram when an inline answer lands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Answering a secops question inline now gets a confirmation.** Two
+  paths reach a resumed session and only one of them reported. A reply
+  that arrived after the session had torn down landed in
+  `pending_resumes` and the sweeper sent `✅ Resume succeeded on <repo>`;
+  a reply that arrived while the session was still parked in
+  `transport.ask` resumed in-process and sent nothing at all.
+
+  The only completion message on that second path was the sweep-wide
+  `✅ Scheduled secops sweep done: N/M ok`, which fires once every repo
+  has been swept. On the 2026-09-09 sweep that was hours after the reply
+  and named no repo: four answers merged 20 Dependabot PRs across
+  `ai-miner`, `kenos-orchestrator`, `prompt-injection-benchmark` and
+  `aiproxyguard-promptest`, and not one outbound message went back to
+  the operator. Answering looked indistinguishable from being ignored.
+
+  The inline path now reports the same three outcomes the sweeper
+  already did — summary, re-blocked question, or error. Repos that never
+  asked anything stay silent; acking all ~90 daily is how an operator
+  learns to ignore the channel. The send is best-effort, so a dead bridge
+  socket cannot discard completed work or abort the rest of the sweep.
+
 ## [0.11.0] - 2026-09-08
 
 ### Added

--- a/src/ctrlrelay/pipelines/secops.py
+++ b/src/ctrlrelay/pipelines/secops.py
@@ -657,6 +657,49 @@ async def run_secops_all(
                 rounds += 1
                 result = await pipeline.resume(ctx, answer)
 
+            # Close the loop on an answer the operator gave inline.
+            # The sweep-wide summary only lands when every repo has
+            # been swept — on a 90-repo sweep that's hours after the
+            # reply, so answering felt like shouting into a void. The
+            # late-answer path (pending_resumes) already reports per
+            # session; this is the same courtesy for the case where
+            # the session was still alive to receive the answer.
+            # Guarded on rounds > 0 so the ~90 repos that never asked
+            # anything stay silent.
+            if rounds > 0 and transport is not None:
+                try:
+                    if result.success:
+                        await transport.send(
+                            f"✅ Answer applied on {repo}\n"
+                            f"Session: `{session_id}`\n"
+                            f"\n{result.summary}"
+                        )
+                    elif result.blocked:
+                        q = result.question or "(no question text)"
+                        await transport.send(
+                            f"⏸️ Re-blocked after your answer on {repo}\n"
+                            f"Session: `{session_id}`\n"
+                            f"\n{q}"
+                        )
+                    else:
+                        err = result.error or result.summary
+                        await transport.send(
+                            f"❌ Failed after your answer on {repo}\n"
+                            f"Session: `{session_id}`\n"
+                            f"\n{err}"
+                        )
+                except Exception as e:
+                    # Best-effort: a dead socket must not lose the
+                    # completed work or abort the rest of the sweep.
+                    log_event(
+                        _logger,
+                        "secops.answer_ack.send_failed",
+                        session_id=session_id,
+                        repo=repo,
+                        error_type=type(e).__name__,
+                        error=str(e)[:200],
+                    )
+
             results.append(result)
 
             status = "done" if result.success else ("blocked" if result.blocked else "failed")

--- a/tests/test_secops_pipeline.py
+++ b/tests/test_secops_pipeline.py
@@ -432,6 +432,203 @@ class TestSecopsBlockedDispatch:
         assert "Need decision" in mock_db.add_pending_resume.call_args.kwargs["question"]
 
 
+class TestSecopsInlineAnswerAck:
+    """An answer the operator gives while the session is still alive must
+    get its own result message. The sweep-wide summary only lands once
+    every repo is done — hours later on a large sweep — so without this
+    the operator answers and hears nothing back. The late-answer path
+    (pending_resumes sweeper) already reports per session; this covers
+    the inline case.
+    """
+
+    @staticmethod
+    def _states(final_status, *, summary=None, question=None, error=None):
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+
+        blocked = MagicMock()
+        blocked.status = CheckpointStatus.BLOCKED_NEEDS_INPUT
+        blocked.question = "Merge PR #42 (minor bump)?"
+        blocked.summary = None
+        blocked.outputs = {}
+        blocked.error = None
+
+        final = MagicMock()
+        final.status = final_status
+        final.summary = summary
+        final.question = question
+        final.outputs = {}
+        final.error = error
+        return blocked, final
+
+    @staticmethod
+    async def _run(tmp_path, blocked, final, transport):
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.side_effect = [
+            SessionResult(session_id="sess", exit_code=0, state=blocked),
+            SessionResult(session_id="sess", exit_code=0, state=final),
+        ]
+
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.get_agent_session_id.return_value = "sess"
+
+        repo = MagicMock()
+        repo.name = "owner/repo"
+
+        return await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=transport,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+    @pytest.mark.asyncio
+    async def test_successful_resume_sends_summary_to_operator(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+
+        blocked, final = self._states(
+            CheckpointStatus.DONE, summary="Merged 7 minor Dependabot PRs"
+        )
+        transport = AsyncMock()
+        transport.ask.return_value = "yes, merge"
+
+        results = await self._run(tmp_path, blocked, final, transport)
+
+        assert results[0].success
+        transport.send.assert_called_once()
+        text = transport.send.call_args.args[0]
+        assert "owner/repo" in text
+        assert "Merged 7 minor Dependabot PRs" in text
+        assert text.startswith("✅")
+
+    @pytest.mark.asyncio
+    async def test_reblocked_resume_reports_the_new_question(
+        self, tmp_path: Path
+    ) -> None:
+        """Hitting max_blocked_rounds (or a second BLOCKED the operator
+        never sees) must not go silent either — report the open question
+        so the operator knows the session is still stuck."""
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        blocked, _ = self._states(CheckpointStatus.DONE)
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="sess", exit_code=0, state=blocked,
+        )
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+        mock_db.get_agent_session_id.return_value = "sess"
+
+        transport = AsyncMock()
+        transport.ask.return_value = "yes"
+        repo = MagicMock()
+        repo.name = "owner/repo"
+
+        results = await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=transport,
+            contexts_dir=tmp_path / "contexts",
+            max_blocked_rounds=2,
+        )
+
+        assert results[0].blocked
+        transport.send.assert_called_once()
+        text = transport.send.call_args.args[0]
+        assert text.startswith("⏸️")
+        assert "Merge PR #42" in text
+
+    @pytest.mark.asyncio
+    async def test_repo_that_never_asked_stays_silent(
+        self, tmp_path: Path
+    ) -> None:
+        """The overwhelming majority of a 90-repo sweep finds nothing to
+        decide. Those must send nothing — otherwise the ack turns into
+        90 notifications a day and the operator stops reading them."""
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+        from ctrlrelay.core.dispatcher import SessionResult
+        from ctrlrelay.pipelines.secops import run_secops_all
+
+        done = MagicMock()
+        done.status = CheckpointStatus.DONE
+        done.summary = "No open Dependabot alerts, nothing to do"
+        done.outputs = {}
+        done.error = None
+
+        mock_dispatcher = AsyncMock()
+        mock_dispatcher.spawn_session.return_value = SessionResult(
+            session_id="sess", exit_code=0, state=done,
+        )
+        mock_worktree = AsyncMock()
+        mock_worktree.create_worktree.return_value = tmp_path / "worktree"
+        mock_worktree.ensure_bare_repo.return_value = tmp_path / "bare"
+        mock_db = MagicMock()
+        mock_db.acquire_lock.return_value = True
+
+        transport = AsyncMock()
+        repo = MagicMock()
+        repo.name = "owner/repo"
+
+        results = await run_secops_all(
+            repos=[repo],
+            dispatcher=mock_dispatcher,
+            github=MagicMock(),
+            worktree=mock_worktree,
+            dashboard=None,
+            state_db=mock_db,
+            transport=transport,
+            contexts_dir=tmp_path / "contexts",
+        )
+
+        assert results[0].success
+        transport.ask.assert_not_called()
+        transport.send.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_send_failure_does_not_lose_the_completed_result(
+        self, tmp_path: Path
+    ) -> None:
+        """A dead bridge socket at ack time must not discard work the
+        agent already did, nor abort the rest of the sweep."""
+        from ctrlrelay.core.checkpoint import CheckpointStatus
+
+        blocked, final = self._states(
+            CheckpointStatus.DONE, summary="Merged PR #42"
+        )
+        transport = AsyncMock()
+        transport.ask.return_value = "yes"
+        transport.send.side_effect = RuntimeError("socket closed")
+
+        results = await self._run(tmp_path, blocked, final, transport)
+
+        assert len(results) == 1
+        assert results[0].success
+        assert results[0].summary == "Merged PR #42"
+
+
 class TestSecopsPromptRespectsAutomationConfig:
     """The per-repo `automation:` block in orchestrator.yaml defines the
     Dependabot policy per severity tier (patch/minor/major × auto/ask/never).


### PR DESCRIPTION
Answering a BLOCKED secops question produced no confirmation when the
session was still alive to receive the answer.

## What the logs showed

Five questions went out on the 2026-09-09 sweep. Four were answered
inline; every one of them did real work:

| Repo | Result of the answer |
|---|---|
| `ai-miner` | merged 7 Dependabot PRs |
| `kenos-orchestrator` | merged 6 |
| `prompt-injection-benchmark` | merged 5 |
| `aiproxyguard-promptest` | merged 2 |

**20 PRs merged, and not one `SEND` frame went back to the operator.**
The bridge log between the first answer (07:22) and the end of the
sweep contains `delivering ANSWER` four times and no outbound message.

## Why

Two paths reach a resumed session, and only one of them reports.

- **Late answer** — the question outlived the session, the reply lands
  in `pending_resumes`, and the sweeper in `cli.py` sends
  `✅ Resume succeeded on <repo>` per session. This has always worked.
- **Inline answer** — the session was still parked in `transport.ask`,
  so it resumed in-process inside `run_secops_all`. That loop appended
  the result and moved to the next repo. Nothing was sent.

The only completion message on the inline path is the sweep-wide
`✅ Scheduled secops sweep done: N/M ok`, which fires after every repo
has been swept. That sweep ran 06:00 → past 07:54 across ~90 repos, so
the operator's feedback for a 07:22 answer was a bare count, hours
later, naming no repo.

## The change

After the BLOCKED loop exits, report the outcome for the repo the
operator actually answered — success summary, the new question if it
re-blocked, or the error. Same three shapes the `pending_resumes`
sweeper already sends, so both paths now read identically in Telegram.

Two constraints shaped it:

- **Guarded on `rounds > 0`.** Most of a 90-repo sweep finds nothing to
  decide. Acking those turns this into ~90 notifications a day, which
  is how an operator learns to ignore the channel.
- **Best-effort send.** A dead bridge socket must not discard work the
  agent already completed or abort the remaining repos, so the send is
  wrapped and logged as `secops.answer_ack.send_failed`.

## Verification

Four tests in `TestSecopsInlineAnswerAck`, covering the ack, the
re-block, the silence guard, and a failing socket.

Reverting `secops.py` alone fails exactly the two that assert the new
messages, and passes the other two:

```
FAILED test_successful_resume_sends_summary_to_operator
FAILED test_reblocked_resume_reports_the_new_question
2 failed, 2 passed
```

Full suite: 932 passed. `ruff` clean. `mypy` reports 21 errors, all 21
also present on `main` and none in the touched file.