### PR TITLE
chore(release): v0.11.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.11.2] - 2026-09-10
+
 ### Fixed
 
 - **A rebased Dependabot branch no longer fails the whole sweep.** The
@@ -1642,7 +1644,8 @@ pipeline).
   per-phase implementation plans (Phase 0 through Phase 4).
 - `docs/Claude_Code_Project_Guide.md` — project development guide.
 
-[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.1...HEAD
+[Unreleased]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.2...HEAD
+[0.11.2]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.1...v0.11.2
 [0.11.1]: https://github.com/AInvirion/ctrlrelay/compare/v0.11.0...v0.11.1
 [0.11.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.10.0...v0.11.0
 [0.10.0]: https://github.com/AInvirion/ctrlrelay/compare/v0.9.0...v0.10.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "ctrlrelay"
-version = "0.11.1"
+version = "0.11.2"
 description = "Local-first orchestrator for headless coding agents across multiple GitHub repos"
 readme = "README.md"
 requires-python = ">=3.12"


### PR DESCRIPTION
Patch release. `main` sat on `v0.11.1`, so this ships one change.

## Contents

- #169 — **a rebased Dependabot branch no longer fails the whole
  sweep.** The bare-repo fetch uses a non-force refspec so it cannot
  discard a prior session's unpushed commits; Dependabot rebases
  rewrite branch tips, so every rebase became a `non-fast-forward`
  rejection and `git fetch` exits 1 on a declined rewind even when
  every other ref applied. Observed on `AInvirion/zzsites`, whose sweep
  died in the same fetch that had just advanced `main` — with twelve
  bare repos holding a `dependabot/*` ref and primed to do the same.

## Why patch, not minor

`ensure_bare_repo` keeps its signature and its contract. The new
`_rejections_are_only_non_fast_forward` and the `tolerate_non_fast_forward`
argument on `_run_git` are both private. Nothing a caller could bind to
in `v0.11.1` changed.

## Verification

`938 passed` (was 932), `ruff` clean, `uv build` produces sdist + wheel.
Version and `CHANGELOG.md` are the only files touched:

```
 CHANGELOG.md   | 4 +++-
 pyproject.toml | 2 +-
```

## After merge

Publish the `v0.11.2` GitHub release to trigger `publish.yml` → PyPI.