### PR TITLE
chore(release): v0.11.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.1] - 2026-09-09
+
 ### Fixed
 
 - **Answering a secops question inline now gets a confirmation.** Two
@@ -1614,7 +1616,8 @@ pipeline).
   per-phase implementation plans (Phase 0 through Phase 4).
 - `docs/Claude_Code_Project_Guide.md` — project development guide.
 
-[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.0...HEAD
+[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.1...HEAD
+[0.11.1]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.9.0...v0.10.0
 [0.9.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.8.1...v0.9.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.11.0"
+version = "0.11.1"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release. `main` sat exactly on `v0.11.0`, so this ships one change.

## Contents

- #167 — **answering a secops question inline now gets a confirmation.**
  A reply that arrived while the session was still parked in
  `transport.ask` resumed in-process and reported nothing; only the
  late-answer path via `pending_resumes` ever sent a result. The
  operator's sole feedback was the sweep-wide count, which on the
  2026-09-09 sweep landed hours after the reply and named no repo —
  four answers merged 20 Dependabot PRs in silence.

## Why patch, not minor

The change is behavioural, inside `run_secops_all`. No new modules, no
new exported functions, no config keys, no signature changes — nothing
a caller can bind to that did not exist in `v0.11.0`.

## Verification

`932 passed`, `ruff` clean, `uv build` produces sdist + wheel.
Version and `CHANGELOG.md` are the only files touched:

```
 CHANGELOG.md   | 5 ++++-
 pyproject.toml | 2 +-
```

## After merge

Publish the `v0.11.1` GitHub release to trigger `publish.yml` → PyPI.