### PR TITLE
fix(worktree): survive a rebased branch instead of failing the sweep

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **A rebased Dependabot branch no longer fails the whole sweep.** The
+  bare-repo fetch uses a non-force refspec so it cannot discard a prior
+  session's unpushed commits. Dependabot rebases its branches onto a
+  moved base, which rewrites their tips — so every rebase became a
+  `non-fast-forward` rejection, and `git fetch` exits 1 on a declined
+  rewind even when every other ref applied. `ensure_bare_repo` read that
+  exit code as failure and aborted the session.
+
+  Observed on `AInvirion/zzsites`, whose sweep died reporting
+  `WorktreeError: git failed: ... ! [rejected] ... (non-fast-forward)`
+  in the same fetch that had just advanced `main`. Twelve bare repos
+  were holding a `dependabot/*` ref at the time, each one primed to fail
+  the moment Dependabot rebased it.
+
+  `dependabot/*` is now fetched with a force refspec first — those
+  branches are bot-authored and never carry local work, so rewinding one
+  destroys nothing. Any rejection that survives is logged as
+  `worktree.fetch.non_fast_forward` and tolerated rather than raised,
+  because a declined rewind is the refspec doing its job. Real failures
+  still raise: a `fatal:`/`error:` line, a rejection for any other
+  reason, or an unexplained non-zero exit. Failing open there would turn
+  an unreachable remote into a silent no-op and run pipelines against a
+  stale tree.
+
 ## [0.11.1] - 2026-09-09
 
 ### Fixed

--- a/src/ctrlrelay/core/worktree.py
+++ b/src/ctrlrelay/core/worktree.py
@@ -8,8 +8,12 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import TYPE_CHECKING
 
+from ctrlrelay.core.obs import get_logger, log_event
+
 if TYPE_CHECKING:
     from ctrlrelay.core.github import GitHubCLI
+
+_logger = get_logger("core.worktree")
 
 
 # Open-PR probe (issue #52) retries a handful of times before failing
@@ -35,6 +39,49 @@ _PR_PROBE_TIMEOUT_SECONDS = 10
 # `default_timeout_seconds` — a transfer still running past that is
 # genuinely stuck, not merely large.
 _GIT_TRANSFER_TIMEOUT_SECONDS = 1800
+
+# Branches ctrlrelay never authors, so rewinding one can never destroy
+# local work. Dependabot rebases its branches onto a moved base, which
+# rewrites their tips — under a non-force refspec every such rebase is
+# a non-fast-forward rejection.
+_BOT_BRANCH_REFSPEC = "+refs/heads/dependabot/*:refs/heads/dependabot/*"
+
+
+def _rejections_are_only_non_fast_forward(stderr: str) -> list[str]:
+    """Return the refs a fetch declined to rewind, or ``[]`` if the
+    failure was anything else.
+
+    A non-fast-forward rejection is the non-force refspec doing its job:
+    it refused to discard local commits. Git still exits 1, which the
+    caller must not read as "the fetch failed" — the rest of the fetch
+    (the default branch, prunes, new branches) applied normally.
+
+    Anything git considers a real error — ``fatal:`` on a dead remote,
+    ``error:`` on a bad object, or a rejection for some other reason —
+    returns ``[]`` so the caller raises as before. Failing open here
+    would turn an unreachable remote into a silent no-op and let
+    pipelines run against a stale tree, which is the bug this module's
+    explicit refspec was added to prevent in the first place.
+    """
+    refs: list[str] = []
+    for raw in stderr.splitlines():
+        line = raw.strip()
+        if not line:
+            continue
+        low = line.lower()
+        if low.startswith(("fatal:", "error:")):
+            return []
+        if not line.startswith("!"):
+            continue  # progress line: "From ...", " * [new branch]", " abc..def"
+        if "non-fast-forward" not in low and "non-fast forward" not in low:
+            return []  # rejected for some other reason — not ours to swallow
+        # " ! [rejected]  <src> -> <dst>  (non-fast-forward)"
+        body = line.lstrip("! ")
+        if "]" in body:
+            body = body.split("]", 1)[1]
+        target = body.split("->")[-1].split("(")[0].strip()
+        refs.append(target or body.strip())
+    return refs
 
 
 class WorktreeError(Exception):
@@ -74,10 +121,17 @@ class WorktreeManager:
         *args: str,
         cwd: Path | None = None,
         timeout: int | None = None,
+        tolerate_non_fast_forward: bool = False,
     ) -> str:
         """Run git command and return stdout. `timeout` overrides self.timeout
         for one call — useful for cheap probes that shouldn't inherit the full
-        120s default when network is flaky."""
+        120s default when network is flaky.
+
+        ``tolerate_non_fast_forward`` is for fetches under a non-force
+        refspec: git exits 1 when it declines to rewind a diverged local
+        branch, even though every other ref updated. See
+        :func:`_rejections_are_only_non_fast_forward`.
+        """
         cmd = ["git", *args]
         effective_timeout = timeout if timeout is not None else self.timeout
         proc = await asyncio.create_subprocess_exec(
@@ -124,7 +178,21 @@ class WorktreeManager:
             raise
 
         if proc.returncode != 0:
-            raise WorktreeError(f"git failed: {stderr.decode().strip()}")
+            err = stderr.decode().strip()
+            declined = (
+                _rejections_are_only_non_fast_forward(err)
+                if tolerate_non_fast_forward
+                else []
+            )
+            if not declined:
+                raise WorktreeError(f"git failed: {err}")
+            log_event(
+                _logger,
+                "worktree.fetch.non_fast_forward",
+                cwd=str(cwd) if cwd is not None else None,
+                refs=declined,
+                ref_count=len(declined),
+            )
 
         return stdout.decode()
 
@@ -766,12 +834,11 @@ class WorktreeManager:
         test counts from a commit that was two weeks old.
 
         Refspec: ``refs/heads/*:refs/heads/*`` (no leading ``+``).
-        Fast-forward-only on purpose — codex caught this on the
-        first pass: a force update would clobber the dev pipeline's
-        ``create_worktree_with_new_branch`` reuse path, which keeps
-        local-ahead-of-origin commits when a prior session pushed
-        partial work. Non-force semantics give us the right
-        behavior in all three cases:
+        Fast-forward-only on purpose: a force update would clobber
+        the dev pipeline's ``create_worktree_with_new_branch`` reuse
+        path, which keeps local-ahead-of-origin commits when a prior
+        session pushed partial work. Non-force semantics give us the
+        right behavior in all three cases:
 
         - Local branch BEHIND origin (default-branch case, the bug
           we're fixing): fast-forward applies, local catches up.
@@ -782,15 +849,32 @@ class WorktreeManager:
 
         ``--prune`` drops refs that no longer exist on origin so
         deleted branches don't linger forever.
+
+        Two things keep that non-force refspec from failing the
+        caller, both learned from a secops sweep that died on
+        ``AInvirion/zzsites`` with ``main`` already updated:
+
+        - ``dependabot/*`` is fetched with a force refspec first.
+          Dependabot rebases its branches, which rewrites their tips,
+          so under a plain refspec every rebase is a rejection. These
+          branches are bot-authored and never carry local work, so
+          rewinding one destroys nothing. Twelve bare repos were
+          holding such a ref when this was found.
+        - Any rejection that survives is tolerated rather than raised.
+          Git exits 1 on a declined rewind even when every other ref
+          applied, and that exit code was aborting the whole session
+          for a branch it had correctly protected.
         """
         bare_path = self._get_bare_repo_path(repo)
 
         if bare_path.exists():
             await self._run_git(
                 "fetch", "--prune", "origin",
+                _BOT_BRANCH_REFSPEC,
                 "refs/heads/*:refs/heads/*",
                 cwd=bare_path,
                 timeout=_GIT_TRANSFER_TIMEOUT_SECONDS,
+                tolerate_non_fast_forward=True,
             )
         else:
             await self._run_git(

--- a/tests/test_worktree.py
+++ b/tests/test_worktree.py
@@ -1599,3 +1599,182 @@ class TestGitTimeoutIsDiagnosable:
         await wt.ensure_bare_repo("owner/repo")
         fetch_kwargs = wt._run_git.await_args_list[0].kwargs
         assert fetch_kwargs["timeout"] == _GIT_TRANSFER_TIMEOUT_SECONDS
+
+
+class TestFetchSurvivesRewrittenBranches:
+    """A secops sweep died on `AInvirion/zzsites` with the message
+    `WorktreeError: git failed: ... ! [rejected] ... (non-fast-forward)`
+    — while the same fetch had already advanced `main`. Dependabot
+    rebases its branches, which rewrites their tips, so under the
+    non-force refspec every rebase is a rejection and `git fetch`
+    exits 1. Twelve bare repos held such a ref when this was found.
+    """
+
+    @staticmethod
+    def _git(*args: str, cwd: Path) -> str:
+        import subprocess
+
+        env = {
+            "GIT_AUTHOR_NAME": "t", "GIT_AUTHOR_EMAIL": "t@t",
+            "GIT_COMMITTER_NAME": "t", "GIT_COMMITTER_EMAIL": "t@t",
+            "PATH": __import__("os").environ.get("PATH", ""),
+            "HOME": str(cwd),
+        }
+        return subprocess.run(
+            ["git", *args], cwd=cwd, env=env,
+            capture_output=True, text=True, check=True,
+        ).stdout
+
+    @classmethod
+    def _build_repos(cls, tmp_path: Path) -> tuple[Path, Path]:
+        """origin with a rewritten dependabot branch and a rewritten
+        `fix/` branch; a bare clone holding its own commit on each."""
+        import subprocess
+
+        origin = tmp_path / "origin"
+        origin.mkdir()
+        cls._git("init", "-q", "-b", "main", ".", cwd=origin)
+        (origin / "f").write_text("base\n")
+        cls._git("add", ".", cwd=origin)
+        cls._git("commit", "-qm", "base", cwd=origin)
+        cls._git("branch", "dependabot/uv/pkg-1.0", cwd=origin)
+        cls._git("branch", "fix/issue-1", cwd=origin)
+
+        bare = tmp_path / "bare.git"
+        subprocess.run(
+            ["git", "clone", "-q", "--bare", str(origin), str(bare)],
+            check=True, capture_output=True,
+        )
+
+        # Rewrite both branches on origin so neither is a descendant of
+        # what the bare clone now holds.
+        for br, text in (
+            ("dependabot/uv/pkg-1.0", "rebased"), ("fix/issue-1", "forced"),
+        ):
+            cls._git("checkout", "-q", br, cwd=origin)
+            (origin / "f").write_text(text + "\n")
+            cls._git("commit", "-qam", "v1", cwd=origin)
+            cls._git("commit", "-q", "--amend", "-m", br, cwd=origin)
+
+        # Give the bare repo a local-only commit on each branch.
+        main_tree = cls._git(
+            "rev-parse", "refs/heads/main^{tree}", cwd=bare
+        ).strip()
+        for br in ("dependabot/uv/pkg-1.0", "fix/issue-1"):
+            sha = cls._git(
+                "commit-tree", main_tree, "-p", "refs/heads/main",
+                "-m", f"local work on {br}", cwd=bare,
+            ).strip()
+            cls._git("update-ref", f"refs/heads/{br}", sha, cwd=bare)
+        return origin, bare
+
+    @staticmethod
+    def _sha(bare: Path, ref: str) -> str:
+        import subprocess
+
+        return subprocess.run(
+            ["git", "rev-parse", ref], cwd=bare,
+            capture_output=True, text=True, check=True,
+        ).stdout.strip()
+
+    @pytest.mark.asyncio
+    async def test_rebased_dependabot_branch_no_longer_fails_the_sweep(
+        self, tmp_path: Path
+    ) -> None:
+        from ctrlrelay.core.worktree import WorktreeManager
+
+        origin, bare = self._build_repos(tmp_path)
+        before_fix = self._sha(bare, "refs/heads/fix/issue-1")
+
+        wt = WorktreeManager(
+            worktrees_dir=tmp_path / "wt", bare_repos_dir=tmp_path / "repos",
+        )
+        target = wt._get_bare_repo_path("owner/repo")
+        target.parent.mkdir(parents=True, exist_ok=True)
+        bare.rename(target)
+        self._git("remote", "set-url", "origin", str(origin), cwd=target)
+
+        # Must not raise — this is the reported failure.
+        await wt.ensure_bare_repo("owner/repo")
+
+        # Bot branch caught up to the rebase...
+        assert self._sha(target, "refs/heads/dependabot/uv/pkg-1.0") == \
+            self._sha(origin, "refs/heads/dependabot/uv/pkg-1.0")
+        # ...and the local commit on fix/ was NOT discarded. This is the
+        # protection the non-force refspec exists for; a blanket "+"
+        # would silently destroy a prior session's unpushed work.
+        assert self._sha(target, "refs/heads/fix/issue-1") == before_fix
+
+    @pytest.mark.asyncio
+    async def test_real_errors_still_raise(self, tmp_path: Path) -> None:
+        """Failing open would turn an unreachable remote into a silent
+        no-op and run pipelines against a stale tree."""
+        from ctrlrelay.core.worktree import WorktreeError, WorktreeManager
+
+        wt = WorktreeManager(
+            worktrees_dir=tmp_path / "wt", bare_repos_dir=tmp_path / "repos",
+        )
+        bare = wt._get_bare_repo_path("owner/repo")
+        bare.parent.mkdir(parents=True, exist_ok=True)
+        self._git("init", "-q", "--bare", str(bare), cwd=tmp_path)
+        self._git(
+            "remote", "add", "origin",
+            str(tmp_path / "does-not-exist"), cwd=bare,
+        )
+
+        with pytest.raises(WorktreeError):
+            await wt.ensure_bare_repo("owner/repo")
+
+
+class TestNonFastForwardClassifier:
+    """`_rejections_are_only_non_fast_forward` decides whether a
+    non-zero `git fetch` is the refspec doing its job or a real
+    failure. Getting it wrong in the permissive direction hides
+    outages; in the strict direction it re-breaks the sweep."""
+
+    def test_extracts_the_declined_refs(self) -> None:
+        from ctrlrelay.core.worktree import (
+            _rejections_are_only_non_fast_forward,
+        )
+
+        stderr = (
+            "From github.com:AInvirion/zzsites\n"
+            " - [deleted]         (none)     -> dependabot/uv/authlib-1.6.12\n"
+            " ! [rejected]        dependabot/uv/playwright-1.62.0 -> "
+            "dependabot/uv/playwright-1.62.0  (non-fast-forward)\n"
+            " * [new branch]      feat/import-navigation -> feat/import-navigation\n"
+            "   c6cfa84..f0a7911  main                   -> main\n"
+        )
+        assert _rejections_are_only_non_fast_forward(stderr) == [
+            "dependabot/uv/playwright-1.62.0"
+        ]
+
+    def test_fatal_is_not_tolerated(self) -> None:
+        from ctrlrelay.core.worktree import (
+            _rejections_are_only_non_fast_forward,
+        )
+
+        stderr = (
+            " ! [rejected]  a -> a  (non-fast-forward)\n"
+            "fatal: could not read from remote repository\n"
+        )
+        assert _rejections_are_only_non_fast_forward(stderr) == []
+
+    def test_other_rejection_reasons_are_not_tolerated(self) -> None:
+        from ctrlrelay.core.worktree import (
+            _rejections_are_only_non_fast_forward,
+        )
+
+        stderr = " ! [rejected]  v1 -> v1  (would clobber existing tag)\n"
+        assert _rejections_are_only_non_fast_forward(stderr) == []
+
+    def test_no_rejection_at_all_is_not_tolerated(self) -> None:
+        """Exit 1 with no rejection line is an unexplained failure."""
+        from ctrlrelay.core.worktree import (
+            _rejections_are_only_non_fast_forward,
+        )
+
+        assert _rejections_are_only_non_fast_forward("") == []
+        assert _rejections_are_only_non_fast_forward(
+            "From github.com:o/r\n   abc..def  main -> main\n"
+        ) == []


### PR DESCRIPTION
Reported from a live sweep:

```
❌ Scheduled secops failed on AInvirion/zzsites
WorktreeError: git failed: From github.com:AInvirion/zzsites
 - [deleted]         (none)  -> dependabot/uv/authlib-1.6.12
 ! [rejected]        dependabot/uv/playwright-1.62.0 -> ...  (non-fast-forward)
 * [new branch]      feat/import-navigation -> feat/import-navigation
   c6cfa84..f0a7911  main    -> main
```

Read that output again: `main` advanced, a branch was pruned, another
was created. The fetch **worked**. One rejected ref took the session
down with it.

## Cause

`ensure_bare_repo` fetches with `refs/heads/*:refs/heads/*` — no
leading `+`, deliberately, so it can never discard a prior session's
unpushed commits. Dependabot rebases its branches onto a moved base,
which rewrites their tips, so under that refspec **every Dependabot
rebase is a rejection**. Git exits 1 on a declined rewind even when
every other ref applied, and `_run_git` raises on any non-zero exit.

Not repo-specific. Twelve bare repos were holding a `dependabot/*`
ref when this was found, each primed to fail the moment that branch
was rebased:

```
14  AInvirion-mining-orchestrator.git
 4  AInvirion-kenos-orchestrator.git
 2  AInvirion-prompt-injection-benchmark.git
 2  AInvirion-aiproxyguard-promptest.git
 1  AInvirion-zzsites.git          (+ 7 more)
```

## Fix

Two parts, because the first alone would leave the general case broken.

**`dependabot/*` is fetched with a force refspec first.** These
branches are bot-authored — ctrlrelay writes `fix/issue-N` style
branches and never these — so rewinding one destroys nothing. This
removes the rejection entirely for the case that actually fires, and
keeps the local mirror current instead of pinned to a stale rebase.

**Any rejection that survives is tolerated, not raised.** A
non-fast-forward rejection is the non-force refspec doing its job. The
exit code was the only problem. Declined refs are logged as
`worktree.fetch.non_fast_forward` so this stays visible rather than
silent.

## What still fails loudly

Failing open here would turn an unreachable remote into a silent no-op
and let pipelines run against a stale tree — the exact bug the explicit
refspec was added to prevent. So `_rejections_are_only_non_fast_forward`
returns "not tolerable" for a `fatal:` or `error:` line, a rejection for
any other reason (`would clobber existing tag`), or a non-zero exit with
no rejection line at all.

## Verification

Six tests. Two drive **real git repos** through the exact scenario
rather than asserting on mocked strings.

Reverting `worktree.py` alone reproduces the reported error verbatim:

```
E  ctrlrelay.core.worktree.WorktreeError: git failed: From .../origin
E   ! [rejected]  dependabot/uv/pkg-1.0 -> dependabot/uv/pkg-1.0  (non-fast-forward)
E   ! [rejected]  fix/issue-1           -> fix/issue-1            (non-fast-forward)
```

The same test also asserts the protection is intact: after the fetch,
the bot branch matches origin **and** the local-only commit on
`fix/issue-1` is still there. A blanket `+` would pass the first
assertion and silently destroy work on the second.

`938 passed` (was 932), `ruff` clean, `mypy` 20 errors — one fewer than
`main`'s 21, none in the touched file.

Also drops a stale tooling reference from the `ensure_bare_repo`
docstring while rewriting the paragraph around it.